### PR TITLE
Remove the outdated npm package

### DIFF
--- a/lib/tools.js
+++ b/lib/tools.js
@@ -763,6 +763,19 @@ function getHostName() {
  */
 function getSystemNpmVersion(callback) {
     var exec = require('child_process').exec;
+    
+    // remove local node_modules\.bin dir from path
+    // or we potentially get a wrong npm version
+    process.env.PATH = process.env.PATH
+        .split(path.delimiter)
+        .filter(dir => {
+            dir = dir.toLowerCase();
+            if (dir.indexOf("iobroker") > -1 && dir.indexOf(path.join("node_modules", ".bin")) > -1) return false;
+            return true;
+        })
+        .join(path.delimiter)
+        ;
+
     exec('npm -v', function (error, stdout) {//, stderr) {
         if (stdout) stdout = semver.valid(stdout.trim());
         if (callback) callback(error, stdout);

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -452,59 +452,31 @@ function getInstalledInfo(hostRunningVersion) {
     return result;
 }
 
-function initNpm(prefix, callback) {
-    if (typeof prefix === 'function') {
-        callback = prefix;
-        prefix   = undefined;
-    }
-
-    var settings = {
-        silent:     true,
-        global:     false,
-        production: true,
-        minTimeout: 500,
-        maxTimeout: 1500,
-        times:      1
-    };
-
-    if (prefix) {
-        settings.prefix = prefix;
-    }
-
-    var npm = require('npm');
-    npm.load(settings, function (er) {
-        // Disable debug outputs
-        npm.registry.log.silly   = function () {};
-        npm.registry.log.verbose = function () {};
-        npm.registry.log.info    = function () {};
-        npm.registry.log.http    = function () {};
-        if (callback) callback(er, npm);
-    });
-}
-
-// reads version of packet from npm
+/**
+ * Reads an adapter's npm version
+ * @param {string | null} adapter The adapter to read the npm version from. Null for the root ioBroker packet
+ * @param {(err: Error | null, version: string) => void} [callback]
+ */
 function getNpmVersion(adapter, callback) {
     adapter = adapter ? module.exports.appName + '.' + adapter : module.exports.appName;
     adapter = adapter.toLowerCase();
 
-    try {
-        initNpm(function (er, npm) {
-            setImmediate(function () {
-                npm.commands.view([adapter, 'dist-tags.latest'], true, function (error, response) {
-                    if (error) return callback ? callback(error) : 0;
+    const cliCommand = `npm view ${adapter}@latest version`;
 
-                    if (response) {
-                        callback && callback(error, Object.keys(response)[0]);
-                    } else {
-                        callback && callback();
-                    }
-                });
-            });
-        });
-    } catch (e) {
-        console.log('error by reading ' + adapter + ': ' + e);
-        callback && callback(e);
-    }
+    var exec = require('child_process').exec;
+    exec(cliCommand, {timeout: 5000}, (error, stdout, stderr) => {
+        let version;
+        if (error) {
+            // command failed
+            if (typeof callback === "function") {
+                callback(error);
+                return;
+            }
+        } else if (stdout) {
+            version = semver.valid(stdout.trim());
+        }
+        if (typeof callback === "function") callback(null, version);
+    });
 }
 
 function getIoPack(sources, name, callback) {
@@ -792,10 +764,7 @@ function getHostName() {
 function getSystemNpmVersion(callback) {
     var exec = require('child_process').exec;
     exec('npm -v', function (error, stdout) {//, stderr) {
-        if (stdout) {
-            var lines = stdout.split('\n');
-            stdout = lines[0].replace('\r', '').trim();
-        }
+        if (stdout) stdout = semver.valid(stdout.trim());
         if (callback) callback(error, stdout);
     });
 }
@@ -912,8 +881,8 @@ function getConfigFileName() {
 
 /**
  * Puts all values from an `arguments` object into an array, starting at the given index
- * @param {{[index: number]: any, length: number}} argsObj An `arguments` object as passed to a function
- * @param {number?} startIndex The optional index to start taking the arguments from
+ * @param {IArguments} argsObj An `arguments` object as passed to a function
+ * @param {number} [startIndex=0] The optional index to start taking the arguments from
  */
 function sliceArgs(argsObj, startIndex) {
     if (startIndex == null) startIndex = 0;
@@ -1051,27 +1020,27 @@ function disablePackageLock(callback) {
 }
 
 module.exports = {
-    findIPs,
-    rmdirRecursiveSync,
-    getRepositoryFile,
-    getIoPack,
-    getFile,
-    getJson,
-    getInstalledInfo,
-    sendDiagInfo,
-    getAdapterDir,
-    getDefaultDataDir,
-    getConfigFileName,
-    initNpm,
-    getHostName,
     appName: getAppName(),
     createUuid,
-    getHostInfo,
-    upToDate,
-    encryptPhrase,
     decryptPhrase,
+    disablePackageLock,
+    encryptPhrase,
+    findIPs,
+    getAdapterDir,
+    getConfigFileName,
+    getDefaultDataDir,
+    getFile,
+    getHostInfo,
+    getHostName,
+    getInstalledInfo,
+    getIoPack,
+    getJson,
+    getRepositoryFile,
+    getSystemNpmVersion,
     promisify,
     promisifyNoError,
     promiseSequence,
-    disablePackageLock
+    rmdirRecursiveSync,
+    sendDiagInfo,
+    upToDate,
 };

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -766,7 +766,8 @@ function getSystemNpmVersion(callback) {
     
     // remove local node_modules\.bin dir from path
     // or we potentially get a wrong npm version
-    process.env.PATH = process.env.PATH
+    var newEnv = Object.assign({}, process.env);
+    newEnv.PATH = (newEnv.PATH || newEnv.Path || newEnv.path)
         .split(path.delimiter)
         .filter(dir => {
             dir = dir.toLowerCase();
@@ -776,7 +777,7 @@ function getSystemNpmVersion(callback) {
         .join(path.delimiter)
         ;
 
-    exec('npm -v', function (error, stdout) {//, stderr) {
+    exec('npm -v', { encoding: "utf8", env: newEnv }, function (error, stdout) {//, stderr) {
         if (stdout) stdout = semver.valid(stdout.trim());
         if (callback) callback(error, stdout);
     });

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -464,7 +464,7 @@ function getNpmVersion(adapter, callback) {
     const cliCommand = `npm view ${adapter}@latest version`;
 
     var exec = require('child_process').exec;
-    exec(cliCommand, {timeout: 5000}, (error, stdout, stderr) => {
+    exec(cliCommand, {timeout: 2000}, (error, stdout, stderr) => {
         let version;
         if (error) {
             // command failed

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "ncp": "^2.0.0",
     "node-schedule": "^1.3.0",
     "node.extend": "^2.0.0",
-    "npm": "^2.15.12",
     "prompt": "^1.0.0",
     "pyconf": "^1.1.2",
     "request": "^2.83.0",


### PR DESCRIPTION
because that messes up our npm version checks. Also the new code using the cli is a bit faster.