### PR TITLE
Fix and enhance permission checks to read/write states

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,10 @@ before_install:
   - 'if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then ln -sfv /usr/local/opt/redis/*.plist ~/Library/LaunchAgents; fi'
   - 'if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then launchctl load ~/Library/LaunchAgents/homebrew.mxcl.redis.plist; sleep 10; fi'
   - sleep 15
-before_script: null
+before_script:
+script:
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then npm test; fi'
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then npm test && test/redis-socket/setup-socket.sh && npm run test-redis-socket; fi'
 env:
   - CXX=g++-4.8
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_install:
 before_script:
   - sudo chmod ogu+x test/redis-socket/setup-socket.sh
 script:
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then npm test; fi && if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then npm test && test/redis-socket/setup-socket.sh && npm run test-redis-socket; fi
+  - npm test && if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then test/redis-socket/setup-socket.sh; fi
 env:
   - CXX=g++-4.8
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,8 @@ before_install:
   - sleep 15
 before_script:
 script:
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then npm test; fi'
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then npm test && test/redis-socket/setup-socket.sh && npm run test-redis-socket; fi'
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then npm test; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then npm test && test/redis-socket/setup-socket.sh && npm run test-redis-socket; fi
 env:
   - CXX=g++-4.8
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,9 @@ before_install:
   - 'if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then launchctl load ~/Library/LaunchAgents/homebrew.mxcl.redis.plist; sleep 10; fi'
   - sleep 15
 before_script:
+  - sudo chmod ogu+x test/redis-socket/setup-socket.sh
 script:
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then npm test; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then npm test && test/redis-socket/setup-socket.sh && npm run test-redis-socket; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then npm test; fi && if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then npm test && test/redis-socket/setup-socket.sh && npm run test-redis-socket; fi
 env:
   - CXX=g++-4.8
 addons:

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -3857,7 +3857,12 @@ function Adapter(options) {
                     endkey:   pattern.replace('*', '\u9999')
                 };
             }
