### PR TITLE
Add promisified methods to the adapter class

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -22,11 +22,11 @@ var fs =                require('fs');
 var extend =            require('node.extend');
 var util =              require('util');
 var EventEmitter =      require('events').EventEmitter;
-var tools =             require('./tools');
+var tools =             require(__dirname + '/tools');
 var getConfigFileName = tools.getConfigFileName;
 var schedule;
 
-var password =          require('./password');
+var password =          require(__dirname + '/password');
 var config =            null;
 var that;
 var defaultObjs;

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -22,11 +22,11 @@ var fs =                require('fs');
 var extend =            require('node.extend');
 var util =              require('util');
 var EventEmitter =      require('events').EventEmitter;
-var tools =             require(__dirname + '/tools');
+var tools =             require('./tools');
 var getConfigFileName = tools.getConfigFileName;
 var schedule;
 
-var password =          require(__dirname + '/password');
+var password =          require('./password');
 var config =            null;
 var that;
 var defaultObjs;
@@ -268,6 +268,11 @@ function Adapter(options) {
     };
 
     /**
+     * Promise-version of Adapter.getPort
+     */
+    that.getPortAsync = tools.promisifyNoError(that.getPort, that);
+
+    /**
      * validates user and password
      *
      *
@@ -305,6 +310,10 @@ function Adapter(options) {
             });
         });
     };
+    /**
+     * Promise-version of Adapter.checkPassword
+     */
+    that.checkPasswordAsync = tools.promisifyNoError(that.checkPassword, that);
 
     /**
      * sets the user's password
@@ -351,6 +360,10 @@ function Adapter(options) {
         });
 
     };
+    /**
+     * Promise-version of Adapter.setPassword
+     */
+    that.setPasswordAsync = tools.promisify(that.setPassword, that);
 
     /**
      * returns if user exists and is in the group
@@ -398,6 +411,10 @@ function Adapter(options) {
             });
         });
     };
+    /**
+     * Promise-version of Adapter.checkGroup
+     */
+    that.checkGroupAsync = tools.promisifyNoError(that.checkGroup, that);
 
     /**
      * get the user permissions
@@ -598,6 +615,10 @@ function Adapter(options) {
             if (callback) callback(acl);
         });
     };
+    /**
+     * Promise-version of Adapter.calculatePermissions
+     */
+    that.calculatePermissionsAsync = tools.promisifyNoError(that.calculatePermissions, that);
 
     function readFileCertificate(cert) {
         if (typeof cert === 'string') {
@@ -687,6 +708,10 @@ function Adapter(options) {
             }
         });
     };
+    /**
+     * Promise-version of Adapter.getCertificates
+     */
+    that.getCertificatesAsync = tools.promisify(that.getCertificates, that);
 
     // Can be later deleted if no more appears
     that.inited = false;
@@ -974,6 +999,10 @@ function Adapter(options) {
                 if (typeof callback === 'function') callback('mandatory property type missing!');
             }
         };
+        /**
+         * Promise-version of Adapter.setObject
+         */
+        that.setObjectAsync = tools.promisify(that.setObject, that);
 
         /**
          * Get all states, channels and devices of this adapter.
@@ -1019,6 +1048,10 @@ function Adapter(options) {
                 });
             });
         };
+        /**
+         * Promise-version of Adapter.getAdapterObjects
+         */
+        that.getAdapterObjectsAsync = tools.promisifyNoError(that.getAdapterObjects, that);
 
         /**
          * Extend some object and create it if it does not exist
@@ -1132,6 +1165,10 @@ function Adapter(options) {
                 that.objects.extendObject(id, obj, options, callback);
             }
         };
+        /**
+         * Promise-version of Adapter.extendObject
+         */
+        that.extendObjectAsync = tools.promisify(that.extendObject, that);
 
         /**
          * Same as {@link Adapter.setObject}, but for any object.
@@ -1161,6 +1198,10 @@ function Adapter(options) {
 
             that.objects.setObject(id, obj, options, callback);
         };
+        /**
+         * Promise-version of Adapter.setForeignObject
+         */
+        that.setForeignObjectAsync = tools.promisify(that.setForeignObject, that);
 
         /**
          * Same as {@link Adapter.extendObject}, but for any object.
@@ -1224,6 +1265,10 @@ function Adapter(options) {
                 that.objects.extendObject(id, obj, options, callback);
             }
         };
+        /**
+         * Promise-version of Adapter.extendForeignObject
+         */
+        that.extendForeignObjectAsync = tools.promisify(that.extendForeignObject, that);
 
         /**
          * Get object of this instance.
@@ -1248,6 +1293,10 @@ function Adapter(options) {
             }
             that.objects.getObject(that._fixId(id), options, callback);
         };
+        /**
+         * Promise-version of Adapter.getObject
+         */
+        that.getObjectAsync = tools.promisify(that.getObject, that);
 
         /**
          * Get the enum tree.
@@ -1303,6 +1352,7 @@ function Adapter(options) {
                 if (typeof callback === 'function') callback(err, result, _enum);
             });
         };
+        // Non-NodeJS-style callback: cannot promisify getEnum
 
         /**
          * Read the members of given enums.
@@ -1389,6 +1439,10 @@ function Adapter(options) {
                 });
             }
         };
+        /**
+         * Promise-version of Adapter.getEnums
+         */
+        that.getEnumsAsync = tools.promisify(that.getEnums, that);
 
         /**
          * Get objects by pattern, by specific type and resolve their enums.
@@ -1501,6 +1555,10 @@ function Adapter(options) {
                 });
             });
         };
+        /**
+         * Promise-version of Adapter.getForeignObjects
+         */
+        that.getForeignObjectsAsync = tools.promisify(that.getForeignObjects, that);
 
         /**
          * Find any object by name or ID.
@@ -1527,6 +1585,7 @@ function Adapter(options) {
             }
             that.objects.findObject(id, type, options, callback);
         };
+        // non-NodeJS-style callback, cannot promisify findForeignObject
 
         /**
          * Get any object.
@@ -1551,6 +1610,10 @@ function Adapter(options) {
             }
             that.objects.getObject(id, options, callback);
         };
+        /**
+         * Promise-version of Adapter.getForeignObject
+         */
+        that.getForeignObjectAsync = tools.promisify(that.getForeignObject, that);
 
         /**
          * Delete object of this instance.
@@ -1576,6 +1639,10 @@ function Adapter(options) {
             id = that._fixId(id);
             that.objects.delObject(id, options, callback);
         };
+        /**
+         * Promise-version of Adapter.delObject
+         */
+        that.delObjectAsync = tools.promisify(that.delObject, that);
 
         /**
          * Delete any object.
@@ -1600,6 +1667,10 @@ function Adapter(options) {
             }
             that.objects.delObject(id, options, callback);
         };
+        /**
+         * Promise-version of Adapter.delForeignObject
+         */
+        that.delForeignObjectAsync = tools.promisify(that.delForeignObject, that);
 
         /**
          * Subscribe for the changes of objects in this instance.
@@ -1682,6 +1753,10 @@ function Adapter(options) {
                 }
             });
         };
+        /**
+         * Promise-version of Adapter.setObjectNotExists
+         */
+        that.setObjectNotExistsAsync = tools.promisify(that.setObjectNotExists, that);
 
         that.setForeignObjectNotExists = function setForeignObjectNotExists(id, obj, options, callback) {
             if (typeof options === 'function') {
@@ -1699,6 +1774,10 @@ function Adapter(options) {
                 }
             });
         };
