### PR TITLE
two more tests AdapterHelpers

### DIFF
--- a/test/lib/testAdapterHelpers.js
+++ b/test/lib/testAdapterHelpers.js
@@ -65,6 +65,7 @@ function register(it, expect, context) {
 
     //_fixId
     it(context.name + ' ' + context.adapterShortName + ' adapter: Check _fixId', function (done) {
+        this.timeout(1000);
         var adapterName = context.adapter.name;
         expect(adapterName).to.equal('test');
         var adapterInstance = context.adapter.instance;
@@ -136,8 +137,76 @@ function register(it, expect, context) {
     });
 
     // idToDCS
-    // _DCS2ID
+    it(context.name + ' ' + context.adapterShortName + ' adapter: Check idToDCS', function (done) {
+        this.timeout(1000);
+        var testString;
 
+        //test no id
+        testString = context.adapter.idToDCS();
+        expect(testString).to.equal(null);
+
+        //test invalid id
+        testString = context.adapter.idToDCS('device.channel.state');
+        expect(testString).to.equal(null);
+
+        //test valid id
+        testString = context.adapter.idToDCS(context.adapter.namespace + '.device.channel.state');
+        expect(testString).to.deep.equal({device: 'device', channel: 'channel', state: 'state'});
+
+        done();
+    });
+
+    // _DCS2ID
+    it(context.name + ' ' + context.adapterShortName + ' adapter: Check _DCS2ID', function (done) {
+        this.timeout(1000);
+        var testString;
+
+        //test no parameters
+        testString = context.adapter._DCS2ID();
+        expect(testString).to.equal('');
+
+        //test device
+        testString = context.adapter._DCS2ID('device');
+        expect(testString).to.equal('device');
+
+        //test device + channel
+        testString = context.adapter._DCS2ID('device', 'channel');
+        expect(testString).to.equal('device.channel');
+
+        //test device + channel + stateOrPoint (true)
+        testString = context.adapter._DCS2ID('device', 'channel', true);
+        expect(testString).to.equal('device.channel.');
+
+        //test device + channel + stateOrPoint (false)
+        testString = context.adapter._DCS2ID('device', 'channel', false);
+        expect(testString).to.equal('device.channel');
+
+        //test device + channel + stateOrPoint (string)
+        testString = context.adapter._DCS2ID('device', 'channel', 'state');
+        expect(testString).to.equal('device.channel.state');
+
+        //test device + stateOrPoint (string)
+        testString = context.adapter._DCS2ID('device', null, 'state');
+        expect(testString).to.equal('device.state');
+
+        //test channel + stateOrPoint (string)
+        testString = context.adapter._DCS2ID(null, 'channel', 'state');
+        expect(testString).to.equal('channel.state');
+
+        //test stateOrPoint (true)
+        testString = context.adapter._DCS2ID(null, null, true);
+        expect(testString).to.equal('');
+
+        //test stateOrPoint (false)
+        testString = context.adapter._DCS2ID(null, null, false);
+        expect(testString).to.equal('');
+
+        //test stateOrPoint (string)
+        testString = context.adapter._DCS2ID(null, null, 'state');
+        expect(testString).to.equal('state');
+
+        done();
+    });
 }
 
 


### PR DESCRIPTION
Both Tests are designed to not fail for the current implementation, but there are two possible issues:

- **idToDCS(id)**:
will not return valid results for ids with structure different to adapter.instance.device.channel.state, e.g. adapter.instance.state will return {device: 'state', channel: undefined, state: undefined}
- **_DCS2ID(null, null, true)**: 
returns '', but I think '.' would be more appropriate

