### PR TITLE
winston update, make travis working, fix dist-config search

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,11 @@ node_js:
   - "0.10"
 before_script:
   - npm install https://github.com/ioBroker/ioBroker.js-controller/tarball/master --production
+env:
+- CXX=g++-4.8
+addons:
+apt:
+  sources:
+  - ubuntu-toolchain-r-test
+  packages:
+  - g++-4.8

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,17 @@
 language: node_js
 node_js:
-  - "4.1"
-  - "4.0"
+  - "6"
+  - "4"
   - "0.12"
   - "0.11"
   - "0.10"
 before_script:
-  - npm install https://github.com/ioBroker/ioBroker.js-controller/tarball/master --production
+  - npm install https://github.com/Apollon77/ioBroker.js-controller/tarball/master --production
 env:
-- CXX=g++-4.8
+  - CXX=g++-4.8
 addons:
-apt:
-  sources:
-  - ubuntu-toolchain-r-test
-  packages:
-  - g++-4.8
+    apt:
+      sources:
+          - ubuntu-toolchain-r-test
+      packages:
+          - g++-4.8

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ node_js:
   - "0.11"
   - "0.10"
 before_script:
-  - npm install https://github.com/Apollon77/ioBroker.js-controller/tarball/master --production
 env:
   - CXX=g++-4.8
 addons:

--- a/lib/setup/setupSetup.js
+++ b/lib/setup/setupSetup.js
@@ -116,7 +116,11 @@ function Setup(options) {
 
         if (!fs.existsSync(tools.getConfigFileName())) {
             isCreated = true;
-            config = require(__dirname + '/../../conf/' + tools.appName + '-dist.json');
+            if (fs.existsSync(__dirname + '/../../conf/' + tools.appName + '-dist.json')) {
+                config = require(__dirname + '/../../conf/' + tools.appName + '-dist.json');
+            } else {
+                config = require(__dirname + '/../../conf/' + tools.appName.toLowerCase() + '-dist.json');
+            }
             console.log('creating conf/' + tools.appName + '.json');
             config.objects.host = yargs.argv.objects || '127.0.0.1';
             config.states.host  = yargs.argv.states  || '127.0.0.1';

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "ncp": "^2.0.0",
     "node-schedule": "1.1.1",
     "node.extend": "^1.1.6",
-    "winston": "^2.2.0",
+    "winston": "^2.3.0",
     "winston-daily-rotate-file": "^1.3.1",
     "yargs": "^6.0.0",
     "mime": "^1.3.4",


### PR DESCRIPTION
STILL NEEDS TO BE TESTED DEEPLY!!

- update winston to most current version (2.3.0) to hopefully fix the travis problems in adapters, but had no real effect, but good to update anyway, or ?!
- make travis working and now builds successfully up to node 6, so can be enabled :-) (see https://travis-ci.org/Apollon77/ioBroker.js-controller/builds/177936775)
- one problem in travis was that the „iobroker-dist.json“ was searched with the wrong case while doing setup first. Added a check for file existence to also search the lowercase version as submitted in git. I do not know if this was a „safe guard“ when someone tried to start iobroker direkctly somehow … so you need to say if this change makes sense. The travis tests work now :-)