+            var originalChecked = undefined;
+            if (options.checked !== undefined) originalChecked = options.checked;
+            options.checked = true;
             that.objects.getObjectView('system', 'state', params, options, function (err, res) {
+                if (originalChecked !== undefined) options.checked = originalChecked
+                    else options.checked = undefined;
                 if (err) {
                     if (typeof callback === 'function') callback(err);
                     return;

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -2773,7 +2773,7 @@ console.log('in checkState before getObject: ' + JSON.stringify(options));
                                 if (command === 'setState' || command === 'delState') {
                                     if (!(obj.acl.state & (2 << 8))/*write*/) {
                                         that.log.warn('Permission error for user "' + options.user + '": ' + command);
-                                        callback('permissionError20', {_id: ids});
+                                        callback('permissionError', {_id: ids});
                                         return;
                                     }
                                 } else if (command === 'getState') {

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -2755,7 +2755,7 @@ function Adapter(options) {
             var originalChecked = undefined;
             if (options.checked !== undefined) originalChecked = options.checked;
             options.checked = true;
-that.log.error('in checkState before getObject: ' + JSON.stringify(options));
+console.log('in checkState before getObject: ' + JSON.stringify(options));
             that.objects.getObject(ids, options, function (err, obj) {
                 if (originalChecked !== undefined) options.checked = originalChecked
                     else options.checked = undefined;
@@ -2763,12 +2763,12 @@ that.log.error('in checkState before getObject: ' + JSON.stringify(options));
                     callback(err, {_id: ids});
                     return;
                 } else {
-                    that.log.error('in checkState after getObject: ' + JSON.stringify(options));
+                    console.log('in checkState after getObject: ' + JSON.stringify(options));
                     if (obj && obj.acl) {
                         if (obj.acl.state === undefined) obj.acl.state = obj.acl.object;
                         if (obj.acl.state !== undefined) {
                             // If user is owner
-                            that.log.error('in checkState: user=' + options.user + ' vs owner =' + obj.acl.owner);
+                            console.log('in checkState: user=' + options.user + ' vs owner =' + obj.acl.owner);
                             if (options.user === obj.acl.owner) {
                                 if (command === 'setState' || command === 'delState') {
                                     if (!(obj.acl.state & (2 << 8))/*write*/) {

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -2763,6 +2763,7 @@ console.log('in checkState before getObject: ' + JSON.stringify(options));
                     callback(err, {_id: ids});
                     return;
                 } else {
+                    var limitToOwnerRights = (options.limitToOwnerRights !== undefined && options.limitToOwnerRights === true);
                     console.log('in checkState after getObject: ' + JSON.stringify(options));
                     if (obj && obj.acl) {
                         if (obj.acl.state === undefined) obj.acl.state = obj.acl.object;
@@ -2785,7 +2786,7 @@ console.log('in checkState before getObject: ' + JSON.stringify(options));
                                 } else {
                                     that.log.warn('Called unknown command:' + command);
                                 }
-                            } else if (options.groups.indexOf(obj.acl.ownerGroup) !== -1) {
+                            } else if (options.groups.indexOf(obj.acl.ownerGroup) !== -1 && !limitToOwnerRights) {
                                 if (command === 'setState' || command === 'delState') {
                                     if (!(obj.acl.state & (2 << 4))/*write*/) {
                                         that.log.warn('Permission error for user "' + options.user + '": ' + command);
@@ -2801,7 +2802,7 @@ console.log('in checkState before getObject: ' + JSON.stringify(options));
                                 } else {
                                     that.log.warn('Called unknown command:' + command);
                                 }
-                            } else{
+                            } else if (!limitToOwnerRights) {
                                 if (command === 'setState' || command === 'delState') {
                                     if (!(obj.acl.state & 2)/*write*/) {
                                         that.log.warn('Permission error for user "' + options.user + '": ' + command);
@@ -2819,6 +2820,11 @@ console.log('in checkState before getObject: ' + JSON.stringify(options));
                                     callback('permissionError', {_id: ids});
                                     return;
                                 }
+                            }
+                            else {
+                                that.log.warn('Permissions limited to Owner rights');
+                                callback('permissionError', {_id: ids});
+                                return;
                             }
                         }
                     }

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -2755,6 +2755,7 @@ function Adapter(options) {
             var originalChecked = undefined;
             if (options.checked !== undefined) originalChecked = options.checked;
             options.checked = true;
+that.log.error('in checkState before getObject: ' + JSON.stringify(options));
             that.objects.getObject(ids, options, function (err, obj) {
                 if (originalChecked !== undefined) options.checked = originalChecked
                     else options.checked = undefined;
@@ -2762,15 +2763,17 @@ function Adapter(options) {
                     callback(err, {_id: ids});
                     return;
                 } else {
+                    that.log.error('in checkState after getObject: ' + JSON.stringify(options));
                     if (obj && obj.acl) {
                         if (obj.acl.state === undefined) obj.acl.state = obj.acl.object;
                         if (obj.acl.state !== undefined) {
                             // If user is owner
+                            that.log.error('in checkState: user=' + options.user + ' vs owner =' + obj.acl.owner);
                             if (options.user === obj.acl.owner) {
                                 if (command === 'setState' || command === 'delState') {
                                     if (!(obj.acl.state & (2 << 8))/*write*/) {
                                         that.log.warn('Permission error for user "' + options.user + '": ' + command);
-                                        callback('permissionError', {_id: ids});
+                                        callback('permissionError20', {_id: ids});
                                         return;
                                     }
                                 } else if (command === 'getState') {

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -2756,13 +2756,16 @@ function Adapter(options) {
             if (options.checked !== undefined) originalChecked = options.checked;
             options.checked = true;
             that.objects.getObject(ids, options, function (err, obj) {
-                if (originalChecked !== undefined) options.checked = originalChecked
-                    else options.checked = undefined;
+                if (originalChecked !== undefined) {
+					options.checked = originalChecked;
+				} else {
+					options.checked = undefined;
+				}
                 if (err) {
                     callback(err, {_id: ids});
                     return;
                 } else {
-                    var limitToOwnerRights = (options.limitToOwnerRights !== undefined && options.limitToOwnerRights === true);
+                    var limitToOwnerRights = options.limitToOwnerRights === true;
                     if (obj && obj.acl) {
                         if (obj.acl.state === undefined) obj.acl.state = obj.acl.object;
                         if (obj.acl.state !== undefined) {
@@ -3861,8 +3864,11 @@ function Adapter(options) {
             if (options.checked !== undefined) originalChecked = options.checked;
             options.checked = true;
             that.objects.getObjectView('system', 'state', params, options, function (err, res) {
-                if (originalChecked !== undefined) options.checked = originalChecked
-                    else options.checked = undefined;
+                if (originalChecked !== undefined) {
+                    options.checked = originalChecked;
+                } else {
+                    options.checked = undefined;
+                }
                 if (err) {
                     if (typeof callback === 'function') callback(err);
                     return;

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -2752,7 +2752,12 @@ function Adapter(options) {
                 });
             }
         } else {
+            var originalChecked = undefined;
+            if (options.checked !== undefined) originalChecked = options.checked;
+            options.checked = true;
             that.objects.getObject(ids, options, function (err, obj) {
+                if (originalChecked !== undefined) options.checked = originalChecked
+                    else options.checked = undefined;
                 if (err) {
                     callback(err, {_id: ids});
                     return;

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -2755,7 +2755,6 @@ function Adapter(options) {
             var originalChecked = undefined;
             if (options.checked !== undefined) originalChecked = options.checked;
             options.checked = true;
-console.log('in checkState before getObject: ' + JSON.stringify(options));
             that.objects.getObject(ids, options, function (err, obj) {
                 if (originalChecked !== undefined) options.checked = originalChecked
                     else options.checked = undefined;
@@ -2764,12 +2763,10 @@ console.log('in checkState before getObject: ' + JSON.stringify(options));
                     return;
                 } else {
                     var limitToOwnerRights = (options.limitToOwnerRights !== undefined && options.limitToOwnerRights === true);
-                    console.log('in checkState after getObject: ' + JSON.stringify(options));
                     if (obj && obj.acl) {
                         if (obj.acl.state === undefined) obj.acl.state = obj.acl.object;
                         if (obj.acl.state !== undefined) {
                             // If user is owner
-                            console.log('in checkState: user=' + options.user + ' vs owner =' + obj.acl.owner);
                             if (options.user === obj.acl.owner) {
                                 if (command === 'setState' || command === 'delState') {
                                     if (!(obj.acl.state & (2 << 8))/*write*/) {
@@ -2827,13 +2824,13 @@ console.log('in checkState before getObject: ' + JSON.stringify(options));
                                 return;
                             }
                         }
-                        else {
+                        else if (limitToOwnerRights) {
                             that.log.warn('Permissions limited to Owner rights');
                             callback('permissionError', {_id: ids});
                             return;
                         }
                     }
-                    else {
+                    else if (limitToOwnerRights){
                         that.log.warn('Permissions limited to Owner rights');
                         callback('permissionError', {_id: ids});
                         return;

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -2827,6 +2827,16 @@ console.log('in checkState before getObject: ' + JSON.stringify(options));
                                 return;
                             }
                         }
+                        else {
+                            that.log.warn('Permissions limited to Owner rights');
+                            callback('permissionError', {_id: ids});
+                            return;
+                        }
+                    }
+                    else {
+                        that.log.warn('Permissions limited to Owner rights');
+                        callback('permissionError', {_id: ids});
+                        return;
                     }
                 }
                 callback();

--- a/lib/objects/objectsInMemServer.js
+++ b/lib/objects/objectsInMemServer.js
@@ -683,7 +683,7 @@ function ObjectsInMemServer(settings) {
             if (typeof callback === 'function') callback(e.message);
         }
     };
-    
+
     this.readFile = function (id, name, options, callback) {
         if (typeof options === 'function') {
             callback = options;
@@ -1570,7 +1570,7 @@ function ObjectsInMemServer(settings) {
             callback(null, settings.connection.noFileCache);
         }, 0);
     };
-    
+
     // -------------- OBJECT FUNCTIONS -------------------------------------------
     function checkObject(id, options, flag) {
         // read rights of object
@@ -1662,27 +1662,27 @@ function ObjectsInMemServer(settings) {
         if (regUser.test(id) || regGroup.test(id)) {
             // If user may write
             if (flag === 2 && !options.acl.users.write) {// write
-                return callback('permissionError', options);
+                return callback('permissionError1', options);
             }
 
             // If user may read
             if (flag === 4 && !options.acl.users.read) {// read
-                return callback('permissionError', options);
+                return callback('permissionError2', options);
             }
 
             // If user may delete
             if (flag === 'delete' && !options.acl.users.delete) {// delete
-                return callback('permissionError', options);
+                return callback('permissionError3', options);
             }
 
             // If user may list
             if (flag === 'list' && !options.acl.users.list) {// list
-                return callback('permissionError', options);
+                return callback('permissionError4', options);
             }
 
             // If user may create
             if (flag === 'create' && !options.acl.users.create) {// create
-                return callback('permissionError', options);
+                return callback('permissionError5', options);
             }
 
             if (flag === 'delete') flag = 2; // write
@@ -1690,22 +1690,22 @@ function ObjectsInMemServer(settings) {
 
         // If user may write
         if (flag === 2 && !options.acl.object.write) {// write
-            return callback('permissionError', options);
+            return callback('permissionError6', options);
         }
 
         // If user may read
         if (flag === 4 && !options.acl.object.read) {// read
-            return callback('permissionError', options);
+            return callback('permissionError7', options);
         }
 
         // If user may delete
         if (flag === 'delete' && !options.acl.object.delete) {// delete
-            return callback('permissionError', options);
+            return callback('permissionError8', options);
         }
 
         // If user may list
         if (flag === 'list' && !options.acl.object.list) {// list
-            return callback('permissionError', options);
+            return callback('permissionError9', options);
         }
 
         if (flag === 'delete') flag = 2; // write
@@ -1713,12 +1713,12 @@ function ObjectsInMemServer(settings) {
         options.checked = true;
 
         if (id && !checkObject(id, options, flag)) {
-            return callback('permissionError', options);
+            return callback('permissionError10', options);
         }
 
         return callback(null, options);
     }
-    
+
     function clone(obj) {
         if (obj === null || obj === undefined || typeof obj !== 'object')
             return obj;
@@ -1758,7 +1758,7 @@ function ObjectsInMemServer(settings) {
             configTimer = null;
         }
     }
-    
+
     function subscribe(socket, type, pattern, options) {
         socket._subscribe = socket._subscribe || {};
         var s = socket._subscribe[type] = socket._subscribe[type] || [];
@@ -1865,7 +1865,7 @@ function ObjectsInMemServer(settings) {
             }
         }
     }*/
-    
+
     this.subscribeConfig = function (pattern, options, callback) {
         if (!options || !options.checked) {
             var socket = this;
@@ -2038,7 +2038,7 @@ function ObjectsInMemServer(settings) {
             if (!configTimer) configTimer = setTimeout(saveConfig, 5000);
         });
     };
-    
+
     this.getObject = function (id, options, callback) {
         if (typeof options === 'function') {
             callback = options;
@@ -2248,7 +2248,7 @@ function ObjectsInMemServer(settings) {
             }
         }
     };
-    
+
     this._applyView = function (func, params, options, callback) {
         if (typeof options === 'function') {
             callback = options;
@@ -2480,7 +2480,7 @@ function ObjectsInMemServer(settings) {
             if (preserveSettings.indexOf(settings[s]) === -1) preserveSettings.push(settings[s]);
         }
     };
-    
+
     this.destroyDB = function (options, callback) {
         if (typeof options === 'function') {
             callback = options;
@@ -2530,7 +2530,7 @@ function ObjectsInMemServer(settings) {
         socket.on('readDir', function (id, path, options, callback) {
             that.readDir.apply(that, arguments);
         });
-        
+
         socket.on('unlink', function (id, name, options, callback) {
             that.unlink.apply(that, arguments);
         });
@@ -2691,7 +2691,7 @@ function ObjectsInMemServer(settings) {
             }
         }
     };
-    
+
     var __construct = (function () {
         if (fs.existsSync(objectsName)) {
             try {

--- a/lib/objects/objectsInMemServer.js
+++ b/lib/objects/objectsInMemServer.js
@@ -1658,6 +1658,8 @@ function ObjectsInMemServer(settings) {
             return;
         }
 
+        log.error(JSON.stringify(options));
+
         // if user or group objects
         if (regUser.test(id) || regGroup.test(id)) {
             // If user may write

--- a/lib/objects/objectsInMemServer.js
+++ b/lib/objects/objectsInMemServer.js
@@ -386,7 +386,7 @@ function ObjectsInMemServer(settings) {
                     }
                 }
             }
-log.error(JSON.stringify(groups));
+
             that.getObjectList({startkey: 'system.user.', endkey: 'system.user.\u9999'}, {checked: true}, function (err, arr) {
                 if (err) log.error(namespace + ' ' + err);
                 users = {};
@@ -419,7 +419,6 @@ log.error(JSON.stringify(groups));
                         }
                     }
                 }
-                log.error(JSON.stringify(users));
 
                 for (var g = 0; g < groups.length; g++) {
                     if (!groups[g].common.members) continue;
@@ -684,7 +683,7 @@ log.error(JSON.stringify(groups));
             if (typeof callback === 'function') callback(e.message);
         }
     };
-    
+
     this.readFile = function (id, name, options, callback) {
         if (typeof options === 'function') {
             callback = options;
@@ -1571,7 +1570,7 @@ log.error(JSON.stringify(groups));
             callback(null, settings.connection.noFileCache);
         }, 0);
     };
-    
+
     // -------------- OBJECT FUNCTIONS -------------------------------------------
     function checkObject(id, options, flag) {
         // read rights of object
@@ -1659,8 +1658,6 @@ log.error(JSON.stringify(groups));
             return;
         }
 
-        log.error(JSON.stringify(options));
-
         // if user or group objects
         if (regUser.test(id) || regGroup.test(id)) {
             // If user may write
@@ -1721,7 +1718,7 @@ log.error(JSON.stringify(groups));
 
         return callback(null, options);
     }
-    
+
     function clone(obj) {
         if (obj === null || obj === undefined || typeof obj !== 'object')
             return obj;
@@ -1761,7 +1758,7 @@ log.error(JSON.stringify(groups));
             configTimer = null;
         }
     }
-    
+
     function subscribe(socket, type, pattern, options) {
         socket._subscribe = socket._subscribe || {};
         var s = socket._subscribe[type] = socket._subscribe[type] || [];
@@ -1868,7 +1865,7 @@ log.error(JSON.stringify(groups));
             }
         }
     }*/
-    
+
     this.subscribeConfig = function (pattern, options, callback) {
         if (!options || !options.checked) {
             var socket = this;
@@ -2041,7 +2038,7 @@ log.error(JSON.stringify(groups));
             if (!configTimer) configTimer = setTimeout(saveConfig, 5000);
         });
     };
-    
+
     this.getObject = function (id, options, callback) {
         if (typeof options === 'function') {
             callback = options;
@@ -2251,7 +2248,7 @@ log.error(JSON.stringify(groups));
             }
         }
     };
-    
+
     this._applyView = function (func, params, options, callback) {
         if (typeof options === 'function') {
             callback = options;
@@ -2483,7 +2480,7 @@ log.error(JSON.stringify(groups));
             if (preserveSettings.indexOf(settings[s]) === -1) preserveSettings.push(settings[s]);
         }
     };
-    
+
     this.destroyDB = function (options, callback) {
         if (typeof options === 'function') {
             callback = options;
@@ -2533,7 +2530,7 @@ log.error(JSON.stringify(groups));
         socket.on('readDir', function (id, path, options, callback) {
             that.readDir.apply(that, arguments);
         });
-        
+
         socket.on('unlink', function (id, name, options, callback) {
             that.unlink.apply(that, arguments);
         });
@@ -2694,7 +2691,7 @@ log.error(JSON.stringify(groups));
             }
         }
     };
-    
+
     var __construct = (function () {
         if (fs.existsSync(objectsName)) {
             try {

--- a/lib/objects/objectsInMemServer.js
+++ b/lib/objects/objectsInMemServer.js
@@ -386,7 +386,7 @@ function ObjectsInMemServer(settings) {
                     }
                 }
             }
-
+log.error(JSON.stringify(groups));
             that.getObjectList({startkey: 'system.user.', endkey: 'system.user.\u9999'}, {checked: true}, function (err, arr) {
                 if (err) log.error(namespace + ' ' + err);
                 users = {};
@@ -419,6 +419,7 @@ function ObjectsInMemServer(settings) {
                         }
                     }
                 }
+                log.error(JSON.stringify(users));
 
                 for (var g = 0; g < groups.length; g++) {
                     if (!groups[g].common.members) continue;

--- a/lib/objects/objectsInMemServer.js
+++ b/lib/objects/objectsInMemServer.js
@@ -684,7 +684,7 @@ log.error(JSON.stringify(groups));
             if (typeof callback === 'function') callback(e.message);
         }
     };
-
+    
     this.readFile = function (id, name, options, callback) {
         if (typeof options === 'function') {
             callback = options;
@@ -1571,7 +1571,7 @@ log.error(JSON.stringify(groups));
             callback(null, settings.connection.noFileCache);
         }, 0);
     };
-
+    
     // -------------- OBJECT FUNCTIONS -------------------------------------------
     function checkObject(id, options, flag) {
         // read rights of object
@@ -1665,27 +1665,27 @@ log.error(JSON.stringify(groups));
         if (regUser.test(id) || regGroup.test(id)) {
             // If user may write
             if (flag === 2 && !options.acl.users.write) {// write
-                return callback('permissionError1', options);
+                return callback('permissionError', options);
             }
 
             // If user may read
             if (flag === 4 && !options.acl.users.read) {// read
-                return callback('permissionError2', options);
+                return callback('permissionError', options);
             }
 
             // If user may delete
             if (flag === 'delete' && !options.acl.users.delete) {// delete
-                return callback('permissionError3', options);
+                return callback('permissionError', options);
             }
 
             // If user may list
             if (flag === 'list' && !options.acl.users.list) {// list
-                return callback('permissionError4', options);
+                return callback('permissionError', options);
             }
 
             // If user may create
             if (flag === 'create' && !options.acl.users.create) {// create
-                return callback('permissionError5', options);
+                return callback('permissionError', options);
             }
 
             if (flag === 'delete') flag = 2; // write
@@ -1693,22 +1693,22 @@ log.error(JSON.stringify(groups));
 
         // If user may write
         if (flag === 2 && !options.acl.object.write) {// write
-            return callback('permissionError6', options);
+            return callback('permissionError', options);
         }
 
         // If user may read
         if (flag === 4 && !options.acl.object.read) {// read
-            return callback('permissionError7', options);
+            return callback('permissionError', options);
         }
 
         // If user may delete
         if (flag === 'delete' && !options.acl.object.delete) {// delete
-            return callback('permissionError8', options);
+            return callback('permissionError', options);
         }
 
         // If user may list
         if (flag === 'list' && !options.acl.object.list) {// list
-            return callback('permissionError9', options);
+            return callback('permissionError', options);
         }
 
         if (flag === 'delete') flag = 2; // write
@@ -1716,12 +1716,12 @@ log.error(JSON.stringify(groups));
         options.checked = true;
 
         if (id && !checkObject(id, options, flag)) {
-            return callback('permissionError10', options);
+            return callback('permissionError', options);
         }
 
         return callback(null, options);
     }
-
+    
     function clone(obj) {
         if (obj === null || obj === undefined || typeof obj !== 'object')
             return obj;
@@ -1761,7 +1761,7 @@ log.error(JSON.stringify(groups));
             configTimer = null;
         }
     }
-
+    
     function subscribe(socket, type, pattern, options) {
         socket._subscribe = socket._subscribe || {};
         var s = socket._subscribe[type] = socket._subscribe[type] || [];
@@ -1868,7 +1868,7 @@ log.error(JSON.stringify(groups));
             }
         }
     }*/
-
+    
     this.subscribeConfig = function (pattern, options, callback) {
         if (!options || !options.checked) {
             var socket = this;
@@ -2041,7 +2041,7 @@ log.error(JSON.stringify(groups));
             if (!configTimer) configTimer = setTimeout(saveConfig, 5000);
         });
     };
-
+    
     this.getObject = function (id, options, callback) {
         if (typeof options === 'function') {
             callback = options;
@@ -2251,7 +2251,7 @@ log.error(JSON.stringify(groups));
             }
         }
     };
-
+    
     this._applyView = function (func, params, options, callback) {
         if (typeof options === 'function') {
             callback = options;
@@ -2483,7 +2483,7 @@ log.error(JSON.stringify(groups));
             if (preserveSettings.indexOf(settings[s]) === -1) preserveSettings.push(settings[s]);
         }
     };
-
+    
     this.destroyDB = function (options, callback) {
         if (typeof options === 'function') {
             callback = options;
@@ -2533,7 +2533,7 @@ log.error(JSON.stringify(groups));
         socket.on('readDir', function (id, path, options, callback) {
             that.readDir.apply(that, arguments);
         });
-
+        
         socket.on('unlink', function (id, name, options, callback) {
             that.unlink.apply(that, arguments);
         });
@@ -2694,7 +2694,7 @@ log.error(JSON.stringify(groups));
             }
         }
     };
-
+    
     var __construct = (function () {
         if (fs.existsSync(objectsName)) {
             try {

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "restart": "node iobroker.js restart",
     "prepublish": "node lib/scripts/scripts.js --prepublish",
     "test": "node node_modules/mocha/bin/mocha test",
+    "test-redis-socket": "node node_modules/mocha/bin/mocha test/redis-socket/",
     "coverage": "node node_modules/istanbul/lib/cli.js cover --config istanbul.yml node_modules/mocha/bin/_mocha ./test -- --ui bdd -R spec"
   },
   "main": "controller.js",

--- a/test/lib/setup4controller.js
+++ b/test/lib/setup4controller.js
@@ -106,7 +106,7 @@ function startController(options, callback) {
             },
             type:           options.states.type     || 'file',
             host:           options.states.host     || '127.0.0.1',
-            port:           options.states.port     || 19000,
+            port:           (options.states.port===undefined) ? 19000 : options.states.port,
             user:           options.states.user     || '',
             pass:           options.states.pass     || '',
             dataDir:        options.states.dataDir  || ''

--- a/test/lib/testObjectsFunctions.js
+++ b/test/lib/testObjectsFunctions.js
@@ -564,43 +564,6 @@ function register(it, expect, context) {
                 }, function (err) {
                     expect(err).to.be.null;
 
-        /*            var objectData = {
-                        "user":"system.user.write-only",
-                        "groups":[
-                            "system.group.writer"
-                        ],
-                        "object":{
-                            "list":false,
-                            "read":true,
-                            "write":false,
-                            "delete":false
-                        },
-                        "state":{
-                            "list":false,
-                            "read":true,
-                            "write":true,
-                            "create":false,
-                            "delete":false
-                        },
-                        "users":{
-                            "write":false,
-                            "create":false,
-                            "delete":false
-                        },
-                        "other":{
-                            "execute":false,
-                            "http":false,
-                            "sendto":false
-                        },
-                        "file":{
-                            "list":false,
-                            "read":false,
-                            "write":false,
-                            "create":false,
-                            "delete":false
-                        }
-                    };*/
-
                     context.objects.getObject(context.adapterShortName + 'f.0.' + gid, {user: "system.user.write-only"}, function (err, obj) {
                         expect(err).to.be.not.ok;
                         expect(obj).to.be.ok;

--- a/test/lib/testObjectsFunctions.js
+++ b/test/lib/testObjectsFunctions.js
@@ -601,7 +601,7 @@ function register(it, expect, context) {
                         }
                     };*/
 
-                    context.objects.getObject(context.adapterShortName + 'f.0.' + gid, objectData, function (err, obj) {
+                    context.objects.getObject(context.adapterShortName + 'f.0.' + gid, {user: "system.user.write-only"}, function (err, obj) {
                         expect(err).to.be.not.ok;
                         expect(obj).to.be.ok;
                         expect(obj.native).to.be.ok;

--- a/test/lib/testObjectsFunctions.js
+++ b/test/lib/testObjectsFunctions.js
@@ -489,7 +489,7 @@ function register(it, expect, context) {
               "state": {
                 "list": false,
                 "read": false,
-                "write": true,
+                "write": false,
                 "create": false,
                 "delete": false
               },

--- a/test/lib/testObjectsFunctions.js
+++ b/test/lib/testObjectsFunctions.js
@@ -466,6 +466,87 @@ function register(it, expect, context) {
                 }, 2000)
             });
     });
+
+    // getObject with acls
+    it(testName + 'Check getObjects with ACLs', function (done) {
+        this.timeout(1000);
+        // create testf.0.myTestObject
+
+        context.adapter.setForeignObject(context.adapterShortName + 'f.0.' + gid, {
+            common: {
+                name: 'test1',
+                type: 'number',
+                role: 'level',
+                members: ['A']
+            },
+            native: {
+                attr1: '1',
+                attr2: '2',
+                attr3: '3',
+                repositories: ['R1'],
+                certificates: ['C1'],
+                devices: ['D1']
+            },
+            type: 'state',
+            acl: {
+                object: 102,
+                owner: "system.user.write-only",
+                ownerGroup:"system.group.administrator",
+                state: 614
+            }
+        }, function (err) {
+            expect(err).to.be.null;
+
+            var objectData = {
+                "user":"system.user.write-only",
+                "groups":[
+                    "system.group.writer"
+                ],
+                "object":{
+                    "list":false,
+                    "read":true,
+                    "write":false,
+                    "delete":false
+                },
+                "state":{
+                    "list":false,
+                    "read":true,
+                    "write":true,
+                    "create":false,
+                    "delete":false
+                },
+                "users":{
+                    "write":false,
+                    "create":false,
+                    "delete":false
+                },
+                "other":{
+                    "execute":false,
+                    "http":false,
+                    "sendto":false
+                },
+                "file":{
+                    "list":false,
+                    "read":false,
+                    "write":false,
+                    "create":false,
+                    "delete":false
+                }
+            };
+
+            context.objects.getObject(context.adapterShortName + 'f.0.' + gid, objectData, function (err, obj) {
+                expect(err).to.be.not.ok;
+                expect(obj).to.be.ok;
+                expect(obj.native).to.be.ok;
+                expect(obj._id).equal(context.adapterShortName + 'f.0.' + gid);
+                expect(obj.common.name).equal('test1');
+                expect(obj.type).equal('state');
+                //expect(obj.acl).to.be.ok;
+                done();
+            });
+        });
+    });
+
 }
 
 module.exports.register = register;

--- a/test/lib/testObjectsFunctions.js
+++ b/test/lib/testObjectsFunctions.js
@@ -482,7 +482,7 @@ function register(it, expect, context) {
             "acl": {
               "object": {
                 "list": false,
-                "read": true,
+                "read": false,
                 "write": false,
                 "delete": false
               },

--- a/test/lib/testObjectsFunctions.js
+++ b/test/lib/testObjectsFunctions.js
@@ -613,6 +613,7 @@ function register(it, expect, context) {
                     });
                 });
             });
+        });
     });
 
 }

--- a/test/lib/testObjectsFunctions.js
+++ b/test/lib/testObjectsFunctions.js
@@ -472,79 +472,148 @@ function register(it, expect, context) {
         this.timeout(1000);
         // create testf.0.myTestObject
 
-        context.adapter.setForeignObject(context.adapterShortName + 'f.0.' + gid, {
-            common: {
-                name: 'test1',
-                type: 'number',
-                role: 'level',
-                members: ['A']
-            },
-            native: {
-                attr1: '1',
-                attr2: '2',
-                attr3: '3',
-                repositories: ['R1'],
-                certificates: ['C1'],
-                devices: ['D1']
-            },
-            type: 'state',
-            acl: {
-                object: 102,
-                owner: "system.user.write-only",
-                ownerGroup:"system.group.administrator",
-                state: 614
+        context.adapter.setForeignObject('system.group.writer', {
+          "common": {
+            "name": "Writer",
+            "desc": "",
+            "members": [
+              "system.user.write-only"
+            ],
+            "acl": {
+              "object": {
+                "list": false,
+                "read": false,
+                "write": false,
+                "delete": false
+              },
+              "state": {
+                "list": false,
+                "read": false,
+                "write": true,
+                "create": false,
+                "delete": false
+              },
+              "users": {
+                "write": false,
+                "create": false,
+                "delete": false
+              },
+              "other": {
+                "execute": false,
+                "http": false,
+                "sendto": false
+              },
+              "file": {
+                "list": false,
+                "read": false,
+                "write": false,
+                "create": false,
+                "delete": false
+              }
             }
+          },
+          "native": {},
+          "acl": {
+            "object": 1638,
+            "owner": "system.user.admin",
+            "ownerGroup": "system.group.administrator"
+          },
+          "_id": "system.group.writer",
+          "type": "group"
         }, function (err) {
             expect(err).to.be.null;
 
-            var objectData = {
-                "user":"system.user.write-only",
-                "groups":[
-                    "system.group.writer"
-                ],
-                "object":{
-                    "list":false,
-                    "read":true,
-                    "write":false,
-                    "delete":false
-                },
-                "state":{
-                    "list":false,
-                    "read":true,
-                    "write":true,
-                    "create":false,
-                    "delete":false
-                },
-                "users":{
-                    "write":false,
-                    "create":false,
-                    "delete":false
-                },
-                "other":{
-                    "execute":false,
-                    "http":false,
-                    "sendto":false
-                },
-                "file":{
-                    "list":false,
-                    "read":false,
-                    "write":false,
-                    "create":false,
-                    "delete":false
+            context.adapter.setForeignObject('system.group.writer', {
+                  "type": "user",
+                  "common": {
+                    "name": "write-only",
+                    "enabled": true,
+                    "groups": [],
+                    "password": "pbkdf2$10000$ab4104d8bb68390ee7e6c9397588e768de6c025f0c732c18806f3d1270c83f83fa86a7bf62583770e5f8d0b405fbb3ad32214ef3584f5f9332478f2506414443a910bf15863b36ebfcaa7cbb19253ae32cd3ca390dab87b29cd31e11be7fa4ea3a01dad625d9de44e412680e1a694227698788d71f1e089e5831dc1bbacfa794b45e1c995214bf71ee4160d98b4305fa4c3e36ee5f8da19b3708f68e7d2e8197375c0f763d90e31143eb04760cc2148c8f54937b9385c95db1742595634ed004fa567655dfe1d9b9fa698074a9fb70c05a252b2d9cf7ca1c9b009f2cd70d6972ccf0ee281d777d66a0346c6c6525436dd7fe3578b28dca2c7adbfde0ecd45148$31c3248ba4dc9600a024b4e0e7c3e585"
+                  },
+                  "_id": "system.user.write-only",
+                  "native": {},
+                  "acl": {
+                    "object": 1638
+                  }
                 }
-            };
+            }, function (err) {
+                expect(err).to.be.null;
+                
+                context.adapter.setForeignObject(context.adapterShortName + 'f.0.' + gid, {
+                    common: {
+                        name: 'test1',
+                        type: 'number',
+                        role: 'level',
+                        members: ['A']
+                    },
+                    native: {
+                        attr1: '1',
+                        attr2: '2',
+                        attr3: '3',
+                        repositories: ['R1'],
+                        certificates: ['C1'],
+                        devices: ['D1']
+                    },
+                    type: 'state',
+                    acl: {
+                        object: 102,
+                        owner: "system.user.write-only",
+                        ownerGroup:"system.group.administrator",
+                        state: 614
+                    }
+                }, function (err) {
+                    expect(err).to.be.null;
 
-            context.objects.getObject(context.adapterShortName + 'f.0.' + gid, objectData, function (err, obj) {
-                expect(err).to.be.not.ok;
-                expect(obj).to.be.ok;
-                expect(obj.native).to.be.ok;
-                expect(obj._id).equal(context.adapterShortName + 'f.0.' + gid);
-                expect(obj.common.name).equal('test1');
-                expect(obj.type).equal('state');
-                //expect(obj.acl).to.be.ok;
-                done();
+        /*            var objectData = {
+                        "user":"system.user.write-only",
+                        "groups":[
+                            "system.group.writer"
+                        ],
+                        "object":{
+                            "list":false,
+                            "read":true,
+                            "write":false,
+                            "delete":false
+                        },
+                        "state":{
+                            "list":false,
+                            "read":true,
+                            "write":true,
+                            "create":false,
+                            "delete":false
+                        },
+                        "users":{
+                            "write":false,
+                            "create":false,
+                            "delete":false
+                        },
+                        "other":{
+                            "execute":false,
+                            "http":false,
+                            "sendto":false
+                        },
+                        "file":{
+                            "list":false,
+                            "read":false,
+                            "write":false,
+                            "create":false,
+                            "delete":false
+                        }
+                    };*/
+
+                    context.objects.getObject(context.adapterShortName + 'f.0.' + gid, objectData, function (err, obj) {
+                        expect(err).to.be.not.ok;
+                        expect(obj).to.be.ok;
+                        expect(obj.native).to.be.ok;
+                        expect(obj._id).equal(context.adapterShortName + 'f.0.' + gid);
+                        expect(obj.common.name).equal('test1');
+                        expect(obj.type).equal('state');
+                        //expect(obj.acl).to.be.ok;
+                        done();
+                    });
+                });
             });
-        });
     });
 
 }

--- a/test/lib/testObjectsFunctions.js
+++ b/test/lib/testObjectsFunctions.js
@@ -523,7 +523,7 @@ function register(it, expect, context) {
         }, function (err) {
             expect(err).to.be.null;
 
-            context.adapter.setForeignObject('system.group.writer', {
+            context.adapter.setForeignObject('system.user.write-only', {
                 "type": "user",
                 "common": {
                     "name": "write-only",

--- a/test/lib/testObjectsFunctions.js
+++ b/test/lib/testObjectsFunctions.js
@@ -482,7 +482,7 @@ function register(it, expect, context) {
             "acl": {
               "object": {
                 "list": false,
-                "read": false,
+                "read": true,
                 "write": false,
                 "delete": false
               },

--- a/test/lib/testObjectsFunctions.js
+++ b/test/lib/testObjectsFunctions.js
@@ -482,7 +482,7 @@ function register(it, expect, context) {
             "acl": {
               "object": {
                 "list": false,
-                "read": false,
+                "read": true,
                 "write": false,
                 "delete": false
               },
@@ -556,10 +556,10 @@ function register(it, expect, context) {
                     },
                     type: 'state',
                     acl: {
-                        object: 102,
+                        object: 1638,
                         owner: "system.user.write-only",
                         ownerGroup:"system.group.administrator",
-                        state: 614
+                        state: 1638
                     }
                 }, function (err) {
                     expect(err).to.be.null;

--- a/test/lib/testObjectsFunctions.js
+++ b/test/lib/testObjectsFunctions.js
@@ -524,22 +524,21 @@ function register(it, expect, context) {
             expect(err).to.be.null;
 
             context.adapter.setForeignObject('system.group.writer', {
-                  "type": "user",
-                  "common": {
+                "type": "user",
+                "common": {
                     "name": "write-only",
                     "enabled": true,
                     "groups": [],
                     "password": "pbkdf2$10000$ab4104d8bb68390ee7e6c9397588e768de6c025f0c732c18806f3d1270c83f83fa86a7bf62583770e5f8d0b405fbb3ad32214ef3584f5f9332478f2506414443a910bf15863b36ebfcaa7cbb19253ae32cd3ca390dab87b29cd31e11be7fa4ea3a01dad625d9de44e412680e1a694227698788d71f1e089e5831dc1bbacfa794b45e1c995214bf71ee4160d98b4305fa4c3e36ee5f8da19b3708f68e7d2e8197375c0f763d90e31143eb04760cc2148c8f54937b9385c95db1742595634ed004fa567655dfe1d9b9fa698074a9fb70c05a252b2d9cf7ca1c9b009f2cd70d6972ccf0ee281d777d66a0346c6c6525436dd7fe3578b28dca2c7adbfde0ecd45148$31c3248ba4dc9600a024b4e0e7c3e585"
-                  },
-                  "_id": "system.user.write-only",
-                  "native": {},
-                  "acl": {
+                },
+                "_id": "system.user.write-only",
+                "native": {},
+                "acl": {
                     "object": 1638
-                  }
                 }
             }, function (err) {
                 expect(err).to.be.null;
-                
+
                 context.adapter.setForeignObject(context.adapterShortName + 'f.0.' + gid, {
                     common: {
                         name: 'test1',

--- a/test/lib/testStates.js
+++ b/test/lib/testStates.js
@@ -341,7 +341,7 @@ function register(it, expect, context) {
             context.states.getState(fGid, function (err, state) {
                 expect(err).to.be.null;
 
-                context.adapter.setForeignState(fGid, 1, {user: "system.user.write-only"}, function (err) {
+                context.adapter.setForeignState(fGid, 1, false, {user: "system.user.write-only"}, function (err) {
                     expect(err).to.be.not.ok;
 
                     context.states.getState(fGid, function (err, state) {

--- a/test/lib/testStates.js
+++ b/test/lib/testStates.js
@@ -454,6 +454,7 @@ function register(it, expect, context) {
 
                 context.adapter.setForeignState(fGid, 1, false, {user: "system.user.write-only"}, function (err) {
                     expect(err).to.be.equal("permissionError");
+                    done();
                 });
             });
         });

--- a/test/lib/testStates.js
+++ b/test/lib/testStates.js
@@ -328,7 +328,7 @@ function register(it, expect, context) {
             "acl": {
               "object": {
                 "list": false,
-                "read": true,
+                "read": false,
                 "write": false,
                 "delete": false
               },
@@ -407,7 +407,7 @@ function register(it, expect, context) {
                     context.states.getState(fGid, function (err, state) {
                         expect(err).to.be.null;
 
-                        context.adapter.setForeignState(fGid, 1, false, {user: "system.user.write-only"}, function (err) {
+                        context.adapter.setForeignState(fGid, 1, false, {user: "system.user.write-only2"}, function (err) {
                             expect(err).to.be.not.ok;
 
                             context.states.getState(fGid, function (err, state) {
@@ -419,6 +419,41 @@ function register(it, expect, context) {
                             });
                         });
                     });
+                });
+            });
+        });
+    });
+
+    // setForeignState with acl failure
+    it(testName + 'Set foreign state with acl failure', function (done) {
+        this.timeout(1000);
+        var fGid = context.adapterShortName + '3.1.' + gid;
+
+        context.objects.setObject(fGid, {
+            common: {
+                name: 'test1',
+                type: 'number',
+                role: 'level',
+                min: -100,
+                max: 100
+            },
+            native: {
+            },
+            type: 'state',
+            acl: {
+                object: 102,
+                owner: "system.user.write-only",
+                ownerGroup:"system.group.administrator",
+                state: 102
+            }
+        }, function (err) {
+            expect(err).to.be.null;
+
+            context.states.getState(fGid, function (err, state) {
+                expect(err).to.be.null;
+
+                context.adapter.setForeignState(fGid, 1, false, {user: "system.user.write-only"}, function (err) {
+                    expect(err).to.be.equal("permissionError");
                 });
             });
         });

--- a/test/lib/testStates.js
+++ b/test/lib/testStates.js
@@ -328,7 +328,7 @@ function register(it, expect, context) {
             "acl": {
               "object": {
                 "list": false,
-                "read": false,
+                "read": true,
                 "write": false,
                 "delete": false
               },

--- a/test/lib/testStates.js
+++ b/test/lib/testStates.js
@@ -242,7 +242,7 @@ function register(it, expect, context) {
 
         context.states.setState(context.adapterShortName + '.0.' + sGid, 9, function (err) {
             expect(err).to.be.not.ok;
-            
+
             context.adapter.unsubscribeStates('*', function () {
                 context.states.setState(context.adapterShortName + '.0.' + sGid, 10, function (err) {
                     expect(err).to.be.not.ok;
@@ -254,7 +254,7 @@ function register(it, expect, context) {
             });
         });
     });
-    
+
     // -------------------------------------------------------------------------------------
     // setForeignState
     it(testName + 'Set foreign state', function (done) {
@@ -308,6 +308,47 @@ function register(it, expect, context) {
                                 });
                             });
                         });
+                    });
+                });
+            });
+        });
+    });
+
+    // setForeignState with acl
+    it(testName + 'Set foreign state with acl', function (done) {
+        this.timeout(1000);
+        var fGid = context.adapterShortName + '1.0.' + gid;
+        context.objects.setObject(fGid, {
+            common: {
+                name: 'test1',
+                type: 'number',
+                role: 'level',
+                min: -100,
+                max: 100
+            },
+            native: {
+            },
+            type: 'state',
+            acl: {
+                object: 1638,
+                owner: "system.user.write-only",
+                ownerGroup:"system.group.administrator",
+                state: 1638
+            }
+        }, function (err) {
+            expect(err).to.be.null;
+
+            context.states.getState(fGid, function (err, state) {
+                expect(err).to.be.null;
+
+                context.adapter.setForeignState(fGid, 1, {user: "system.user.write-only"}, function (err) {
+                    expect(err).to.be.not.ok;
+
+                    context.states.getState(fGid, function (err, state) {
+                        expect(err).to.be.null;
+                        expect(state).to.be.ok;
+                        expect(state.val).to.equal(1);
+                        expect(state.ack).to.equal(false);
                     });
                 });
             });
@@ -501,7 +542,7 @@ function register(it, expect, context) {
             });
         });
     });
-    
+
     // getHistory - cannot be tested
  }
 

--- a/test/lib/testStates.js
+++ b/test/lib/testStates.js
@@ -317,7 +317,7 @@ function register(it, expect, context) {
     // setForeignState with acl
     it(testName + 'Set foreign state with acl', function (done) {
         this.timeout(1000);
-        var fGid = context.adapterShortName + '1.0.' + gid;
+        var fGid = context.adapterShortName + '3.0.' + gid;
         context.objects.setObject(fGid, {
             common: {
                 name: 'test1',

--- a/test/lib/testStates.js
+++ b/test/lib/testStates.js
@@ -318,38 +318,106 @@ function register(it, expect, context) {
     it(testName + 'Set foreign state with acl', function (done) {
         this.timeout(1000);
         var fGid = context.adapterShortName + '3.0.' + gid;
-        context.objects.setObject(fGid, {
-            common: {
-                name: 'test1',
-                type: 'number',
-                role: 'level',
-                min: -100,
-                max: 100
-            },
-            native: {
-            },
-            type: 'state',
-            acl: {
-                object: 1638,
-                owner: "system.user.write-only",
-                ownerGroup:"system.group.administrator",
-                state: 1638
+        context.adapter.setForeignObject('system.group.writer2', {
+          "common": {
+            "name": "Writer2",
+            "desc": "",
+            "members": [
+              "system.user.write-only2"
+            ],
+            "acl": {
+              "object": {
+                "list": false,
+                "read": false,
+                "write": false,
+                "delete": false
+              },
+              "state": {
+                "list": false,
+                "read": true,
+                "write": false,
+                "create": false,
+                "delete": false
+              },
+              "users": {
+                "write": false,
+                "create": false,
+                "delete": false
+              },
+              "other": {
+                "execute": false,
+                "http": false,
+                "sendto": false
+              },
+              "file": {
+                "list": false,
+                "read": false,
+                "write": false,
+                "create": false,
+                "delete": false
+              }
             }
+          },
+          "native": {},
+          "acl": {
+            "object": 1638,
+            "owner": "system.user.admin",
+            "ownerGroup": "system.group.administrator"
+          },
+          "_id": "system.group.writer2",
+          "type": "group"
         }, function (err) {
             expect(err).to.be.null;
 
-            context.states.getState(fGid, function (err, state) {
-                expect(err).to.be.null;
+            context.adapter.setForeignObject('system.user.write-only2', {
+                "type": "user",
+                "common": {
+                    "name": "write-only2",
+                    "enabled": true,
+                    "groups": [],
+                    "password": "pbkdf2$10000$ab4104d8bb68390ee7e6c9397588e768de6c025f0c732c18806f3d1270c83f83fa86a7bf62583770e5f8d0b405fbb3ad32214ef3584f5f9332478f2506414443a910bf15863b36ebfcaa7cbb19253ae32cd3ca390dab87b29cd31e11be7fa4ea3a01dad625d9de44e412680e1a694227698788d71f1e089e5831dc1bbacfa794b45e1c995214bf71ee4160d98b4305fa4c3e36ee5f8da19b3708f68e7d2e8197375c0f763d90e31143eb04760cc2148c8f54937b9385c95db1742595634ed004fa567655dfe1d9b9fa698074a9fb70c05a252b2d9cf7ca1c9b009f2cd70d6972ccf0ee281d777d66a0346c6c6525436dd7fe3578b28dca2c7adbfde0ecd45148$31c3248ba4dc9600a024b4e0e7c3e585"
+                },
+                "_id": "system.user.write-only2",
+                "native": {},
+                "acl": {
+                    "object": 1638
+                }
+            }, function (err) {
 
-                context.adapter.setForeignState(fGid, 1, false, {user: "system.user.write-only"}, function (err) {
-                    expect(err).to.be.not.ok;
+                context.objects.setObject(fGid, {
+                    common: {
+                        name: 'test1',
+                        type: 'number',
+                        role: 'level',
+                        min: -100,
+                        max: 100
+                    },
+                    native: {
+                    },
+                    type: 'state',
+                    acl: {
+                        object: 1638,
+                        owner: "system.user.write-only2",
+                        ownerGroup:"system.group.administrator",
+                        state: 1638
+                    }
+                }, function (err) {
+                    expect(err).to.be.null;
 
                     context.states.getState(fGid, function (err, state) {
                         expect(err).to.be.null;
-                        expect(state).to.be.ok;
-                        expect(state.val).to.equal(1);
-                        expect(state.ack).to.equal(false);
-                        done();
+
+                        context.adapter.setForeignState(fGid, 1, false, {user: "system.user.write-only"}, function (err) {
+                            expect(err).to.be.not.ok;
+
+                            context.states.getState(fGid, function (err, state) {
+                                expect(err).to.be.null;
+                                expect(state).to.be.ok;
+                                expect(state.val).to.equal(1);
+                                expect(state.ack).to.equal(false);
+                                done();
+                            });
+                        });
                     });
                 });
             });
@@ -357,7 +425,7 @@ function register(it, expect, context) {
     });
 
     // setForeignState with acl write only
-    it(testName + 'Set foreign state with acl', function (done) {
+    it(testName + 'Set foreign state with acl write only', function (done) {
         this.timeout(1000);
         var fGid = context.adapterShortName + '3.0.' + gid;
         context.objects.setObject(fGid, {
@@ -373,7 +441,7 @@ function register(it, expect, context) {
             type: 'state',
             acl: {
                 object: 1126,
-                owner: "system.user.write-only",
+                owner: "system.user.write-only2",
                 ownerGroup:"system.group.administrator",
                 state: 614
             }
@@ -383,7 +451,7 @@ function register(it, expect, context) {
             context.states.getState(fGid, function (err, state) {
                 expect(err).to.be.null;
 
-                context.adapter.setForeignState(fGid, 1, false, {user: "system.user.write-only"}, function (err) {
+                context.adapter.setForeignState(fGid, 1, false, {user: "system.user.write-only2"}, function (err) {
                     expect(err).to.be.not.ok;
 
                     context.states.getState(fGid, function (err, state) {

--- a/test/lib/testStates.js
+++ b/test/lib/testStates.js
@@ -314,7 +314,7 @@ function register(it, expect, context) {
         });
     });
 
-    // setForeignState with acl
+    // setForeignState with acl all
     it(testName + 'Set foreign state with acl', function (done) {
         this.timeout(1000);
         var fGid = context.adapterShortName + '3.0.' + gid;
@@ -349,6 +349,49 @@ function register(it, expect, context) {
                         expect(state).to.be.ok;
                         expect(state.val).to.equal(1);
                         expect(state.ack).to.equal(false);
+                        done();
+                    });
+                });
+            });
+        });
+    });
+
+    // setForeignState with acl write only
+    it(testName + 'Set foreign state with acl', function (done) {
+        this.timeout(1000);
+        var fGid = context.adapterShortName + '3.0.' + gid;
+        context.objects.setObject(fGid, {
+            common: {
+                name: 'test1',
+                type: 'number',
+                role: 'level',
+                min: -100,
+                max: 100
+            },
+            native: {
+            },
+            type: 'state',
+            acl: {
+                object: 1126,
+                owner: "system.user.write-only",
+                ownerGroup:"system.group.administrator",
+                state: 614
+            }
+        }, function (err) {
+            expect(err).to.be.null;
+
+            context.states.getState(fGid, function (err, state) {
+                expect(err).to.be.null;
+
+                context.adapter.setForeignState(fGid, 1, false, {user: "system.user.write-only"}, function (err) {
+                    expect(err).to.be.not.ok;
+
+                    context.states.getState(fGid, function (err, state) {
+                        expect(err).to.be.null;
+                        expect(state).to.be.ok;
+                        expect(state.val).to.equal(1);
+                        expect(state.ack).to.equal(false);
+                        done();
                     });
                 });
             });

--- a/test/redis-socket/redis-socket.config
+++ b/test/redis-socket/redis-socket.config
@@ -1,0 +1,8 @@
+# Specify the path for the unix socket that will be used to listen for
+# incoming connections. There is no default, so Redis will not listen
+# on a unix socket when not specified.
+#
+unixsocket /tmp/redis.sock
+unixsocketperm 755
+
+# The default values of all other paramaters should be ok.

--- a/test/redis-socket/redis-socket.config
+++ b/test/redis-socket/redis-socket.config
@@ -3,6 +3,6 @@
 # on a unix socket when not specified.
 #
 unixsocket /tmp/redis.sock
-unixsocketperm 755
+unixsocketperm 777
 
 # The default values of all other paramaters should be ok.

--- a/test/redis-socket/redis-socket.config
+++ b/test/redis-socket/redis-socket.config
@@ -2,7 +2,9 @@
 # incoming connections. There is no default, so Redis will not listen
 # on a unix socket when not specified.
 #
-unixsocket /tmp/redis.sock
+port 0
+bind 127.0.0.1
+unixsocket /var/run/redis.sock
 unixsocketperm 777
 
 # The default values of all other paramaters should be ok.

--- a/test/redis-socket/setup-socket.sh
+++ b/test/redis-socket/setup-socket.sh
@@ -1,0 +1,4 @@
+#/bin/sh
+redis-cli SHUTDOWN
+sudo redis-server ${TRAVIS_BUILD_DIR}/test/redis-socket/redis-socket.config
+redis-cli PING

--- a/test/redis-socket/setup-socket.sh
+++ b/test/redis-socket/setup-socket.sh
@@ -1,4 +1,5 @@
 #/bin/sh
 redis-cli SHUTDOWN
-sudo redis-server ${TRAVIS_BUILD_DIR}/test/redis-socket/redis-socket.config
+sudo redis-server ${TRAVIS_BUILD_DIR}/test/redis-socket/redis-socket.config &
+sleep 15
 redis-cli PING

--- a/test/redis-socket/setup-socket.sh
+++ b/test/redis-socket/setup-socket.sh
@@ -3,3 +3,4 @@ redis-cli SHUTDOWN
 sudo redis-server ${TRAVIS_BUILD_DIR}/test/redis-socket/redis-socket.config &
 sleep 15
 redis-cli PING
+npm run test-redis-socket

--- a/test/redis-socket/setup-socket.sh
+++ b/test/redis-socket/setup-socket.sh
@@ -4,3 +4,5 @@ sudo redis-server ${TRAVIS_BUILD_DIR}/test/redis-socket/redis-socket.config &
 sleep 15
 redis-cli -s /tmp/redis.sock PING
 npm run test-redis-socket
+redis-cli -s /tmp/redis.sock PING
+redis-cli -s /tmp/redis.sock SHUTDOWN

--- a/test/redis-socket/setup-socket.sh
+++ b/test/redis-socket/setup-socket.sh
@@ -2,5 +2,5 @@
 redis-cli SHUTDOWN
 sudo redis-server ${TRAVIS_BUILD_DIR}/test/redis-socket/redis-socket.config &
 sleep 15
-redis-cli PING
+redis-cli -s /tmp/redis.sock PING
 npm run test-redis-socket

--- a/test/redis-socket/setup-socket.sh
+++ b/test/redis-socket/setup-socket.sh
@@ -2,7 +2,7 @@
 redis-cli SHUTDOWN
 sudo redis-server ${TRAVIS_BUILD_DIR}/test/redis-socket/redis-socket.config &
 sleep 15
-redis-cli -s /tmp/redis.sock PING
+redis-cli -s /var/run/redis.sock PING
 npm run test-redis-socket
-redis-cli -s /tmp/redis.sock PING
-redis-cli -s /tmp/redis.sock SHUTDOWN
+redis-cli -s /var/run/redis.sock PING
+redis-cli -s /var/run/redis.sock SHUTDOWN

--- a/test/redis-socket/setup-socket.sh
+++ b/test/redis-socket/setup-socket.sh
@@ -4,5 +4,5 @@ sudo redis-server ${TRAVIS_BUILD_DIR}/test/redis-socket/redis-socket.config &
 sleep 15
 redis-cli -s /var/run/redis.sock PING
 npm run test-redis-socket
-redis-cli -s /var/run/redis.sock PING
-redis-cli -s /var/run/redis.sock SHUTDOWN
+#redis-cli -s /var/run/redis.sock PING
+#redis-cli -s /var/run/redis.sock SHUTDOWN

--- a/test/redis-socket/testAdapterStatesRedis.js
+++ b/test/redis-socket/testAdapterStatesRedis.js
@@ -1,0 +1,36 @@
+/* jshint -W097 */
+/* jshint strict:false */
+/* jslint node:true */
+/* jshint expr:true */
+'use strict';
+
+var testAdapter = require(__dirname + '/../lib/testAdapter');
+var dataDir = __dirname + '/../../tmp/data-redis';
+
+var statesConfig = {
+    options : {
+        auth_pass: null,
+        retry_max_delay: 15000
+    },
+    type:           'redis',
+    host:           '/tmp/redis.sock',
+    port:           0
+};
+
+var objectsConfig = {
+    dataDir:        dataDir,
+    type:           'file',
+    host:           '127.0.0.1',
+    port:           19002,
+    user:           '',
+    pass:           '',
+    noFileCache:    true,
+    connectTimeout: 2000
+};
+
+// states in REDIS, objects in files
+testAdapter({
+    statesConfig:  statesConfig,
+    objectsConfig: objectsConfig,
+    name: 'Tests REDIS-Socket'
+});

--- a/test/redis-socket/testAdapterStatesRedis.js
+++ b/test/redis-socket/testAdapterStatesRedis.js
@@ -13,7 +13,7 @@ var statesConfig = {
         retry_max_delay: 15000
     },
     type:           'redis',
-    host:           '/tmp/redis.sock',
+    host:           '/var/run/redis.sock',
     port:           0
 };
 

--- a/test/redis-socket/testStatesRedis.js
+++ b/test/redis-socket/testStatesRedis.js
@@ -41,7 +41,7 @@ describe('States-Redis-Socket: Test states', function() {
                 },
                 states: {
                     type: 'redis',
-                    host: '/tmp/redis.sock',
+                    host: '/var/run/redis.sock',
                     port: 0,
                     onChange: function (id, state) {
                         console.log('Redis-state-Socket changed. ' + id);

--- a/test/redis-socket/testStatesRedis.js
+++ b/test/redis-socket/testStatesRedis.js
@@ -1,0 +1,98 @@
+/* jshint -W097 */
+/* jshint strict:false */
+/* jslint node:true */
+/* jshint expr:true */
+'use strict';
+
+var expect = require('chai').expect;
+var setup  = require(__dirname + '/../lib/setup4controller');
+var fs     = require('fs');
+var objects     = null;
+var states      = null;
+var onStatesChanged = null;
+var dataDir = __dirname + '/../../tmp/data';
+
+function cleanDbs() {
+    if (fs.existsSync(dataDir + '/objects.json')) {
+        fs.unlinkSync(dataDir + '/objects.json');
+    }
+    if (fs.existsSync(dataDir + '/objects.json.bak')) {
+        fs.unlinkSync(dataDir + '/objects.json.bak');
+    }
+    if (fs.existsSync(dataDir + '/states.json')) {
+        fs.unlinkSync(dataDir + '/states.json');
+    }
+    if (fs.existsSync(dataDir + '/states.json.bak')) {
+        fs.unlinkSync(dataDir + '/states.json.bak');
+    }
+}
+
+describe('States-Redis: Test states', function() {
+    before('States-Redis: Start js-controller', function (_done) {
+        this.timeout(10000);
+        cleanDbs();
+
+        setup.startController({
+                objects: {
+                    dataDir: dataDir,
+                    onChange:function (id, obj) {
+                        console.log('object changed. ' + id);
+                    }
+                },
+                states: {
+                    type: 'redis',
+                    host: '/tmp/redis.sock',
+                    port: 0,
+                    onChange: function (id, state) {
+                        console.log('Redis-state changed. ' + id);
+                        if (onStatesChanged) onStatesChanged(id, state);
+                    }
+                }
+            },
+            function (_objects, _states) {
+                objects = _objects;
+                states  = _states;
+                states.subscribe('*');
+                expect(objects).to.be.ok;
+                expect(states).to.be.ok;
+                setTimeout(_done, 5000);
+            }
+        );
+    });
+
+    it('States-Redis: should setState', function (done) {
+        this.timeout(10000);
+
+        var testID = 'testObject.0.test1';
+        onStatesChanged = function (id, state) {
+            if (id === testID) {
+                expect(state).to.be.ok;
+                expect(state.val).to.be.equal(1);
+                expect(state.ack).to.be.false;
+                expect(state.ts).to.be.ok;
+                expect(state.q).to.be.equal(0);
+
+                states.getState(testID, function (err, state) {
+                    expect(err).to.be.not.ok;
+                    expect(state).to.be.ok;
+                    expect(state.val).to.be.equal(1);
+                    expect(state.ack).to.be.false;
+                    expect(state.ts).to.be.ok;
+                    expect(state.q).to.be.equal(0);
+                    done();
+                });
+            }
+        };
+
+        states.setState(testID, 1, function (err) {
+            expect(err).to.be.not.ok;
+        });
+    });
+
+    after('States-Redis: Stop js-controller', function (done) {
+        this.timeout(5000);
+        setup.stopController(function () {
+            done();
+        });
+    });
+});

--- a/test/redis-socket/testStatesRedis.js
+++ b/test/redis-socket/testStatesRedis.js
@@ -27,8 +27,8 @@ function cleanDbs() {
     }
 }
 
-describe('States-Redis: Test states', function() {
-    before('States-Redis: Start js-controller', function (_done) {
+describe('States-Redis-Socket: Test states', function() {
+    before('States-Redis-Socket: Start js-controller', function (_done) {
         this.timeout(10000);
         cleanDbs();
 
@@ -44,7 +44,7 @@ describe('States-Redis: Test states', function() {
                     host: '/tmp/redis.sock',
                     port: 0,
                     onChange: function (id, state) {
-                        console.log('Redis-state changed. ' + id);
+                        console.log('Redis-state-Socket changed. ' + id);
                         if (onStatesChanged) onStatesChanged(id, state);
                     }
                 }
@@ -60,7 +60,7 @@ describe('States-Redis: Test states', function() {
         );
     });
 
-    it('States-Redis: should setState', function (done) {
+    it('States-Redis-Socket: should setState', function (done) {
         this.timeout(10000);
 
         var testID = 'testObject.0.test1';
@@ -89,7 +89,7 @@ describe('States-Redis: Test states', function() {
         });
     });
 
-    after('States-Redis: Stop js-controller', function (done) {
+    after('States-Redis-Socket: Stop js-controller', function (done) {
         this.timeout(5000);
         setup.stopController(function () {
             done();


### PR DESCRIPTION
- fix that objects permissions were needed when reading or writing ForeignStates
- add feature to allow limit of permission checks to owner of objects/states only. Will be used by simple-api in a first place
- add some tests with permissions