### PR TITLE
visdebug - check for different adapter directories

### DIFF
--- a/lib/setup/setupVisDebug.js
+++ b/lib/setup/setupVisDebug.js
@@ -36,7 +36,26 @@ function VisDebug(options) {
     }
 
     this.enableDebug = function (widgetset) {
-        var adapterDir = tools.getAdapterDir('vis-' + widgetset);
+
+        //Try to find out the adapter directory out of a list of options
+        var adapterDir;
+        var adapterNames2Try=["vis-"+widgetset, widgetset];
+        for (i in adapterNames2Try) {
+            try {
+                var adapterDir2Try = tools.getAdapterDir(adapterNames2Try[i]);
+                // Query the entry
+                var stats = fs.lstatSync(adapterDir2Try);
+
+                // Is it a directory?
+                if (stats.isDirectory()) {
+                    //found it!
+                    adapterDir = adapterDir2Try;
+                    break;
+                }
+            } catch (e) {};
+        }
+        if (!adapterDir) throw "Adapter not found. Tried: "+adapterNames2Try;
+
         // copy index.html.original to index.html
         // copy edit.html.original to edit.html
         // correct iobroker.json


### PR DESCRIPTION
I am adding some widgets to the [chromecast](https://github.com/angelnu/ioBroker.chromecast) adapter and had to modify visdebug so that it does not assume that the adapter starts with "vis-".