### PR TITLE
allow redis connections via unix sockets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.1.1 (2017-06-29)
+* (jens-maus) allow redis connections via unix sockets by specifying host as e.g. '/var/run/redis/redis.sock' and setting port to 0. This should slightly improve performance on busy installations.
+
 # 1.1.0 (2017-06-08)
 * (bluefox) BREAKING Changes: For multihost systems the user MUST explicit allow connections from other IPs in /opt/iobroker/iobroker-data/iobroker.json
   

--- a/io-package.json
+++ b/io-package.json
@@ -1,11 +1,16 @@
 {
     "common": {
         "name":       "js-controller",
-        "version":    "1.1.0",
+        "version":    "1.1.1",
         "platform":   "Javascript/Node.js",
         "controller": true,
         "title":      "ioBroker.js-controller",
         "news": {
+            "1.1.1": {
+                "en": "Allow redis connections via unix sockets",
+                "de": "Erlaube Redis verbindungen via Unix Sockets",
+                "en": "Allow redis unix socket connections"
+            },
             "1.1.0": {
                 "en": "Close sockets by defaul for external connects",
                 "de": "Erlaube die Verbindung auf Objeke/States-Sockets nicht",

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -438,7 +438,7 @@ function processCommand(command, args, params, callback) {
                                 callback(23);
                             }
                         }
-                        rl.question('Host of objects DB(' + otype + '), default[127.0.0.1]: ', function (ohost) {
+                        rl.question('Host / Unix Socket of objects DB(' + otype + '), default[127.0.0.1]: ', function (ohost) {
                             if (!ohost) {
                                 ohost = '127.0.0.1';
                             } else {
@@ -469,7 +469,7 @@ function processCommand(command, args, params, callback) {
                                     }
                                 } else {
                                     oport = parseInt(oport, 10);
-                                    if (!oport) {
+                                    if (isNaN(oport)) {
                                         console.log('Invalid objects port: ' + oport);
                                         callback(23);
                                     }
@@ -489,7 +489,7 @@ function processCommand(command, args, params, callback) {
                                         }
                                     }
 
-                                    rl.question('Host of states DB (' + stype + '), default[' + ohost + ']: ', function (shost) {
+                                    rl.question('Host / Unix Socket of states DB (' + stype + '), default[' + ohost + ']: ', function (shost) {
                                         if (!shost) {
                                             shost = ohost;
                                         } else {
@@ -512,7 +512,7 @@ function processCommand(command, args, params, callback) {
                                                 }
                                             } else {
                                                 sport = parseInt(sport, 10);
-                                                if (!sport) {
+                                                if (isNaN(sport)) {
                                                     console.log('Invalid states port: ' + sport);
                                                     callback(23);
                                                 }

--- a/lib/states/statesInRedis.js
+++ b/lib/states/statesInRedis.js
@@ -82,8 +82,14 @@ function StateRedis(settings) {
     }
 
     var __construct = (function () {
-        client =    redis.createClient(settings.connection.port, settings.connection.host, settings.connection.options);
-        sub =       redis.createClient(settings.connection.port, settings.connection.host, settings.connection.options);
+        if (settings.connection.port === 0) {
+            // initiate a unix socket connection using the parameter 'host'
+            client = redis.createClient(settings.connection.host, settings.connection.options);
+            sub    = redis.createClient(settings.connection.host, settings.connection.options);
+        } else {
+            client = redis.createClient(settings.connection.port, settings.connection.host, settings.connection.options);
+            sub    = redis.createClient(settings.connection.port, settings.connection.host, settings.connection.options);
+        }
 
         if (typeof settings.change === 'function') {
             sub.on('pmessage', function (pattern, channel, message) {
@@ -115,7 +121,11 @@ function StateRedis(settings) {
         });
 
         sub.on('connect', function (error) {
-            log.info(settings.namespace + ' States connected to redis ' + settings.connection.host + ':' + settings.connection.port);
+            if (settings.connection.port === 0) {
+              log.info(settings.namespace + ' States connected to redis: ' + settings.connection.host);
+            } else {
+              log.info(settings.namespace + ' States connected to redis: ' + settings.connection.host + ':' + settings.connection.port);
+            }
         });
 
         client.on('connect', function (error) {
@@ -711,7 +721,12 @@ function StateRedis(settings) {
             settings.connection.options = settings.connection.options || {};
             var opt = JSON.parse(JSON.stringify(settings.connection.options));
             opt.return_buffers = true;
-            clientBin = redis.createClient(settings.connection.port, settings.connection.host, opt);
+            if (settings.connection.port === 0) {
+                // initiate a unix socket connection using the parameter 'host'
+                clientBin = redis.createClient(settings.connection.host, opt);
+            } else {
+                clientBin = redis.createClient(settings.connection.port, settings.connection.host, opt);
+            }
         }
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iobroker.js-controller",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "engines": {
     "node": ">=0.8"
   },


### PR DESCRIPTION
This PR allows redis connections via unix sockets by specifying host as e.g. `/var/run/redis/redis.sock` and setting port to 0. This should slightly improve performance on busy installations.