### PR TITLE
Enabled type-checking in VSCode and fix found issues

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -32,7 +32,7 @@ var that;
 var defaultObjs;
 
 if (fs.existsSync(getConfigFileName())) {
-    config = JSON.parse(fs.readFileSync(getConfigFileName()));
+    config = JSON.parse(fs.readFileSync(getConfigFileName(), 'utf8'));
     if (!config.states)  config.states  = {type: 'file'};
     if (!config.objects) config.objects = {type: 'file'};
 } else {
@@ -149,14 +149,14 @@ function Adapter(options) {
     }
 
     if (fs.existsSync(this.adapterDir + '/package.json')) {
-        this.pack = JSON.parse(fs.readFileSync(this.adapterDir + '/package.json'));
+        this.pack = JSON.parse(fs.readFileSync(this.adapterDir + '/package.json', 'utf8'));
     } else {
         logger.info('Non npm module. No package.json');
     }
 
     if (!this.pack || !this.pack.io) {
         if (fs.existsSync(this.adapterDir + '/io-package.json')) {
-            this.ioPack = JSON.parse(fs.readFileSync(this.adapterDir + '/io-package.json'));
+            this.ioPack = JSON.parse(fs.readFileSync(this.adapterDir + '/io-package.json', 'utf8'));
         } else {
             logger.error('Cannot find: ' + this.adapterDir + '/io-package.json');
             process.exit(10);
@@ -399,6 +399,8 @@ function Adapter(options) {
         });
     };
 
+    /** @typedef {{[permission: string]: {type: 'object' | 'state' | '' | 'other' | 'file', operation: string}}} CommandsPermissions */
+
     /**
      * get the user permissions
      *
@@ -408,7 +410,7 @@ function Adapter(options) {
      * @alias calculatePermissions
      * @memberof Adapter
      * @param {string} user user name as text
-     * @param {string} commandsPermissions object that describes the access rights like
+     * @param {CommandsPermissions} commandsPermissions object that describes the access rights like
      *     <pre><code>
      *         // static information
      *         var commandsPermissions = {
@@ -1425,7 +1427,7 @@ function Adapter(options) {
          * @memberof Adapter
          * @param {string} pattern object ID/wildchars
          * @param {string} type type of object: 'state', 'channel' or 'device'. Default - 'state'
-         * @param {string} enums object ID, that must be overwritten or created.
+         * @param {string|string[]} enums object ID, that must be overwritten or created.
          * @param {object} options optional user context
          * @param {function} callback return result
          *        <pre><code>
@@ -2776,6 +2778,7 @@ function Adapter(options) {
             var result = '';
 
             function put(s) {
+                /** @type {number | string} */
                 var v = '';
                 switch (s) {
                     case 'YYYY':
@@ -2784,7 +2787,7 @@ function Adapter(options) {
                     case 'YY':
                     case 'JJ':
                     case 'ГГ':
-                        v = dateObj.getFullYear();
+                        v = /** @type {Date} */(dateObj).getFullYear();
                         if (s.length === 2) v %= 100;
                         if (v <= 9) v = '0' + v;
                         break;

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -205,6 +205,7 @@ function timestamp() {
     var ts = new Date();
     var result = ts.getFullYear() + '-';
 
+    /** @type {number | string} */
     var value = ts.getMonth() + 1;
     if (value < 10) value = '0' + value;
     result += value + '-';

--- a/lib/objects.js
+++ b/lib/objects.js
@@ -1,5 +1,5 @@
 var getConfigFileName = require(__dirname + '/tools').getConfigFileName;
-var config = JSON.parse(require('fs').readFileSync(getConfigFileName()));
+var config = JSON.parse(require('fs').readFileSync(getConfigFileName(), 'utf8'));
 if (!config.objects) config.objects = {type: 'file'};
 
 if (config.objects.type === 'file') {

--- a/lib/objects/objectsInMemServer.js
+++ b/lib/objects/objectsInMemServer.js
@@ -291,7 +291,7 @@ function ObjectsInMemServer(settings) {
         if (!fileOptions[id]) {
             if (fs.existsSync(objectsDir + id + '/_data.json')) {
                 try {
-                    fileOptions[id] = JSON.parse(fs.readFileSync(objectsDir + id + '/_data.json'));
+                    fileOptions[id] = JSON.parse(fs.readFileSync(objectsDir + id + '/_data.json', 'utf8'));
                 } catch (e) {
                     log.error(namespace + ' Cannot parse ' + objectsDir + id + '/_data.json: ' + e);
                 }
@@ -647,7 +647,7 @@ function ObjectsInMemServer(settings) {
             if (!fileOptions[id]) {
                 if (fs.existsSync(objectsDir + id + '/_data.json')) {
                     try {
-                        fileOptions[id] = JSON.parse(fs.readFileSync(objectsDir + id + '/_data.json'));
+                        fileOptions[id] = JSON.parse(fs.readFileSync(objectsDir + id + '/_data.json', 'utf8'));
                     } catch (e) {
                         log.error(namespace + ' Cannot parse ' + objectsDir + id + '/_data.json: ' + e);
                     }
@@ -714,7 +714,8 @@ function ObjectsInMemServer(settings) {
                 // Create directories if complex structure
                 mkpathSync(objectsDir + id + '/', name);
                 // Store file
-                fs.writeFileSync(objectsDir + id + '/' + name, data, {'flags': 'w', 'encoding': isBinary ? 'binary' : 'utf8'});
+                // I 
+                fs.writeFileSync(objectsDir + id + '/' + name, data, {'flag': 'w', 'encoding': isBinary ? 'binary' : 'utf8'});
                 // Store dir description
                 saveFileSettings(id);
             } catch (e) {
@@ -863,7 +864,7 @@ function ObjectsInMemServer(settings) {
             var changed = false;
             if (!fileOptions[id]) {
                 if (fs.existsSync(objectsDir + id + '/_data.json')) {
-                    fileOptions[id] = JSON.parse(fs.readFileSync(objectsDir + id + '/_data.json'));
+                    fileOptions[id] = JSON.parse(fs.readFileSync(objectsDir + id + '/_data.json', 'utf8'));
                 } else {
                     fileOptions[id] = {};
                 }
@@ -985,6 +986,7 @@ function ObjectsInMemServer(settings) {
         var len = (name) ? name.length : 0;
         for (var f in fileOptions[id]) {
             if (fileOptions[id].hasOwnProperty(f) && (!name || f.substring(0, len) === name)) {
+                /** @type {string|string[]} */
                 var rest = f.substring(len);
                 rest = rest.split('/', 2);
                 if (rest[0] && _files.indexOf(rest[0]) === -1) {
@@ -1125,7 +1127,7 @@ function ObjectsInMemServer(settings) {
         try {
             if (!fileOptions[id]) {
                 if (fs.existsSync(objectsDir + id + '/_data.json')) {
-                    fileOptions[id] = JSON.parse(fs.readFileSync(objectsDir + id + '/_data.json'));
+                    fileOptions[id] = JSON.parse(fs.readFileSync(objectsDir + id + '/_data.json', 'utf8'));
                 } else {
                     fileOptions[id] = {};
                 }
@@ -1170,7 +1172,7 @@ function ObjectsInMemServer(settings) {
         try {
             if (!fileOptions[id]) {
                 if (fs.existsSync(objectsDir + id + '/_data.json')) {
-                    fileOptions[id] = JSON.parse(fs.readFileSync(objectsDir + id + '/_data.json'));
+                    fileOptions[id] = JSON.parse(fs.readFileSync(objectsDir + id + '/_data.json', 'utf8'));
                 } else {
                     fileOptions[id] = {};
                 }
@@ -1265,7 +1267,7 @@ function ObjectsInMemServer(settings) {
         try {
             if (!fileOptions[id]) {
                 if (fs.existsSync(objectsDir + id + '/_data.json')) {
-                    fileOptions[id] = JSON.parse(fs.readFileSync(objectsDir + id + '/_data.json'));
+                    fileOptions[id] = JSON.parse(fs.readFileSync(objectsDir + id + '/_data.json', 'utf8'));
                 } else {
                     fileOptions[id] = {};
                 }
@@ -1355,7 +1357,7 @@ function ObjectsInMemServer(settings) {
         try {
             if (!fileOptions[id]) {
                 if (fs.existsSync(objectsDir + id + '/_data.json')) {
-                    fileOptions[id] = JSON.parse(fs.readFileSync(objectsDir + id + '/_data.json'));
+                    fileOptions[id] = JSON.parse(fs.readFileSync(objectsDir + id + '/_data.json', 'utf8'));
                 } else {
                     fileOptions[id] = {};
                 }
@@ -2753,7 +2755,7 @@ function ObjectsInMemServer(settings) {
     function initSocket(socket) {
         if (settings.auth) {
             var user = null;
-            socketEvents(socket, user);
+            socketEvents(socket /*, user*/);
         } else {
             socketEvents(socket);
         }
@@ -2872,6 +2874,7 @@ function ObjectsInMemServer(settings) {
 
         // Check if directory exists
         objectsName = objectsName.replace(/\\/g, '/');
+        /** @type {string|string[]} */
         var parts = objectsName.split('/');
         parts.pop();
         parts = parts.join('/');

--- a/lib/objects/objectsInMemServer.js
+++ b/lib/objects/objectsInMemServer.js
@@ -714,7 +714,6 @@ function ObjectsInMemServer(settings) {
                 // Create directories if complex structure
                 mkpathSync(objectsDir + id + '/', name);
                 // Store file
-                // I 
                 fs.writeFileSync(objectsDir + id + '/' + name, data, {'flag': 'w', 'encoding': isBinary ? 'binary' : 'utf8'});
                 // Store dir description
                 saveFileSettings(id);

--- a/lib/objects/objectsInRedis.js
+++ b/lib/objects/objectsInRedis.js
@@ -6,6 +6,7 @@
 var extend      = require('node.extend');
 var StatesRedis = require(__dirname + '/../states/statesInRedis.js');
 
+var fs       = require('fs');
 var stream   = require('stream');
 var util     = require('util');
 var Writable = stream.Writable;
@@ -170,9 +171,10 @@ function ObjectsInMem(settings) {
 
         // read rights of file
         if (!fileOptions[id]) {
+            // ERROR: objectsDir not found!
             if (fs.existsSync(objectsDir + id + '/_data.json')) {
                 try {
-                    fileOptions[id] = JSON.parse(fs.readFileSync(objectsDir + id + '/_data.json'));
+                    fileOptions[id] = JSON.parse(fs.readFileSync(objectsDir + id + '/_data.json', 'utf8'));
                 } catch (e) {
                     log.error('Cannot parse ' + objectsDir + id + '/_data.json: ' + e);
                 }
@@ -535,6 +537,7 @@ function ObjectsInMem(settings) {
             if (_obj) {
                 _obj._attachments = _obj._attachments || {};
                 if (!_obj._attachments[name]) {
+                    // ERROR: mimeType not found
                     _obj._attachments[name] = mimeType;
                 }
                 states.setConfig(id, _obj, function () {
@@ -1458,6 +1461,7 @@ function ObjectsInMem(settings) {
                 }
                 if (obj && obj.views && obj.views[search]) {
                     objects[obj._id] = obj;
+                    // ERROR: result not found
                     that._applyView(result, obj.views[search], params, options, callback);
                 } else {
                     console.log('Cannot find view "' + design + '"');

--- a/lib/restart.js
+++ b/lib/restart.js
@@ -161,7 +161,7 @@ if (require('os').platform().match(/^win/) && fs.existsSync(__dirname + '/../_se
                     });
                 });
             } catch (e) {
-                log('Error by pids.txt', e);
+                log('Error by pids.txt: ' + e);
                 log('Starting daemon ' + tools.appName + '...');
                 daemon.start(function (err, pid) {
                     log('Daemon ' + tools.appName + ' started');

--- a/lib/scripts/scripts.js
+++ b/lib/scripts/scripts.js
@@ -42,6 +42,7 @@ function updateVersion(name, callback, _sources) {
     child.stderr.pipe(process.stdout);
     child.on('exit', function (code /* , signal */) {
         if (code) {
+            // ERROR: hostname is not defined!
             console.error('host.' + hostname + ' Cannot get version of  ' +  tools.appName + '.' + name + ': ' + code);
             callback(code, _sources, name, null);
         } else {

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -439,7 +439,7 @@ function processCommand(command, args, params, callback) {
                     // read actual configuration
                     try {
                         if (fs.existsSync(tools.getConfigFileName())) {
-                            config = JSON.parse(fs.readFileSync(tools.getConfigFileName()));
+                            config = JSON.parse(fs.readFileSync(tools.getConfigFileName(), 'utf8'));
                         } else {
                             config = require(__dirname + '/../conf/' + tools.appName + '-dist.json');
                         }
@@ -2269,12 +2269,13 @@ function processCommand(command, args, params, callback) {
                 var oldHostname;
                 var newHostname;
                 if (!change) {
+                    // ERROR: hostname not found
                     console.warn('Please write "' + tools.appName + ' host this" to use this host ("' + hostname + '") in ' + tools.appName + ' for all instances.');
                     callback(1);
                 }
 
                 var config  = tools.getConfigFileName();
-                var data    = JSON.parse(fs.readFileSync(config));
+                var data    = JSON.parse(fs.readFileSync(config, 'utf8'));
 
                 if (change === 'set') {
                     oldHostname = tools.getHostName();

--- a/lib/setup/setupBackup.js
+++ b/lib/setup/setupBackup.js
@@ -155,7 +155,7 @@ function BackupRestore(options) {
                 result.objects = res.rows;
             }
 
-            if (fs.existsSync(tools.getConfigFileName())) result.config = JSON.parse(fs.readFileSync(tools.getConfigFileName()));
+            if (fs.existsSync(tools.getConfigFileName())) result.config = JSON.parse(fs.readFileSync(tools.getConfigFileName(), 'utf8'));
 
             states.getKeys('io.*', function (err, keys) {
                 /*for (var i = keys.length - 1; i >= 0; i--) {
@@ -385,7 +385,7 @@ function BackupRestore(options) {
                         }
                         var adapterDir = tools.getAdapterDir(dirs[index]);
                         if (fs.existsSync(adapterDir + '/io-package.json')) {
-                            pkg = JSON.parse(fs.readFileSync(adapterDir + '/io-package.json'));
+                            pkg = JSON.parse(fs.readFileSync(adapterDir + '/io-package.json', 'utf8'));
                         }
 
                         if (pkg && pkg.objects && pkg.objects.length) {
@@ -483,7 +483,7 @@ function BackupRestore(options) {
                         //  reload objects of adapters
                         reloadAdaptersObjects(function () {
                             // Reload host objects
-                            var pckgio = JSON.parse(fs.readFileSync(__dirname + '/../../io-package.json'));
+                            var pckgio = JSON.parse(fs.readFileSync(__dirname + '/../../io-package.json', 'utf8'));
                             reloadAdapterObject(0, pckgio ? pckgio.objects : null, function () {
                                 if (restartOnFinish) {
                                     restartController(callback);

--- a/lib/setup/setupInstall.js
+++ b/lib/setup/setupInstall.js
@@ -130,7 +130,7 @@ function Install(options) {
         // try to extract the information from local sources-dist.json
         if (!sources[packetName]) {
             try {
-                var sourcesDist = JSON.parse(fs.readFileSync(__dirname + '/../../conf/sources-dist.json'));
+                var sourcesDist = JSON.parse(fs.readFileSync(__dirname + '/../../conf/sources-dist.json', 'utf8'));
                 sources[packetName] = sourcesDist[packetName];
             } catch (e) {
 
@@ -201,7 +201,7 @@ function Install(options) {
                     if (fs.existsSync(source + '/io-package.json')) {
                         var packetIo;
                         try {
-                            packetIo = JSON.parse(fs.readFileSync(source + '/io-package.json'));
+                            packetIo = JSON.parse(fs.readFileSync(source + '/io-package.json', 'utf8'));
                         } catch (e) {
                             console.error('host.' + hostname + ' io-package.json has invalid format! Installation terminated.');
                             if (typeof callback === 'function') callback(name, 'Invalid io-package.json!');
@@ -251,10 +251,10 @@ function Install(options) {
                     if (typeof callback === 'function') callback(name, 'Packet is empty');
                     processExit(12);
                 }
-            }, function (error) {
+            }/*, function (error) {
                 console.error(error);
                 processExit(12);
-            });
+            }*/);
         });
     };
 
@@ -312,6 +312,7 @@ function Install(options) {
         }
 
         // Install node modules
+        /** @type {string|string[]} */
         var cwd = __dirname.replace(/\\/g, '/');
         if (fs.existsSync(__dirname + '/../../../../node_modules/' + tools.appName + '.js-controller')) {
             // js-controller installed as npm
@@ -420,7 +421,7 @@ function Install(options) {
                             // Check only version
                             if (version !== null) {
                                 if (!semver) semver = require('semver');
-                                var iopkg_ = JSON.parse(fs.readFileSync(__dirname + '/../../package.json'));
+                                var iopkg_ = JSON.parse(fs.readFileSync(__dirname + '/../../package.json', 'utf8'));
                                 if (!semver.satisfies(iopkg_.version, version)) {
                                     console.error('host.' + hostname + ' Invalid version of "' + dName + '". Installed "' + iopkg_.version + '", required "' + version);
                                     processExit(30);

--- a/lib/setup/setupMultihost.js
+++ b/lib/setup/setupMultihost.js
@@ -17,7 +17,7 @@ function Multihost(options) {
         // read actual configuration
         try {
             if (fs.existsSync(configName)) {
-                config = JSON.parse(fs.readFileSync(configName));
+                config = JSON.parse(fs.readFileSync(configName, 'utf8'));
             } else {
                 config = require(__dirname + '/../../conf/' + tools.appName + '-dist.json');
             }

--- a/lib/setup/setupRepo.js
+++ b/lib/setup/setupRepo.js
@@ -72,7 +72,7 @@ function Repo(options) {
             downloads.push(name);
         }
 
-        download(sources);
+        download(/*sources*/);
     }
 
     this.showRepo = function (repoUrl, flags, callback) {
@@ -99,7 +99,7 @@ function Repo(options) {
                 text += '"' + name + '"' + ((name.length < 15) ? new Array(15 - name.length).join(' ') : '');
 
                 var tLen = 10;
-                if (name.length >= 15) tLen -= (name.length > tLen);
+                if (name.length >= 15) tLen -= (name.length > tLen ? 1 : 0);
                 if (tLen < 0) tLen = 0;
 
                 if (sources[name].version) {

--- a/lib/setup/setupSetup.js
+++ b/lib/setup/setupSetup.js
@@ -78,7 +78,7 @@ function Setup(options) {
     function setupObjects(callback) {
         dbConnect(params, function (_objects, _states) {
             objects = _objects;
-            var iopkg = JSON.parse(fs.readFileSync(__dirname + '/../../io-package.json'));
+            var iopkg = JSON.parse(fs.readFileSync(__dirname + '/../../io-package.json', 'utf8'));
             dbSetup(iopkg, callback);
         });
     }

--- a/lib/setup/setupUpgrade.js
+++ b/lib/setup/setupUpgrade.js
@@ -63,7 +63,7 @@ function Upgrade(options) {
             if (!semver) semver = require('semver');
             if (adapter === 'js-controller') {
                 try {
-                    iopack = JSON.parse(fs.readFileSync(__dirname + '/../../io-package.json'));
+                    iopack = JSON.parse(fs.readFileSync(__dirname + '/../../io-package.json', 'utf8'));
                 } catch (e) {
                     return 'Cannot find io-package.json in "' + __dirname + '/../../": ' + e;
                 }
@@ -71,7 +71,7 @@ function Upgrade(options) {
                 if (!semver.satisfies(iopack.common.version, adapters[adapter])) return 'Invalid version of js-controler. Required ' + adapters[adapter];
             } else {
                 try {
-                    iopack = JSON.parse(fs.readFileSync(adapterDir + '/io-package.json'));
+                    iopack = JSON.parse(fs.readFileSync(adapterDir + '/io-package.json', 'utf8'));
                 } catch (e) {
                     return 'Cannot find io-package.json in "' + adapterDir + '": ' + e;
                 }
@@ -99,7 +99,7 @@ function Upgrade(options) {
             if (!iopack) {
                 var adapterDir = tools.getAdapterDir(name);
                 try {
-                    iopack = JSON.parse(fs.readFileSync(adapterDir + '/io-package.json'));
+                    iopack = JSON.parse(fs.readFileSync(adapterDir + '/io-package.json', 'utf8'));
                 } catch (e) {
                     console.error('Cannot find io-package.json in ' + adapterDir);
                     processExit(10);
@@ -251,7 +251,7 @@ function Upgrade(options) {
         }
 
         var hostname = tools.getHostName();
-        var installed = JSON.parse(fs.readFileSync(__dirname + '/../../io-package.json'));
+        var installed = JSON.parse(fs.readFileSync(__dirname + '/../../io-package.json', 'utf8'));
         if (!installed || !installed.common || !installed.common.version) {
             console.error('Host "' + hostname + '"' + ((hostname.length < 15) ? new Array(15 - hostname.length).join(' '): '') + ' is not installed.');
             if (callback) callback();

--- a/lib/setup/setupUpload.js
+++ b/lib/setup/setupUpload.js
@@ -444,7 +444,7 @@ function Upload(options) {
         if (!iopack) {
             var adapterDir = tools.getAdapterDir(name);
             try {
-                iopack = JSON.parse(fs.readFileSync(adapterDir + '/io-package.json'));
+                iopack = JSON.parse(fs.readFileSync(adapterDir + '/io-package.json', 'utf8'));
             } catch (e) {
                 console.error('Cannot find io-package.json in ' + adapterDir);
                 iopack = null;

--- a/lib/setup/setupVisDebug.js
+++ b/lib/setup/setupVisDebug.js
@@ -91,13 +91,13 @@ function VisDebug(options) {
         objects.writeFile('vis', 'edit.html', file);
 
         console.log('Modify "' + path.normalize(visDir + '/www/cache.manifest') + '"');
-        file = fs.readFileSync(visDir + '/www/cache.manifest').toString();
+        file = fs.readFileSync(visDir + '/www/cache.manifest', 'utf8');
         var n = file.match(/# dev build (\d+)/, '5');
         n = n[1];
         file = file.replace('# dev build '+ n, '# dev build ' + (parseInt(n, 10) + 1));
         objects.writeFile('vis', 'cache.manifest', file);
 
-        file = fs.readFileSync(tools.getConfigFileName());
+        file = fs.readFileSync(tools.getConfigFileName(), 'utf8');
         file = JSON.parse(file);
 
         var count = 0;

--- a/lib/states.js
+++ b/lib/states.js
@@ -1,5 +1,5 @@
 var getConfigFileName = require(__dirname + '/tools').getConfigFileName;
-var config = JSON.parse(require('fs').readFileSync(getConfigFileName()));
+var config = JSON.parse(require('fs').readFileSync(getConfigFileName(), 'utf8'));
 if (!config.states) config.states = {type: 'file'};
 
 if (config.states.type === 'file') {

--- a/lib/states/statesInMemServer.js
+++ b/lib/states/statesInMemServer.js
@@ -196,6 +196,7 @@ function StatesInMemory(settings) {
 
         // Check if directory exists
         objectsName = objectsName.replace(/\\/g, '/');
+        /** @type {string|string[]} */
         var parts = objectsName.split('/');
         parts.pop();
         parts = parts.join('/');

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -348,7 +348,7 @@ function getJson(urlOrPath, callback) {
         } else {
             if (fs.existsSync(urlOrPath)) {
                 try {
-                    sources = JSON.parse(fs.readFileSync(urlOrPath));
+                    sources = JSON.parse(fs.readFileSync(urlOrPath, 'utf8'));
                 } catch (e) {
                     console.log('Cannot parse json file from ' + urlOrPath + '. Error: ' + e);
                     if (callback) callback(null, urlOrPath);
@@ -358,7 +358,7 @@ function getJson(urlOrPath, callback) {
             } else
             if (fs.existsSync(__dirname + '/../' + urlOrPath)) {
                 try {
-                    sources = JSON.parse(fs.readFileSync(__dirname + '/../' + urlOrPath));
+                    sources = JSON.parse(fs.readFileSync(__dirname + '/../' + urlOrPath, 'utf8'));
                 }catch (e) {
                     console.log('Cannot parse json file from ' + __dirname + '/../' + urlOrPath + '. Error: ' + e);
                     if (callback) callback(null, urlOrPath);
@@ -367,7 +367,7 @@ function getJson(urlOrPath, callback) {
                 if (callback) callback(sources, urlOrPath);
             } else if (fs.existsSync(__dirname + '/../tmp/' + urlOrPath)) {
                 try {
-                    sources = JSON.parse(fs.readFileSync(__dirname + '/../tmp/' + urlOrPath));
+                    sources = JSON.parse(fs.readFileSync(__dirname + '/../tmp/' + urlOrPath, 'utf8'));
                 } catch (e) {
                     console.log('Cannot parse json file from ' + __dirname + '/../tmp/' + urlOrPath + '. Error: ' + e);
                     if (callback) callback(null, urlOrPath);
@@ -391,8 +391,8 @@ function scanDirectory(dirName, list, regExp) {
                 var fileIoName = path.join(fullPath, 'io-package.json');
                 var fileName   = path.join(fullPath, 'package.json');
                 if (regExp.test(dirs[i]) && fs.existsSync(fileIoName)) {
-                    var ioPackage = JSON.parse(fs.readFileSync(fileIoName));
-                    var package_  = fs.existsSync(fileName) ? JSON.parse(fs.readFileSync(fileName)) : {};
+                    var ioPackage = JSON.parse(fs.readFileSync(fileIoName, 'utf8'));
+                    var package_  = fs.existsSync(fileName) ? JSON.parse(fs.readFileSync(fileName, 'utf8')) : {};
 
                     //noinspection JSUnresolvedVariable
                     list[ioPackage.common.name] = {
@@ -421,8 +421,8 @@ function getInstalledInfo(hostRunningVersion) {
     var result = {};
     var path = __dirname + '/../';
     // Get info about host
-    var ioPackage = JSON.parse(fs.readFileSync(path + 'io-package.json'));
-    var package_  = fs.existsSync(path + 'package.json') ? JSON.parse(fs.readFileSync(path + 'package.json')) : {};
+    var ioPackage = JSON.parse(fs.readFileSync(path + 'io-package.json', 'utf8'));
+    var package_  = fs.existsSync(path + 'package.json') ? JSON.parse(fs.readFileSync(path + 'package.json', 'utf8')) : {};
     var regExp    = new RegExp('^' + module.exports.appName + '\\.', 'i');
 
     //noinspection JSUnresolvedVariable
@@ -667,12 +667,12 @@ function getRepositoryFile(urlOrPath, additionalInfo, callback) {
     } else
     if (!urlOrPath) {
         try {
-            sources = JSON.parse(fs.readFileSync(getDefaultDataDir() + 'sources.json'));
+            sources = JSON.parse(fs.readFileSync(getDefaultDataDir() + 'sources.json', 'utf8'));
         } catch (e) {
             sources = {};
         }
         try {
-            var sourcesDist = JSON.parse(fs.readFileSync(__dirname + '/../conf/sources-dist.json'));
+            var sourcesDist = JSON.parse(fs.readFileSync(__dirname + '/../conf/sources-dist.json', 'utf8'));
             sources = extend(true, sourcesDist, sources);
         } catch (e) {
 
@@ -767,7 +767,7 @@ function getAdapterDir(adapter) {
 function getHostName() {
     try {
         var configName = getConfigFileName();
-        var config = JSON.parse(fs.readFileSync(configName));
+        var config = JSON.parse(fs.readFileSync(configName, 'utf8'));
         return config.system ? config.system.hostname || require('os').hostname() : require('os').hostname();
     } catch (err) {
         return require('os').hostname();
@@ -884,6 +884,7 @@ function getDefaultDataDir() {
 }
 
 function getConfigFileName() {
+    /** @type {string|string[]} */
     var configDir = __dirname.replace(/\\/g, '/');
     configDir = configDir.split('/');
 

--- a/lib/uploadFiles.js
+++ b/lib/uploadFiles.js
@@ -22,6 +22,7 @@ var yargs = require('yargs')
 var fs =      require('fs');
 var mime =    require('mime');
 var Objects = require(__dirname + '/objects.js');
+var tools =   require('./tools');
 
 var files = [];
 var rev;

--- a/package.json
+++ b/package.json
@@ -38,15 +38,16 @@
     "yargs": "^6.0.0"
   },
   "devDependencies": {
-    "grunt": "^1.0.1",
-    "grunt-replace": "^1.0.1",
-    "grunt-contrib-jshint": "^1.1.0",
-    "grunt-jscs": "^3.0.1",
-    "grunt-http": "^2.2.0",
-    "grunt-jsdoc": "^2.1.0",
-    "mocha": "^4.1.0",
+    "@types/node": "^4.2.23",
     "chai": "^4.1.2",
-    "istanbul": "^0.4.5"
+    "grunt": "^1.0.1",
+    "grunt-contrib-jshint": "^1.1.0",
+    "grunt-http": "^2.2.0",
+    "grunt-jscs": "^3.0.1",
+    "grunt-jsdoc": "^2.1.0",
+    "grunt-replace": "^1.0.1",
+    "istanbul": "^0.4.5",
+    "mocha": "^4.1.0"
   },
   "homepage": "http://www.iobroker.com",
   "description": "...domesticate the Internet of Things",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,58 @@
+{
+	"compilerOptions": {
+	  /* Basic Options */
+	  "target": "es5",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', or 'ESNEXT'. */
+	  "module": "commonjs",                     /* Specify module code generation: 'none', commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
+	  "lib": ["es6"],                             /* Specify library files to be included in the compilation:  */
+	  "allowJs": true,                       /* Allow javascript files to be compiled. */
+	  "checkJs": true,                       /* Report errors in .js files. */
+	  // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
+	  // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
+	  // "sourceMap": true,                     /* Generates corresponding '.map' file. */
+	  // "outFile": "./",                       /* Concatenate and emit output to single file. */
+	  // "outDir": "./",                        /* Redirect output structure to the directory. */
+	  // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+	  // "removeComments": true,                /* Do not emit comments to output. */
+	  "noEmit": true,                        /* Do not emit outputs. */
+	  // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
+	  // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
+	  // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
+  
+	  /* Strict Type-Checking Options */
+	  "strict": false,                            /* Enable all strict type-checking options. */
+	  "noImplicitAny": false,                 /* Raise error on expressions and declarations with an implied 'any' type. */
+	  // "strictNullChecks": true,              /* Enable strict null checks. */
+	  // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
+	  // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
+  
+	  /* Additional Checks */
+	  // "noUnusedLocals": true,                /* Report errors on unused locals. */
+	  // "noUnusedParameters": true,            /* Report errors on unused parameters. */
+	  // "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
+	  // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
+  
+	  /* Module Resolution Options */
+	  // "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+	  // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
+	  // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+	  // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
+	  // "typeRoots": [],                       /* List of folders to include type definitions from. */
+	  // "types": [],                           /* Type declaration files to be included in compilation. */
+	  // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
+	  // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
+  
+	  /* Source Map Options */
+	  // "sourceRoot": "./",                    /* Specify the location where debugger should locate TypeScript files instead of source locations. */
+	  // "mapRoot": "./",                       /* Specify the location where debugger should locate map files instead of generated locations. */
+	  // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
+	  // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
+  
+	  /* Experimental Options */
+	  // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
+	  // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+	},
+	"include": [
+	  "iobroker.js",
+	  "lib/**/*.js"
+	]
+  }


### PR DESCRIPTION
Same as I already did with zwave and another adapter I don't remember right now. Many "issues" could be fixed by asserting the variable type myself.

A bunch of the reported issues were with `fs.readFileSync()` which expects the encoding as the 2nd parameter. The fallback to `utf8` if none is given is not documented, so we should avoid it.

Aside from that, there were some actual bugs (undefined variables). I commented below where I found them.