### PR TITLE
fix for exception due to incorrect  "oport.toLowerCase()" call during "iobroker setup custom"

### DIFF
--- a/lib/setup.js
+++ b/lib/setup.js
@@ -234,8 +234,6 @@ switch (yargs.argv._[0]) {
                                     ot = 'redis';
                                     oport = 5984;
                                 }
-                            } else {
-                                oport = oport.toLowerCase();
                             }
                             rl.question('Type of states DB [file, redis], default [' + ot + ']: ', function (stype) {
                                 if (!stype) {
@@ -266,10 +264,8 @@ switch (yargs.argv._[0]) {
                                             if (stype == 'file') {
                                                 sport = 9000;
                                             } else if (stype == 'redis') {
-                                                oport = 6379;
+                                                sport = 6379;
                                             }
-                                        } else {
-                                            oport = oport.toLowerCase();
                                         }
                                         if ((stype == 'file' && (shost == 'localhost' || shost == '127.0.0.1')) ||
                                             (otype == 'file' && (ohost == 'localhost' || ohost == '127.0.0.1'))) {


### PR DESCRIPTION
When performing "iobroker setup custom" and entering own port numbers the setup throws an error due to toLowerCase() being used. In addition sport is not set correct which causes an incorrect port being used as well in that case.