+        /**
+         * Promise-version of Adapter.setForeignObjectNotExists
+         */
+        that.setForeignObjectNotExistsAsync = tools.promisify(that.setForeignObjectNotExists, that);
 
         that._DCS2ID = function (device, channel, stateOrPoint) {
             var id = '';
@@ -1742,6 +1821,10 @@ function Adapter(options) {
                 native:   _native
             }, options, callback);
         };
+        /**
+         * Promise-version of Adapter.createDevice
+         */
+        that.createDeviceAsync = tools.promisify(that.createDevice, that);
 
         // name of channel must be in format "channel"
         that.createChannel = function createChannel(parentDevice, channelName, roleOrCommon, _native, options, callback) {
@@ -1785,6 +1868,10 @@ function Adapter(options) {
 
             that.setObjectNotExists(channelName, obj, options, callback);
         };
+        /**
+         * Promise-version of Adapter.createChannel
+         */
+        that.createChannelAsync = tools.promisify(that.createChannel, that);
 
         that.createState = function createState(parentDevice, parentChannel, stateName, roleOrCommon, _native, options, callback) {
             if (typeof options === 'function') {
@@ -1896,6 +1983,10 @@ function Adapter(options) {
                 that.setState(id, null, true, options);
             }
         };
+        /**
+         * Promise-version of Adapter.createState
+         */
+        that.createStateAsync = tools.promisify(that.createState, that);
 
         that.deleteDevice = function deleteDevice(deviceName, options, callback) {
             if (typeof options === 'function') {
@@ -1951,6 +2042,10 @@ function Adapter(options) {
                 if (!cnt && callback) callback();
             });
         };
+        /**
+         * Promise-version of Adapter.deleteDevice
+         */
+        that.deleteDeviceAsync = tools.promisify(that.deleteDevice, that);
 
         that.addChannelToEnum = function addChannelToEnum(enumName, addTo, parentDevice, channelName, options, callback) {
             if (typeof options === 'function') {
@@ -2029,6 +2124,10 @@ function Adapter(options) {
                 });
             }
         };
+        /**
+         * Promise-version of Adapter.addChannelToEnum
+         */
+        that.addChannelToEnumAsync = tools.promisify(that.addChannelToEnum, that);
 
         that.deleteChannelFromEnum = function deleteChannelFromEnum(enumName, parentDevice, channelName, options, callback) {
             if (typeof options === 'function') {
@@ -2102,6 +2201,10 @@ function Adapter(options) {
                 }
             });
         };
+        /**
+         * Promise-version of Adapter.deleteChannelFromEnum
+         */
+        that.deleteChannelFromEnumAsync = tools.promisify(that.deleteChannelFromEnum, that);
 
         that.deleteChannel = function deleteChannel(parentDevice, channelName, options, callback) {
             if (typeof options === 'function') {
@@ -2192,6 +2295,10 @@ function Adapter(options) {
                 if (!cnt && callback) callback();
             });
         };
+        /**
+         * Promise-version of Adapter.deleteChannel
+         */
+        that.deleteChannelAsync = tools.promisify(that.deleteChannel, that);
 
         that.deleteState = function deleteState(parentDevice, parentChannel, stateName, options, callback) {
             if (typeof parentChannel === 'function' && stateName === undefined) {
@@ -2267,6 +2374,10 @@ function Adapter(options) {
                 that.delObject(_name, options, callback);
             });
         };
+        /**
+         * Promise-version of Adapter.deleteState
+         */
+        that.deleteStateAsync = tools.promisify(that.deleteState, that);
 
         that.getDevices = function getDevices(options, callback) {
             if (typeof options === 'function' && typeof callback === 'object') {
@@ -2293,6 +2404,10 @@ function Adapter(options) {
                 }
             });
         };
