### PR TITLE
Log an error when npmInstallWithCheck throws

### DIFF
--- a/lib/setup/setupInstall.js
+++ b/lib/setup/setupInstall.js
@@ -298,7 +298,8 @@ function Install(options) {
             that.npmInstall(npmUrl, options, debug, callback);
         }
         catch (e) {
-            console.error('Could not check npm version. Assuming that correct version is installed.');
+            console.error('Could not check npm version: ' + e);
+            console.error('Assuming that correct version is installed.');
         }
     };
 


### PR DESCRIPTION
Followup to #168 - find out why the npm version check sometimes fails.