### PR TITLE
[npm5] Disable package-lock.json before installing anything

### DIFF
--- a/lib/setup.js
+++ b/lib/setup.js
@@ -2840,24 +2840,26 @@ function installNpm(adapter, callback) {
 
     // iob_npm.done file was created if "npm i" yet called there
     if (fs.existsSync(path + '/package.json') && !fs.existsSync(path + '/iob_npm.done')) {
-        var cmd = 'npm install --production';
-        console.log(cmd + ' (System call) in "' + path + '"');
-        // Install node modules as system call
-
-        // System call used for update of js-controller itself,
-        // because during installation npm packet will be deleted too, but some files must be loaded even during the install process.
-        var exec = require('child_process').exec;
-        var child = exec(cmd, {
-            cwd: path
-        });
-        child.stderr.pipe(process.stdout);
-        child.on('exit', function (code, signal) {
-            if (code) {
-                console.log('Cannot install ' + tools.appName + '.' + adapter + ': ' + code);
-                (callback || processExit)(25);
-            }
-            // command succeeded
-            if (callback) callback(null, adapter);
+        tools.disablePackageLock(function (err) {
+            var cmd = 'npm install --production';
+            console.log(cmd + ' (System call) in "' + path + '"');
+            // Install node modules as system call
+    
+            // System call used for update of js-controller itself,
+            // because during installation npm packet will be deleted too, but some files must be loaded even during the install process.
+            var exec = require('child_process').exec;
+            var child = exec(cmd, {
+                cwd: path
+            });
+            child.stderr.pipe(process.stdout);
+            child.on('exit', function (code, signal) {
+                if (code) {
+                    console.log('Cannot install ' + tools.appName + '.' + adapter + ': ' + code);
+                    (callback || processExit)(25);
+                }
+                // command succeeded
+                if (callback) callback(null, adapter);
+            });
         });
     } else {
         if (callback) callback(null, adapter);

--- a/lib/setup/setupInstall.js
+++ b/lib/setup/setupInstall.js
@@ -263,7 +263,6 @@ function Install(options) {
     };
 
     this.npmInstallWithCheck = function (npmUrl, options, debug, callback) {
-        var that = this;
         // Get npm version
         try {
             var nodeVersion = semver.valid(process.version);
@@ -298,7 +297,7 @@ function Install(options) {
                 return;
             }
 
-            that.npmInstall(npmUrl, options, debug, callback);
+            this.npmInstall(npmUrl, options, debug, callback);
         } catch (e) {
             console.error('Could not check npm version: ' + e);
             console.error('Assuming that correct version is installed.');
@@ -334,31 +333,33 @@ function Install(options) {
             }
         }
 
-        var cmd = 'npm install ' + npmUrl + (options.unsafePerm ? ' --unsafe-perm' : '') + ' --production --save --prefix "' + cwd + '"';
+        tools.disablePackageLock(function (err) {
+            var cmd = 'npm install ' + npmUrl + (options.unsafePerm ? ' --unsafe-perm' : '') + ' --production --save --prefix "' + cwd + '"';
 
-        console.log(cmd + ' (System call)');
-        // Install node modules as system call
-
-        // System call used for update of js-controller itself,
-        // because during installation npm packet will be deleted too, but some files must be loaded even during the install process.
-        var exec = require('child_process').exec;
-        var child = exec(cmd);
-        child.stderr.pipe(process.stdout);
-        if (debug || params.debug) {
-            child.stdout.pipe(process.stdout);
-        }
-        child.on('exit', function (code /* , signal */) {
-            // code 1 is strange error that cannot be explained. Everything is installed but error :(
-            if (code && code !== 1) {
-                console.error('host.' + hostname + ' Cannot install ' + npmUrl + ': ' + code);
-                processExit(25);
+            console.log(cmd + ' (System call)');
+            // Install node modules as system call
+    
+            // System call used for update of js-controller itself,
+            // because during installation npm packet will be deleted too, but some files must be loaded even during the install process.
+            var exec = require('child_process').exec;
+            var child = exec(cmd);
+            child.stderr.pipe(process.stdout);
+            if (debug || params.debug) {
+                child.stdout.pipe(process.stdout);
             }
-            // create file that indicates, that npm was called there
-            if (npmUrl.indexOf(':') === -1 && fs.existsSync(cwd + '/node_modules/' + npmUrl)) {
-                fs.writeFileSync(cwd + '/node_modules/' + npmUrl + '/iob_npm.done', ' ');
-            }
-            // command succeeded
-            if (callback) callback(npmUrl, cwd + '/node_modules');
+            child.on('exit', function (code /* , signal */) {
+                // code 1 is strange error that cannot be explained. Everything is installed but error :(
+                if (code && code !== 1) {
+                    console.error('host.' + hostname + ' Cannot install ' + npmUrl + ': ' + code);
+                    processExit(25);
+                }
+                // create file that indicates, that npm was called there
+                if (npmUrl.indexOf(':') === -1 && fs.existsSync(cwd + '/node_modules/' + npmUrl)) {
+                    fs.writeFileSync(cwd + '/node_modules/' + npmUrl + '/iob_npm.done', ' ');
+                }
+                // command succeeded
+                if (callback) callback(npmUrl, cwd + '/node_modules');
+            });
         });
     };
 

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -2,6 +2,7 @@
 
 var fs   = require('fs');
 var path = require('path');
+var semver = require('semver');
 require('events').EventEmitter.prototype._maxListeners = 100;
 var request;
 var extend;
@@ -911,8 +912,8 @@ function getConfigFileName() {
 
 /**
  * Puts all values from an `arguments` object into an array, starting at the given index
- * @param {{[index: number]: any}} argsObj An `arguments` object as passed to a function
- * @param {number} startIndex The optional index to start taking the arguments from
+ * @param {{[index: number]: any, length: number}} argsObj An `arguments` object as passed to a function
+ * @param {number?} startIndex The optional index to start taking the arguments from
  */
 function sliceArgs(argsObj, startIndex) {
     if (startIndex == null) startIndex = 0;
@@ -1025,6 +1026,30 @@ function promiseSequence(promiseFactories) {
     }, Promise.resolve([]));
 }
 
+
+let packageLockDisabled = false;
+/**
+ * Ensures that package-lock.json gets ignored. Fixes installation issues on npm5
+ * @param {(err?) => void} callback The callback to invoke after the command has finished
+ */
+function disablePackageLock(callback) {
+    if (packageLockDisabled) return callback();
+    
+    const npmrcPath = path.join(__dirname, '../../..', '.npmrc');
+    getSystemNpmVersion(function (err, version) {
+        packageLockDisabled = true;
+        if (semver.gte(version, '5.0.0')) {
+            // we need to disable the package lock
+            if (!fs.existsSync(npmrcPath)) {
+                // create the file
+                fs.writeFile(npmrcPath, 'package-lock=false\n', {encoding: 'utf8'}, callback);
+                return;
+            }
+        }
+        callback();
+    })
+}
+
 module.exports = {
     findIPs,
     rmdirRecursiveSync,
@@ -1047,5 +1072,6 @@ module.exports = {
     decryptPhrase,
     promisify,
     promisifyNoError,
-    promiseSequence
+    promiseSequence,
+    disablePackageLock
 };

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   },
   "devDependencies": {
     "@types/node": "^4.2.23",
+    "chai": "^4.1.2",
     "chai-as-promised": "^7.1.1",
     "grunt": "^1.0.1",
     "grunt-contrib-jshint": "^1.1.0",
@@ -47,8 +48,7 @@
     "grunt-jsdoc": "^2.1.0",
     "grunt-replace": "^1.0.1",
     "istanbul": "^0.4.5",
-    "mocha": "^5.0.1",
-    "istanbul": "^0.4.5"
+    "mocha": "^5.0.1"
   },
   "homepage": "http://www.iobroker.com",
   "description": "...domesticate the Internet of Things",


### PR DESCRIPTION
This adds another safety-net for npm5 in case NodeJS/npm gets updated with an existing ioBroker installation. Just like on a fresh installation, this disables package.-lock before any npm installation.

I hope I didn't miss any location where `npm install` is being called. 

This must be merged and published together with https://github.com/ioBroker/ioBroker/pull/44