+        /**
+         * Promise-version of Adapter.getDevices
+         */
+        that.getDevicesAsync = tools.promisify(that.getDevices, that);
 
         that.getChannelsOf = function getChannelsOf(parentDevice, options, callback) {
             if (typeof options === 'function') {
@@ -2325,6 +2440,10 @@ function Adapter(options) {
                 }
             });
         };
+        /**
+         * Promise-version of Adapter.getChannelsOf
+         */
+        that.getChannelsOfAsync = tools.promisify(that.getChannelsOf, that);
 
         that.getChannels = that.getChannelsOf;
 
@@ -2386,6 +2505,10 @@ function Adapter(options) {
                 }
             });
         };
+        /**
+         * Promise-version of Adapter.getStatesOf
+         */
+        that.getStatesOfAsync = tools.promisify(that.getStatesOf, that);
 
         that.addStateToEnum = function addStateToEnum(enumName, addTo, parentDevice, parentChannel, stateName, options, callback) {
             if (typeof options === 'function') {
@@ -2474,6 +2597,10 @@ function Adapter(options) {
                 });
             }
         };
+        /**
+         * Promise-version of Adapter.addStateToEnum
+         */
+        that.addStateToEnumAsync = tools.promisify(that.addStateToEnum, that);
 
         that.deleteStateFromEnum = function deleteStateFromEnum(enumName, parentDevice, parentChannel, stateName, options, callback) {
             if (typeof options === 'function') {
@@ -2563,6 +2690,10 @@ function Adapter(options) {
                 }
             });
         };
+        /**
+         * Promise-version of Adapter.deleteStateFromEnum
+         */
+        that.deleteStateFromEnumAsync = tools.promisify(that.deleteStateFromEnum, that);
 
         that.chmodFile = function chmodFile(_adapter, path, options, callback) {
             if (_adapter === null) _adapter = that.name;
@@ -3330,6 +3461,10 @@ function Adapter(options) {
                 that.states.pushMessage(instanceName, obj);
             }
         };
+        /**
+         * Promise-version of Adapter.sendTo
+         */
+        that.sendToAsync = tools.promisifyNoError(that.sendTo, that);
 
         /**
          * Send message to specific host or to all hosts.
@@ -3399,6 +3534,10 @@ function Adapter(options) {
                 that.states.pushMessage(hostName, obj);
             }
         };
+        /**
+         * Promise-version of Adapter.sendToHost
+         */
+        that.sendToHostAsync = tools.promisifyNoError(that.sendToHost, that);
 
         /**
          * Writes value into states DB.
@@ -3470,6 +3609,10 @@ function Adapter(options) {
                 that.states.setState(id, state, callback);
             }
         };
+        /**
+         * Promise-version of Adapter.setState
+         */
+        that.setStateAsync = tools.promisify(that.setState, that);
 
         /**
          * Writes value into states DB only if the value really changed.
@@ -3528,6 +3671,10 @@ function Adapter(options) {
                 _setStateChangedHelper(id, state, callback);
             }
         };
+        /**
+         * Promise-version of Adapter.setStateChanged
+         */
+        that.setStateChangedAsync = tools.promisify(that.setStateChanged, that);
 
         /**
          * Writes value into states DB for any instance.
@@ -3599,6 +3746,10 @@ function Adapter(options) {
                 that.states.setState(id, state, callback);
             }
         };
+        /**
+         * Promise-version of Adapter.setForeignState
+         */
+        that.setForeignStateAsync = tools.promisify(that.setForeignState, that);
 
         /**
          * Writes value into states DB for any instance, but only if state changed.
@@ -3668,6 +3819,10 @@ function Adapter(options) {
                 _setStateChangedHelper(id, state, callback);
             }
         };
+        /**
+         * Promise-version of Adapter.setForeignStateChanged
+         */
+        that.setForeignStateChangedAsync = tools.promisify(that.setForeignStateChanged, that);
 
         /**
          * Read value from states DB.
@@ -3714,6 +3869,10 @@ function Adapter(options) {
                 }
             }
         };
+        /**
+         * Promise-version of Adapter.getState
+         */
+        that.getStateAsync = tools.promisify(that.getState, that);
 
         /**
          * Read value from states DB for any instance and system state.
@@ -3758,6 +3917,10 @@ function Adapter(options) {
                 }
             }
         };
+        /**
+         * Promise-version of Adapter.getForeignState
+         */
+        that.getForeignStateAsync = tools.promisify(that.getForeignState, that);
 
         /**
          * Read historian data for states of any instance or system state.
@@ -3882,6 +4045,10 @@ function Adapter(options) {
                 that.states.delState(id, callback);
             }
         };
+        /**
+         * Promise-version of Adapter.delState
+         */
+        that.delStateAsync = tools.promisify(that.delState, that);
 
         /**
          * Delete one state of any adapter.
@@ -3919,6 +4086,10 @@ function Adapter(options) {
             }
 
         };
+        /**
+         * Promise-version of Adapter.delForeignState
+         */
+        that.delForeignStateAsync = tools.promisify(that.delForeignState, that);
 
         /**
          * Read all states of this adapter, that pass the pattern
@@ -3946,6 +4117,10 @@ function Adapter(options) {
             pattern = that._fixId(pattern, 'state');
             that.getForeignStates(pattern, options, callback);
         };
+        /**
+         * Promise-version of Adapter.getStates
+         */
+        that.getStatesAsync = tools.promisify(that.getStates, that);
 
         /**
          * Read all states of all adapters (and system states), that pass the pattern
@@ -4087,6 +4262,10 @@ function Adapter(options) {
                 }
             });
         };
+        /**
+         * Promise-version of Adapter.getForeignStates
+         */
+        that.getForeignStatesAsync = tools.promisify(that.getForeignStates, that);
 
         /**
          * Subscribe for changes on all states of all adapters (and system states), that pass the pattern

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -1352,7 +1352,10 @@ function Adapter(options) {
                 if (typeof callback === 'function') callback(err, result, _enum);
             });
         };
-        // Non-NodeJS-style callback: cannot promisify getEnum
+        /**
+         * Promise-version of Adapter.getEnum
+         */
+        that.getEnumAsync = tools.promisify(that.getEnum, that, ["result", "requestEnum"]);
 
         /**
          * Read the members of given enums.
@@ -3674,7 +3677,7 @@ function Adapter(options) {
         /**
          * Promise-version of Adapter.setStateChanged
          */
