### PR TITLE
bugfix + test for formatValue

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -2481,7 +2481,7 @@ function Adapter(options) {
                 decimals = 2;
             }
 
-            var format = (_format === undefined) ? ((that.isFloatComma === undefined) ? '.,' : ((that.isFloatComma) ? '.,' : ',.')) : _format;
+            var format = (!_format || _format.length != 2) ? ((that.isFloatComma === undefined) ? '.,' : ((that.isFloatComma) ? '.,' : ',.')) : _format;
 
             if (typeof value !== 'number') value = parseFloat(value);
             return isNaN(value) ? '' : value.toFixed(decimals || 0).replace(format[0], format[1]).replace(/\B(?=(\d{3})+(?!\d))/g, format[0]);

--- a/test/testAdapter.js
+++ b/test/testAdapter.js
@@ -332,6 +332,31 @@ describe('Test ' + adapterShortName + ' adapter', function() {
     // readFile
     // writeFile
     // formatValue
+    it('Test ' + adapterShortName + ' adapter: Check formatValue', function (done) {
+        this.timeout(1000);
+        var testValue, testValue2;
+
+        testValue = adapter.formatValue(1000,'.,');
+        expect(testValue).to.be.a('string');
+        expect(testValue).to.equal('1.000,00');
+
+        testValue = adapter.formatValue(1000.1994,3,'.,');
+        expect(testValue).to.equal('1.000,199');
+        testValue = adapter.formatValue(1000.1996,3,'.,');
+        expect(testValue).to.equal('1.000,200');
+
+        testValue = adapter.formatValue("1000",'.,');
+        expect(testValue).to.be.a('string');
+        expect(testValue).to.equal('1.000,00');
+
+        testValue = adapter.formatValue("1000",'');
+        testValue2 = adapter.formatValue("1000", (adapter.isFloatComma === undefined) ? '.,' : ((adapter.isFloatComma) ? '.,' : ',.'));
+        expect(testValue).to.equal(testValue2);
+
+        testValue = adapter.formatValue(undefined,'.,');
+        expect(testValue).to.be.empty;
+    });
+
     // formatDate
     it('Test ' + adapterShortName + ' adapter: Check formatDate', function (done) {
         this.timeout(1000);

--- a/test/testAdapter.js
+++ b/test/testAdapter.js
@@ -336,25 +336,30 @@ describe('Test ' + adapterShortName + ' adapter', function() {
         this.timeout(1000);
         var testValue, testValue2;
 
+        // Test with number
         testValue = adapter.formatValue(1000,'.,');
         expect(testValue).to.be.a('string');
         expect(testValue).to.equal('1.000,00');
 
+        // Test against rounding errors
         testValue = adapter.formatValue(1000.1994,3,'.,');
         expect(testValue).to.equal('1.000,199');
         testValue = adapter.formatValue(1000.1996,3,'.,');
         expect(testValue).to.equal('1.000,200');
 
+        // Test with string
         testValue = adapter.formatValue("1000",'.,');
         expect(testValue).to.be.a('string');
         expect(testValue).to.equal('1.000,00');
 
-        testValue = adapter.formatValue("1000",'');
-        testValue2 = adapter.formatValue("1000", (adapter.isFloatComma === undefined) ? '.,' : ((adapter.isFloatComma) ? '.,' : ',.'));
+        // Test with an empty format pattern
+        testValue = adapter.formatValue("1000",''); //1.000,00
+        testValue2 = adapter.formatValue("1000", (adapter.isFloatComma === undefined) ? '.,' : ((adapter.isFloatComma) ? '.,' : ',.')); //1.000,00
         expect(testValue).to.equal(testValue2);
 
         testValue = adapter.formatValue(undefined,'.,');
         expect(testValue).to.be.empty;
+        done();
     });
 
     // formatDate
@@ -373,6 +378,11 @@ describe('Test ' + adapterShortName + ' adapter', function() {
         testStringDate = adapter.formatDate(1 * 3600000 + 1 * 60000 + 42000 + 1, 'duration', 'hh.mm.ss.sss');
         expect(testStringDate).to.be.a('string');
         expect(testStringDate).to.equal('01.01.42.001'); // 1 hour, 1 minute, 42 seconds, 1 milliseconds
+
+        // positive test with "Februar"
+        testStringDate = adapter.formatDate('23 Februar 2014', 'YYYY.MM.DD');
+        expect(testStringDate).to.be.a('string');
+        expect(testStringDate).to.contain('2014.02.23');
 
         // negative test, give the wrong date "Fabruar"
         testStringDate = adapter.formatDate('23 Fabruar 2014', 'YYYY.MM.DD');


### PR DESCRIPTION
if I set _format to a empty string I get something like
"1undefined000.200" and if I choose "." (length != 2) for _format I get
1.000undefined.200. Maybe the rigth way would be an regex-check but I
don´t know if someone wants to format to "AB" or so.