### PR TITLE
(Bluefox) fix npm install for windows

### DIFF
--- a/setup.js
+++ b/setup.js
@@ -243,7 +243,7 @@ function installAdapter(adapter, callback) {
     if (fs.existsSync(__dirname + '/adapter/' + adapter + '/package.json') && !fs.existsSync(__dirname + '/adapter/' + adapter + '/node_modules')) {
         // Install node modules
         var exec = require('child_process').exec;
-        var cmd = 'npm install ' + __dirname + '/adapter/' + adapter + ' --prefix ' + __dirname + '/adapter/' + adapter;
+        var cmd = 'npm install "' + __dirname + '/adapter/' + adapter + '" --prefix "' + __dirname + '/adapter/' + adapter + '"';
         console.log(cmd);
         var child = exec(cmd);
         child.stderr.pipe(process.stderr);


### PR DESCRIPTION
Under windows the path can be "c:\Program Files\iobroker..." and then npm install takes only "c:\Program"