-        that.setStateChangedAsync = tools.promisify(that.setStateChanged, that);
+        that.setStateChangedAsync = tools.promisify(that.setStateChanged, that, ["id", "notChanged"]);
 
         /**
          * Writes value into states DB for any instance.
@@ -3988,6 +3991,10 @@ function Adapter(options) {
                 });
             });
         };
+        /**
+         * Promise-version of Adapter.getHistory
+         */
+        that.getHistoryAsync = tools.promisify(that.getHistory, that, ["result", "step", "sessionId"]);
 
         /**
          * Convert ID into object with device's, channel's and state's name.
@@ -4316,6 +4323,10 @@ function Adapter(options) {
                 that.states.subscribe(pattern, callback);
             });
         };
+        /**
+         * Promise-version of Adapter.subscribeForeignStates
+         */
+        that.subscribeForeignStatesAsync = tools.promisify(that.subscribeForeignStates, that);
 
         /**
          * Unsubscribe for changes for given pattern
@@ -4378,6 +4389,10 @@ function Adapter(options) {
 
             that.states.unsubscribe(pattern, callback);
         };
+        /**
+         * Promise-version of Adapter.unsubscribeForeignStates
+         */
+        that.unsubscribeForeignStatesAsync = tools.promisify(that.unsubscribeForeignStates, that);
 
         /**
          * Subscribe for changes on all states of this instance, that pass the pattern
@@ -4408,6 +4423,10 @@ function Adapter(options) {
                 that.states.subscribe(pattern, callback);
             }
         };
+        /**
+         * Promise-version of Adapter.subscribeStates
+         */
+        that.subscribeStatesAsync = tools.promisify(that.subscribeStates, that);
 
         /**
          * Unsubscribe for changes for given pattern for own states.
@@ -4440,6 +4459,10 @@ function Adapter(options) {
                 that.states.unsubscribe(pattern, callback);
             }
         };
+        /**
+         * Promise-version of Adapter.unsubscribeStates
+         */
+        that.unsubscribeStatesAsync = tools.promisify(that.unsubscribeStates, that);
 
         that.pushFifo = function pushFifo(id, state, callback) {
             that.states.pushFifo(id, state, callback);

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -1588,7 +1588,10 @@ function Adapter(options) {
             }
             that.objects.findObject(id, type, options, callback);
         };
-        // non-NodeJS-style callback, cannot promisify findForeignObject
+        /**
+         * Promise-version of Adapter.findForeignObject
+         */
+        that.findForeignObjectAsync = tools.promisify(that.findForeignObject, that, ["id", "name"]);
 
         /**
          * Get any object.
@@ -2708,6 +2711,10 @@ function Adapter(options) {
 
             that.objects.chmodFile(_adapter, path, options, callback);
         };
+        /**
+         * Promise-version of Adapter.chmodFile
+         */
+        that.chmodFileAsync = tools.promisify(that.chmodFile, that, ["entries", "id"]);
 
         /**
          * Read directory from DB.
@@ -2756,6 +2763,10 @@ function Adapter(options) {
 
             that.objects.readDir(_adapter, path, options, callback);
         };
+        /**
+         * Promise-version of Adapter.readDir
+         */
+        that.readDirAsync = tools.promisify(that.readDir, that);
 
         that.unlink = function unlink(_adapter, name, options, callback) {
             if (_adapter === null) _adapter = that.name;
@@ -2767,8 +2778,13 @@ function Adapter(options) {
 
             that.objects.unlink(_adapter, name, options, callback);
         };
+        /**
+         * Promise-version of Adapter.unlink
+         */
+        that.unlinkAsync = tools.promisify(that.unlink, that);
 
         that.delFile = that.unlink;
+        that.delFileAsync = that.unlinkAsync;
 
         that.rename = function rename(_adapter, oldName, newName, options, callback) {
             if (_adapter === null) _adapter = that.name;
@@ -2778,6 +2794,10 @@ function Adapter(options) {
             }
             that.objects.rename(_adapter, oldName, newName, options, callback);
         };
+        /**
+         * Promise-version of Adapter.rename
+         */
+        that.renameAsync = tools.promisify(that.rename, that);
 
         that.mkdir = function mkdir(_adapter, dirname, options, callback) {
             if (_adapter === null) _adapter = that.name;
@@ -2788,6 +2808,10 @@ function Adapter(options) {
 
             that.objects.mkdir(_adapter, dirname, options, callback);
         };
+        /**
+         * Promise-version of Adapter.mkdir
+         */
+        that.mkdirAsync = tools.promisify(that.mkdir, that);
 
         /**
          * Read file from DB.
@@ -2823,6 +2847,10 @@ function Adapter(options) {
 
             that.objects.readFile(_adapter, filename, options, callback);
         };
+        /**
+         * Promise-version of Adapter.readFile
+         */
+        that.readFileAsync = tools.promisify(that.readFile, that, ["file", "mimeType"]);
 
         /**
          * Write file to DB.
@@ -2859,6 +2887,10 @@ function Adapter(options) {
 
             that.objects.writeFile(_adapter, filename, data, options, callback);
         };
+        /**
+         * Promise-version of Adapter.writeFile
+         */
+        that.writeFileAsync = tools.promisify(that.writeFile, that);
 
         that.formatValue = function (value, decimals, _format) {
             if (typeof decimals !== 'number') {
@@ -4526,6 +4558,10 @@ function Adapter(options) {
                 that.states.setBinaryState(id, binary, callback);
             }
         };
+        /**
+         * Promise-version of Adapter.setBinaryState
+         */
+        that.setBinaryStateAsync = tools.promisify(that.setBinaryState, that);
 
         // Read binary block from redis, e.g. image
         that.getBinaryState = function getBinaryState(id, options, callback) {
@@ -4545,6 +4581,11 @@ function Adapter(options) {
                 that.states.getBinaryState(id, callback);
             }
         };
+        /**
+         * Promise-version of Adapter.getBinaryState
+         */
+        that.getBinaryStateAsync = tools.promisify(that.getBinaryState, that);
+
     }
 
     // read all logs prepared for this adapter at start

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -906,6 +906,56 @@ function getConfigFileName() {
     }
 }
 
+/**
+ * Promisifies a function which returns an error as the first argument in its callback
+ * @param {Function} fn The function to promisify
+ * @param {any} context (optional) The context (value of `this` to bind the function to)
+ * @returns {(...args: any[]) => Promise<any>}
+ */
+function promisify(fn, context) {
+    return function () {
+        var args = [];
+        for (var _i = 0; _i < arguments.length; _i++) {
+            args[_i] = arguments[_i];
+        }
+        context = context || this;
+        return new Promise(function (resolve, reject) {
+            fn.apply(context, args.concat([
+                function (error, result) {
+                    if (error) {
+                        return reject(error);
+                    } else {
+                        return resolve(result);
+                    }
+                }
+            ]));
+        });
+    };
+}
+
+/**
+ * Promisifies a function which does not provide an error as the first argument in its callback
+ * @param {Function} fn The function to promisify
+ * @param {any} context (optional) The context (value of `this` to bind the function to)
+ * @returns {(...args: any[]) => Promise<any>}
+ */
+function promisifyNoError(fn, context) {
+    return function () {
+        var args = [];
+        for (var _i = 0; _i < arguments.length; _i++) {
+            args[_i] = arguments[_i];
+        }
+        context = context || this;
+        return new Promise(function (resolve, reject) {
+            fn.apply(context, args.concat([
+                function (result) {
+                    return resolve(result);
+                }
+            ]));
+        });
+    };
+}
+
 module.exports.findIPs =            findIPs;
 module.exports.rmdirRecursiveSync = rmdirRecursiveSync;
 module.exports.getRepositoryFile =  getRepositoryFile;
@@ -925,3 +975,5 @@ module.exports.getHostInfo =        getHostInfo;
 module.exports.upToDate =           upToDate;
 module.exports.encryptPhrase =      encryptPhrase;
 module.exports.decryptPhrase =      decryptPhrase;
+module.exports.promisify =          promisify;
+module.exports.promisifyNoError =   promisifyNoError;

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var fs   = require('fs');
 var path = require('path');
 require('events').EventEmitter.prototype._maxListeners = 100;

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -907,17 +907,31 @@ function getConfigFileName() {
 }
 
 /**
+ * Puts all values from an `arguments` object into an array, starting at the given index
+ * @param {{[index: number]: any}} argsObj An `arguments` object as passed to a function
+ * @param {number} startIndex The optional index to start taking the arguments from
+ */
+function sliceArgs(argsObj, startIndex) {
+    if (startIndex == null) startIndex = 0;
+    const ret = [];
+    for (let i = startIndex; i < argsObj.length; i++) {
+        ret.push(argsObj[i]);
+    }
+    return ret;
+}
+
+/**
  * Promisifies a function which returns an error as the first argument in its callback
  * @param {Function} fn The function to promisify
  * @param {any} context (optional) The context (value of `this` to bind the function to)
+ * @param {string[]} returnArgNames (optional) If the callback contains multiple arguments, 
+ * you can combine them into one object by passing the names as an array. 
+ * Otherwise the Promise will resolve with an array
  * @returns {(...args: any[]) => Promise<any>}
  */
-function promisify(fn, context) {
+function promisify(fn, context, returnArgNames) {
     return function () {
-        var args = [];
-        for (var _i = 0; _i < arguments.length; _i++) {
-            args[_i] = arguments[_i];
-        }
+        const args = sliceArgs(arguments);
         context = context || this;
         return new Promise(function (resolve, reject) {
             fn.apply(context, args.concat([
@@ -925,7 +939,28 @@ function promisify(fn, context) {
                     if (error) {
                         return reject(error);
                     } else {
-                        return resolve(result);
+                        // decide on how we want to return the callback arguments
+                        switch (arguments.length) {
+                            case 1: // only an error was given
+                                return resolve(); // Promise<void>
+                            case 2: // a single value (result) was returned
+                                return resolve(result);
+                            default: // multiple values should be returned
+                                /** @type {{} | any[]} */
+                                let ret;
+                                const extraArgs = sliceArgs(arguments, 1);
+                                if (returnArgNames && returnArgNames.length === extraArgs.length) {
+                                    // we can build an object
+                                    ret = {};
+                                    for (let i = 0; i < returnArgNames.length; i++) {
+                                        ret[returnArgNames[i]] = extraArgs[i];
+                                    }
+                                } else {
+                                    // we return the raw array
+                                    ret = extraArgs;
+                                }
+                                return resolve(ret);
+                        }
                     }
                 }
             ]));
@@ -937,19 +972,40 @@ function promisify(fn, context) {
  * Promisifies a function which does not provide an error as the first argument in its callback
  * @param {Function} fn The function to promisify
  * @param {any} context (optional) The context (value of `this` to bind the function to)
+ * @param {string[]} returnArgNames (optional) If the callback contains multiple arguments, 
+ * you can combine them into one object by passing the names as an array. 
+ * Otherwise the Promise will resolve with an array
  * @returns {(...args: any[]) => Promise<any>}
  */
-function promisifyNoError(fn, context) {
+function promisifyNoError(fn, context, returnArgNames) {
     return function () {
-        var args = [];
-        for (var _i = 0; _i < arguments.length; _i++) {
-            args[_i] = arguments[_i];
-        }
+        const args = sliceArgs(arguments);
         context = context || this;
         return new Promise(function (resolve, reject) {
             fn.apply(context, args.concat([
                 function (result) {
-                    return resolve(result);
+                    // decide on how we want to return the callback arguments
+                    switch (arguments.length) {
+                        case 0: // no arguments were given
+                            return resolve(); // Promise<void>
+                        case 1: // a single value (result) was returned
+                            return resolve(result);
+                        default: // multiple values should be returned
+                            /** @type {{} | any[]} */
+                            let ret;
+                            const extraArgs = sliceArgs(arguments, 0);
+                            if (returnArgNames && returnArgNames.length === extraArgs.length) {
+                                // we can build an object
+                                ret = {};
+                                for (let i = 0; i < returnArgNames.length; i++) {
+                                    ret[returnArgNames[i]] = extraArgs[i];
+                                }
+                            } else {
+                                // we return the raw array
+                                ret = extraArgs;
+                            }
+                            return resolve(ret);
+                    }
                 }
             ]));
         });

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -1014,24 +1014,37 @@ function promisifyNoError(fn, context, returnArgNames) {
     };
 }
 
-module.exports.findIPs =            findIPs;
-module.exports.rmdirRecursiveSync = rmdirRecursiveSync;
-module.exports.getRepositoryFile =  getRepositoryFile;
-module.exports.getIoPack =          getIoPack;
-module.exports.getFile =            getFile;
-module.exports.getJson =            getJson;
-module.exports.getInstalledInfo =   getInstalledInfo;
-module.exports.sendDiagInfo =       sendDiagInfo;
-module.exports.getAdapterDir =      getAdapterDir;
-module.exports.getDefaultDataDir =  getDefaultDataDir;
-module.exports.getConfigFileName =  getConfigFileName;
-module.exports.initNpm =            initNpm;
-module.exports.getHostName =        getHostName;
-module.exports.appName =            getAppName();
-module.exports.createUuid =         createUuid;
-module.exports.getHostInfo =        getHostInfo;
-module.exports.upToDate =           upToDate;
-module.exports.encryptPhrase =      encryptPhrase;
-module.exports.decryptPhrase =      decryptPhrase;
-module.exports.promisify =          promisify;
-module.exports.promisifyNoError =   promisifyNoError;
+/**
+ * Creates and executes an array of promises in sequence
+ * @param {((...args: any[]) => Promise<any>)[]} promiseFactories An array of promise-returning functions
+ */
+function promiseSequence(promiseFactories) {
+    return promiseFactories.reduce((promise, factory) => {
+        return promise.then(result => factory().then(Array.prototype.concat.bind(result)))
+    }, Promise.resolve([]));
+}
+
+module.exports = {
+    findIPs,
+    rmdirRecursiveSync,
+    getRepositoryFile,
+    getIoPack,
+    getFile,
+    getJson,
+    getInstalledInfo,
+    sendDiagInfo,
+    getAdapterDir,
+    getDefaultDataDir,
+    getConfigFileName,
+    initNpm,
+    getHostName,
+    appName: getAppName(),
+    createUuid,
+    getHostInfo,
+    upToDate,
+    encryptPhrase,
+    decryptPhrase,
+    promisify,
+    promisifyNoError,
+    promiseSequence
+};

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "yargs": "^6.0.0"
   },
   "devDependencies": {
+    "chai-as-promised": "^7.1.1",
     "grunt": "^1.0.1",
     "grunt-replace": "^1.0.1",
     "grunt-contrib-jshint": "^1.1.0",

--- a/test/lib/testAdapter.js
+++ b/test/lib/testAdapter.js
@@ -4,7 +4,15 @@
 /* jshint expr:true */
 'use strict';
 
-var expect = require('chai').expect;
+const chai = require('chai');
+const chaiAsPromised = require('chai-as-promised');
+const expect = chai.expect;
+
+before(() => {
+    chai.should();
+    chai.use(chaiAsPromised);
+})
+
 var setup  = require(__dirname + '/setup4controller');
 
 function testAdapter(options) {

--- a/test/lib/testAdapterHelpers.js
+++ b/test/lib/testAdapterHelpers.js
@@ -33,25 +33,27 @@ function register(it, expect, context) {
         });
     });
 
-    //adapterGetPort (async)
-    it(context.name + ' ' + context.adapterShortName + ' adapter: find next free port (ASYNC)', function () {
-        this.timeout(1000);
+    // NOT READY: Running this after the adapterGetPort (sync) test causes getPortRunning to already exist
+    
+    // //adapterGetPort (async)
+    // it(context.name + ' ' + context.adapterShortName + ' adapter: find next free port (ASYNC)', function () {
+    //     this.timeout(1000);
 
-        const tests = [
-            //Throw Error            
-            () => context.adapter.getPortAsync('').should.be.rejectedWith('adapterGetPort: no port'),
-            () => expect(context.adapter.getPortRunning).to.not.exist,
+    //     const tests = [
+    //         //Throw Error            
+    //         () => context.adapter.getPortAsync('').should.be.rejectedWith('adapterGetPort: no port'),
+    //         () => expect(context.adapter.getPortRunning).to.not.exist,
             
-            //Works like it should be
-            () => context.adapter.getPortAsync(8080).to.be.fulfilled.then(port => {
-                expect(port).to.be.at.least(8080);
-                expect(context.adapter.getPortRunning).to.have.all.keys(['port', 'callback']);
-                expect(context.adapter.getPortRunning).to.have.property('port', port);
-            })
-        ];
+    //         //Works like it should be
+    //         () => context.adapter.getPortAsync(8080).to.be.fulfilled.then(port => {
+    //             expect(port).to.be.at.least(8080);
+    //             expect(context.adapter.getPortRunning).to.have.all.keys(['port', 'callback']);
+    //             expect(context.adapter.getPortRunning).to.have.property('port', port);
+    //         })
+    //     ];
 
-        return promiseSequence(tests);
-    });
+    //     return promiseSequence(tests);
+    // });
     
     //checkPassword
     it(context.name + ' ' + context.adapterShortName + ' adapter: validates user and password', function (done) {

--- a/test/lib/testAdapterHelpers.js
+++ b/test/lib/testAdapterHelpers.js
@@ -43,9 +43,11 @@ function register(it, expect, context) {
             () => expect(context.adapter.getPortRunning).to.not.exist,
             
             //Works like it should be
-            () => context.adapter.getPortAsync(8080).should.eventually.be.at.least(8080),
-            () => expect(context.adapter.getPortRunning).to.have.all.keys(['port', 'callback']),
-            () => expect(context.adapter.getPortRunning).to.have.property('port', port),
+            () => context.adapter.getPortAsync(8080).to.be.fulfilled.then(port => {
+                expect(port).to.be.at.least(8080);
+                expect(context.adapter.getPortRunning).to.have.all.keys(['port', 'callback']);
+                expect(context.adapter.getPortRunning).to.have.property('port', port);
+            })
         ];
 
         return promiseSequence(tests);

--- a/test/lib/testAdapterHelpers.js
+++ b/test/lib/testAdapterHelpers.js
@@ -4,6 +4,14 @@
 /* jshint expr:true */
 'use strict';
 
+const promiseSequence = require('../../lib/tools').promiseSequence;
+
+/**
+ * @typedef {{adapter: {[fnName: string]: (...args: any[]) => any}}} Context
+ */
+/**
+ * @param {Context} context 
+ */
 function register(it, expect, context) {
 
     //adapterGetPort
@@ -20,11 +28,29 @@ function register(it, expect, context) {
             expect(port).to.be.at.least(8080);
             expect(context.adapter.getPortRunning).to.have.all.keys(['port', 'callback']);
             expect(context.adapter.getPortRunning).to.have.property('port', port);
-        });
 
-        done();
+            done();
+        });
     });
 
+    //adapterGetPort (async)
+    it(context.name + ' ' + context.adapterShortName + ' adapter: find next free port (ASYNC)', function () {
+        this.timeout(1000);
+
+        const tests = [
+            //Throw Error            
+            () => context.adapter.getPortAsync('').should.be.rejectedWith('adapterGetPort: no port'),
+            () => expect(context.adapter.getPortRunning).to.not.exist,
+            
+            //Works like it should be
+            () => context.adapter.getPortAsync(8080).should.eventually.be.at.least(8080),
+            () => expect(context.adapter.getPortRunning).to.have.all.keys(['port', 'callback']),
+            () => expect(context.adapter.getPortRunning).to.have.property('port', port),
+        ];
+
+        return promiseSequence(tests);
+    });
+    
     //checkPassword
     it(context.name + ' ' + context.adapterShortName + ' adapter: validates user and password', function (done) {
         this.timeout(1000);
@@ -45,31 +71,52 @@ function register(it, expect, context) {
         done();
     });
 
+    //checkPassword (async)
+    it(context.name + ' ' + context.adapterShortName + ' adapter: validates user and password (ASYNC)', function () {
+        this.timeout(1000);
+
+        const tests = [
+            // promisify always provides a callback, so that doesn't need to be tested
+
+            // User doesn't exist
+            () => context.adapter.checkPasswordAsync('claus', '1234').should.eventually.equal(false),
+            
+            // Wrong password
+            () => context.adapter.checkPasswordAsync('admin', '1234').should.eventually.equal(false),
+        ]; 
+
+        return promiseSequence(tests);
+    });
+
     //setPassword
     it(context.name + ' ' + context.adapterShortName + ' adapter: sets the users password', function (done) {
         this.timeout(1000);
-
+        // TODO: sync
+        // TODO: async
         done();
     });
 
     //checkGroup
     it(context.name + ' ' + context.adapterShortName + ' adapter: user exists and is in the group', function (done) {
         this.timeout(1000);
-
+        // TODO: sync
+        // TODO: async
         done();
     });
 
     //calculatePermissions
     it(context.name + ' ' + context.adapterShortName + ' adapter: get the user permissions', function (done) {
         this.timeout(1000);
-
+        // TODO: sync
+        // TODO: async
         done();
     });
 
     //getCertificates
     it(context.name + ' ' + context.adapterShortName + ' adapter: eturns SSL certificates by name', function (done) {
         this.timeout(1000);
-
+        // TODO: sync
+        // TODO: async
         done();
     });
 

--- a/test/lib/testObjectsFunctions.js
+++ b/test/lib/testObjectsFunctions.js
@@ -4,6 +4,14 @@
 /* jshint expr:true */
 'use strict';
 
+const promiseSequence = require('../../lib/tools').promiseSequence;
+
+/**
+ * @typedef {{adapter: {[fnName: string]: (...args: any[]) => any}}} Context
+ */
+/**
+ * @param {Context} context 
+ */
 function register(it, expect, context) {
     var testName = context.name + ' ' + context.adapterShortName + ' adapter: ';
     var gid = 'myTestObject';
@@ -38,6 +46,40 @@ function register(it, expect, context) {
         });
     });
 
+    // setObject positive (async)
+    it(testName + 'Check if objects will be created (ASYNC)', function () {
+        this.timeout(1000);
+
+        const tests = [
+            // Creating an object works
+            () => context.adapter.setObjectAsync(gid, {
+                common: {
+                    name: 'test2',
+                    type: 'number',
+                    role: 'level'
+                },
+                native: {
+                    attr1: '1',
+                    attr2: '2',
+                    attr3: '3'
+                },
+                type: 'state'
+            }).should.be.fulfilled,
+
+            // getting it returns the correct values
+            () => context.objects.getObjectAsync(context.adapterShortName + '.0.' + gid).should.be.fulfilled.then(obj => {
+                expect(obj).to.be.ok;
+                expect(obj.native).to.be.ok;
+                expect(obj._id).equal(context.adapterShortName + '.0.' + gid);
+                expect(obj.common.name).equal('test1');
+                expect(obj.type).equal('state');
+            })
+        ]; 
+
+        return promiseSequence(tests);
+        
+    });
+    
     // setObject negative
     it(testName + 'Check if objects will not be created without mandatory attribute type', function (done) {
         this.timeout(1000);

--- a/test/lib/testObjectsFunctions.js
+++ b/test/lib/testObjectsFunctions.js
@@ -46,39 +46,41 @@ function register(it, expect, context) {
         });
     });
 
-    // setObject positive (async)
-    it(testName + 'Check if objects will be created (ASYNC)', function () {
-        this.timeout(1000);
+    // NOT READY: need async functions on Objects
+    
+    // // setObject positive (async)
+    // it(testName + 'Check if objects will be created (ASYNC)', function () {
+    //     this.timeout(1000);
 
-        const tests = [
-            // Creating an object works
-            () => context.adapter.setObjectAsync(gid, {
-                common: {
-                    name: 'test1',
-                    type: 'number',
-                    role: 'level'
-                },
-                native: {
-                    attr1: '1',
-                    attr2: '2',
-                    attr3: '3'
-                },
-                type: 'state'
-            }).should.be.fulfilled,
+    //     const tests = [
+    //         // Creating an object works
+    //         () => context.adapter.setObjectAsync(gid, {
+    //             common: {
+    //                 name: 'test1',
+    //                 type: 'number',
+    //                 role: 'level'
+    //             },
+    //             native: {
+    //                 attr1: '1',
+    //                 attr2: '2',
+    //                 attr3: '3'
+    //             },
+    //             type: 'state'
+    //         }).should.be.fulfilled,
 
-            // getting it returns the correct values
-            () => context.objects.getObjectAsync(context.adapterShortName + '.0.' + gid).should.be.fulfilled.then(obj => {
-                expect(obj).to.be.ok;
-                expect(obj.native).to.be.ok;
-                expect(obj._id).equal(context.adapterShortName + '.0.' + gid);
-                expect(obj.common.name).equal('test1');
-                expect(obj.type).equal('state');
-            })
-        ]; 
+    //         // getting it returns the correct values
+    //         () => context.objects.getObjectAsync(context.adapterShortName + '.0.' + gid).should.be.fulfilled.then(obj => {
+    //             expect(obj).to.be.ok;
+    //             expect(obj.native).to.be.ok;
+    //             expect(obj._id).equal(context.adapterShortName + '.0.' + gid);
+    //             expect(obj.common.name).equal('test1');
+    //             expect(obj.type).equal('state');
+    //         })
+    //     ]; 
 
-        return promiseSequence(tests);
+    //     return promiseSequence(tests);
         
-    });
+    // });
     
     // setObject negative
     it(testName + 'Check if objects will not be created without mandatory attribute type', function (done) {

--- a/test/lib/testObjectsFunctions.js
+++ b/test/lib/testObjectsFunctions.js
@@ -54,7 +54,7 @@ function register(it, expect, context) {
             // Creating an object works
             () => context.adapter.setObjectAsync(gid, {
                 common: {
-                    name: 'test2',
+                    name: 'test1',
                     type: 'number',
                     role: 'level'
                 },


### PR DESCRIPTION
As we only support NodeJS 4+ with native promise support, we can now natively provide promisified versions of the `Adapter` class methods. These have the name of the original function with `Async` appended to it. Adapter developers can now opt to use promises instead of classic callbacks - or even `async`/`await` when using TypeScript, e.g.:
```js
adapter.getStateAsync("foo").then(result => {
    // do something with the result
}).catch(e => {
    // something went wrong
});

// or even this:
let fooValue;
try {
    fooValue = await adapter.getStateAsync("foo");
    // do something with the result
} catch (e) { 
    // something went wrong
}
```

I exposed a bunch of adapter methods (including the most important `setState`, `getState`, etc...). Other ones (especially the ones linked to objects.js) are still missing.

**Before I invest more time, what are your thoughts on this?**

Also, according to http://node.green/#ES2015-functions-class we should be able to rewrite the Adapter class using the `class` keyword, since this is supported in NodeJS 4 aswell. It would greatly improve the auto-completion and hints when using VSCode for example. I can give it a shot aswell if you're okay with that.