### PR TITLE
 Remove the outdated npm package and disable package-lock before installing

### DIFF
--- a/lib/preinstall_check.js
+++ b/lib/preinstall_check.js
@@ -15,7 +15,6 @@ var rootDir = __dirname.substr(0, __dirname.lastIndexOf("node_modules"));
 function checkNpmVersion() {
     // Get npm version
     try {
-        var nodeVersion = process.version;
         var npmVersion;
         try {
             npmVersion = child_process.execSync('npm -v', { encoding: "utf8" });
@@ -25,30 +24,19 @@ function checkNpmVersion() {
             console.error('Error trying to check npm version: ' + e);
         }
 
-        if (!npmVersion) {
-            console.error('!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!');
-            console.error('Aborting install because the npm version could not be checked!');
-            console.error('Please check that npm is installed correctly.');
-            console.error('Use "npm install -g npm@4" or "npm install -g npm@latest" to install a supported version.');
-            console.error('You need to make sure to repeat this step after installing an update to NodeJS and/or npm.');
-            console.error('!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!');
-            process.exit(3);
-            return;
-        }
-
         if (gte(npmVersion, "5.0.0") && lt(npmVersion, "5.7.1")) {
-            console.error('!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!');
-            console.error('NPM 5 is only supported starting with version 5.7.1!');
-            console.error('Please use "npm install -g npm@4" to downgrade npm to 4.x or ');
-            console.error('use "npm install -g npm@latest" to install a supported version of npm 5!')
-            console.error('You need to make sure to repeat this step after installing an update to NodeJS and/or npm.');
-            console.error('!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!');
-            process.exit(4);
-            return;
+			console.warn('!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!');
+			console.warn('WARNING:');
+			console.warn('You are using an unsupported npm version!')
+			console.warn('This can lead to problems when installing further packages')
+			console.warn();
+            console.warn('Please use "npm install -g npm@4" to downgrade npm to 4.x or ');
+            console.warn('use "npm install -g npm@latest" to install a supported version of npm 5!')
+            console.warn('You need to make sure to repeat this step after installing an update to NodeJS and/or npm.');
+            console.warn('!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!');
         }
         return npmVersion;
-    }
-    catch (e) {
+    } catch (e) {
         console.error('Could not check npm version: ' + e);
         console.error('Assuming that correct version is installed.');
     }

--- a/lib/preinstall_check.js
+++ b/lib/preinstall_check.js
@@ -1,0 +1,166 @@
+'use strict';
+
+// we cannot use semver here, because dependencies are not installed yet
+// so the version checks get a bit messy
+
+var fs = require('fs');
+var path = require('path');
+var child_process = require('child_process');
+var os = require('os');
+
+// where ioBroker is installed
+var rootDir = __dirname.substr(0, __dirname.lastIndexOf("node_modules"));
+
+
+function checkNpmVersion() {
+    // Get npm version
+    try {
+        var nodeVersion = process.version;
+        var npmVersion;
+        try {
+            npmVersion = child_process.execSync('npm -v', { encoding: "utf8" });
+            if (npmVersion) npmVersion = npmVersion.trim();
+            console.log('NPM version: ' + npmVersion);
+        } catch (e) {
+            console.error('Error trying to check npm version: ' + e);
+        }
+
+        if (!npmVersion) {
+            console.error('!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!');
+            console.error('Aborting install because the npm version could not be checked!');
+            console.error('Please check that npm is installed correctly.');
+            console.error('Use "npm install -g npm@4" or "npm install -g npm@latest" to install a supported version.');
+            console.error('You need to make sure to repeat this step after installing an update to NodeJS and/or npm.');
+            console.error('!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!');
+            process.exit(3);
+            return;
+        }
+
+        if (gte(npmVersion, "5.0.0") && lt(npmVersion, "5.7.1")) {
+            console.error('!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!');
+            console.error('NPM 5 is only supported starting with version 5.7.1!');
+            console.error('Please use "npm install -g npm@4" to downgrade npm to 4.x or ');
+            console.error('use "npm install -g npm@latest" to install a supported version of npm 5!')
+            console.error('You need to make sure to repeat this step after installing an update to NodeJS and/or npm.');
+            console.error('!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!');
+            process.exit(4);
+            return;
+        }
+        return npmVersion;
+    }
+    catch (e) {
+        console.error('Could not check npm version: ' + e);
+        console.error('Assuming that correct version is installed.');
+    }
+}
+
+if (gte(checkNpmVersion(), "5.0.0")) {
+    // disables NPM's package-lock.json on NPM >= 5 because that creates heaps of problems
+    console.log("npm version >= 5: disabling package-lock")
+    fs.writeFileSync(path.join(rootDir, '.npmrc'), 'package-lock=false' + os.EOL, "utf8");
+}
+
+process.exit(0);
+
+// ======================================
+// all the functions to replace `semver`:
+
+/**
+ * @typedef {{major: number, minor: number, build: number}} Version
+ */
+/**
+ * Parses a version string
+ * @param {string} version The version string to parse
+ * @returns {Version | null} The parsed version
+ */
+function parseVersion(version) {
+	var versionRegExp = /^v?(\d+)\.(\d+)\.(\d+).*?/;
+	var parsed = versionRegExp.exec(version);
+	if (!parsed) return null;
+
+	return {
+		major: +parsed[1],
+		minor: +parsed[2],
+		build: +parsed[3]
+	};
+}
+
+/**
+ * Checks if v1 > v2
+ * @param {Version | string} v1 
+ * @param {Version | string} v2 
+ */
+function gt(v1, v2) {
+	if (typeof v1 === "string") v1 = parseVersion(v1);
+	if (typeof v2 === "string") v2 = parseVersion(v2);
+
+	if (v1.major > v2.major) return true;
+	else if (v1.major < v2.major) return false;
+	
+	if (v1.minor > v2.minor) return true;
+	else if (v1.minor < v2.minor) return false;
+	
+	if (v1.build > v2.build) return true;
+	return false;
+}
+
+/**
+ * Checks if v1 < v2
+ * @param {Version | string} v1 
+ * @param {Version | string} v2 
+ */
+function lt(v1, v2) {
+	if (typeof v1 === "string") v1 = parseVersion(v1);
+	if (typeof v2 === "string") v2 = parseVersion(v2);
+
+	if (v1.major < v2.major) return true;
+	else if (v1.major > v2.major) return false;
+	
+	if (v1.minor < v2.minor) return true;
+	else if (v1.minor > v2.minor) return false;
+	
+	if (v1.build < v2.build) return true;
+	return false;
+}
+
+/**
+ * Checks if v1 == v2
+ * @param {Version | string} v1 
+ * @param {Version | string} v2 
+ */
+function eq(v1, v2) {
+	if (typeof v1 === "string") v1 = parseVersion(v1);
+	if (typeof v2 === "string") v2 = parseVersion(v2);
+
+	if (v1.major !== v2.major) return false;
+	if (v1.minor !== v2.minor) return false;
+	if (v1.build !== v2.build) return false;
+	return true;
+}
+
+/**
+ * Checks if v1 != v2
+ * @param {Version | string} v1 
+ * @param {Version | string} v2 
+ */
+function ne(v1, v2) {
+	return !eq(v1, v2);
+}
+
+/**
+ * Checks if v1 >= v2
+ * @param {Version | string} v1 
+ * @param {Version | string} v2 
+ */
+function gte(v1, v2) {
+	return gt(v1, v2) || eq(v1, v2);
+}
+
+/**
+ * Checks if v1 <= v2
+ * @param {Version | string} v1 
+ * @param {Version | string} v2 
+ */
+function lte(v1, v2) {
+	return lt(v1, v2) || eq(v1, v2);
+}

--- a/lib/preinstall_check.js
+++ b/lib/preinstall_check.js
@@ -13,39 +13,53 @@ var rootDir = __dirname.substr(0, __dirname.lastIndexOf("node_modules"));
 
 
 function checkNpmVersion() {
-    // Get npm version
-    try {
-        var npmVersion;
-        try {
-            npmVersion = child_process.execSync('npm -v', { encoding: "utf8" });
-            if (npmVersion) npmVersion = npmVersion.trim();
-            console.log('NPM version: ' + npmVersion);
-        } catch (e) {
-            console.error('Error trying to check npm version: ' + e);
-        }
+	// Get npm version
+	try {
+		var npmVersion;
+		try {
 
-        if (gte(npmVersion, "5.0.0") && lt(npmVersion, "5.7.1")) {
+			// remove local node_modules\.bin dir from path
+			// or we potentially get a wrong npm version
+			var newEnv = Object.assign({}, process.env);
+			newEnv.PATH = (newEnv.PATH || newEnv.Path || newEnv.path)
+				.split(path.delimiter)
+				.filter(dir => {
+					dir = dir.toLowerCase();
+					if (dir.indexOf("iobroker") > -1 && dir.indexOf(path.join("node_modules", ".bin")) > -1) return false;
+					return true;
+				})
+				.join(path.delimiter)
+				;
+
+			npmVersion = child_process.execSync('npm -v', { encoding: "utf8", env: newEnv });
+			if (npmVersion) npmVersion = npmVersion.trim();
+			console.log('NPM version: ' + npmVersion);
+		} catch (e) {
+			console.error('Error trying to check npm version: ' + e);
+		}
+
+		if (gte(npmVersion, "5.0.0") && lt(npmVersion, "5.7.1")) {
 			console.warn('!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!');
 			console.warn('WARNING:');
 			console.warn('You are using an unsupported npm version!')
 			console.warn('This can lead to problems when installing further packages')
 			console.warn();
-            console.warn('Please use "npm install -g npm@4" to downgrade npm to 4.x or ');
-            console.warn('use "npm install -g npm@latest" to install a supported version of npm 5!')
-            console.warn('You need to make sure to repeat this step after installing an update to NodeJS and/or npm.');
-            console.warn('!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!');
-        }
-        return npmVersion;
-    } catch (e) {
-        console.error('Could not check npm version: ' + e);
-        console.error('Assuming that correct version is installed.');
-    }
+			console.warn('Please use "npm install -g npm@4" to downgrade npm to 4.x or ');
+			console.warn('use "npm install -g npm@latest" to install a supported version of npm 5!')
+			console.warn('You need to make sure to repeat this step after installing an update to NodeJS and/or npm.');
+			console.warn('!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!');
+		}
+		return npmVersion;
+	} catch (e) {
+		console.error('Could not check npm version: ' + e);
+		console.error('Assuming that correct version is installed.');
+	}
 }
 
 if (gte(checkNpmVersion(), "5.0.0")) {
-    // disables NPM's package-lock.json on NPM >= 5 because that creates heaps of problems
-    console.log("npm version >= 5: disabling package-lock")
-    fs.writeFileSync(path.join(rootDir, '.npmrc'), 'package-lock=false' + os.EOL, "utf8");
+	// disables NPM's package-lock.json on NPM >= 5 because that creates heaps of problems
+	console.log("npm version >= 5: disabling package-lock")
+	fs.writeFileSync(path.join(rootDir, '.npmrc'), 'package-lock=false' + os.EOL, "utf8");
 }
 
 process.exit(0);

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -763,6 +763,19 @@ function getHostName() {
  */
 function getSystemNpmVersion(callback) {
     var exec = require('child_process').exec;
+    
+    // remove local node_modules\.bin dir from path
+    // or we potentially get a wrong npm version
+    process.env.PATH = process.env.PATH
+        .split(path.delimiter)
+        .filter(dir => {
+            dir = dir.toLowerCase();
+            if (dir.indexOf("iobroker") > -1 && dir.indexOf(path.join("node_modules", ".bin")) > -1) return false;
+            return true;
+        })
+        .join(path.delimiter)
+        ;
+
     exec('npm -v', function (error, stdout) {//, stderr) {
         if (stdout) stdout = semver.valid(stdout.trim());
         if (callback) callback(error, stdout);

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -452,59 +452,31 @@ function getInstalledInfo(hostRunningVersion) {
     return result;
 }
 
-function initNpm(prefix, callback) {
-    if (typeof prefix === 'function') {
-        callback = prefix;
-        prefix   = undefined;
-    }
-
-    var settings = {
-        silent:     true,
-        global:     false,
-        production: true,
-        minTimeout: 500,
-        maxTimeout: 1500,
-        times:      1
-    };
-
-    if (prefix) {
-        settings.prefix = prefix;
-    }
-
-    var npm = require('npm');
-    npm.load(settings, function (er) {
-        // Disable debug outputs
-        npm.registry.log.silly   = function () {};
-        npm.registry.log.verbose = function () {};
-        npm.registry.log.info    = function () {};
-        npm.registry.log.http    = function () {};
-        if (callback) callback(er, npm);
-    });
-}
-
-// reads version of packet from npm
+/**
+ * Reads an adapter's npm version
+ * @param {string | null} adapter The adapter to read the npm version from. Null for the root ioBroker packet
+ * @param {(err: Error | null, version: string) => void} [callback]
+ */
 function getNpmVersion(adapter, callback) {
     adapter = adapter ? module.exports.appName + '.' + adapter : module.exports.appName;
     adapter = adapter.toLowerCase();
 
-    try {
-        initNpm(function (er, npm) {
-            setImmediate(function () {
-                npm.commands.view([adapter, 'dist-tags.latest'], true, function (error, response) {
-                    if (error) return callback ? callback(error) : 0;
+    const cliCommand = `npm view ${adapter}@latest version`;
 
-                    if (response) {
-                        callback && callback(error, Object.keys(response)[0]);
-                    } else {
-                        callback && callback();
-                    }
-                });
-            });
-        });
-    } catch (e) {
-        console.log('error by reading ' + adapter + ': ' + e);
-        callback && callback(e);
-    }
+    var exec = require('child_process').exec;
+    exec(cliCommand, {timeout: 2000}, (error, stdout, stderr) => {
+        let version;
+        if (error) {
+            // command failed
+            if (typeof callback === "function") {
+                callback(error);
+                return;
+            }
+        } else if (stdout) {
+            version = semver.valid(stdout.trim());
+        }
+        if (typeof callback === "function") callback(null, version);
+    });
 }
 
 function getIoPack(sources, name, callback) {
@@ -792,10 +764,7 @@ function getHostName() {
 function getSystemNpmVersion(callback) {
     var exec = require('child_process').exec;
     exec('npm -v', function (error, stdout) {//, stderr) {
-        if (stdout) {
-            var lines = stdout.split('\n');
-            stdout = lines[0].replace('\r', '').trim();
-        }
+        if (stdout) stdout = semver.valid(stdout.trim());
         if (callback) callback(error, stdout);
     });
 }
@@ -912,8 +881,8 @@ function getConfigFileName() {
 
 /**
  * Puts all values from an `arguments` object into an array, starting at the given index
- * @param {{[index: number]: any, length: number}} argsObj An `arguments` object as passed to a function
- * @param {number?} startIndex The optional index to start taking the arguments from
+ * @param {IArguments} argsObj An `arguments` object as passed to a function
+ * @param {number} [startIndex=0] The optional index to start taking the arguments from
  */
 function sliceArgs(argsObj, startIndex) {
     if (startIndex == null) startIndex = 0;
@@ -1051,27 +1020,27 @@ function disablePackageLock(callback) {
 }
 
 module.exports = {
-    findIPs,
-    rmdirRecursiveSync,
-    getRepositoryFile,
-    getIoPack,
-    getFile,
-    getJson,
-    getInstalledInfo,
-    sendDiagInfo,
-    getAdapterDir,
-    getDefaultDataDir,
-    getConfigFileName,
-    initNpm,
-    getHostName,
     appName: getAppName(),
     createUuid,
-    getHostInfo,
-    upToDate,
-    encryptPhrase,
     decryptPhrase,
+    disablePackageLock,
+    encryptPhrase,
+    findIPs,
+    getAdapterDir,
+    getConfigFileName,
+    getDefaultDataDir,
+    getFile,
+    getHostInfo,
+    getHostName,
+    getInstalledInfo,
+    getIoPack,
+    getJson,
+    getRepositoryFile,
+    getSystemNpmVersion,
     promisify,
     promisifyNoError,
     promiseSequence,
-    disablePackageLock
+    rmdirRecursiveSync,
+    sendDiagInfo,
+    upToDate,
 };

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -766,7 +766,8 @@ function getSystemNpmVersion(callback) {
     
     // remove local node_modules\.bin dir from path
     // or we potentially get a wrong npm version
-    process.env.PATH = process.env.PATH
+    var newEnv = Object.assign({}, process.env);
+    newEnv.PATH = (newEnv.PATH || newEnv.Path || newEnv.path)
         .split(path.delimiter)
         .filter(dir => {
             dir = dir.toLowerCase();
@@ -776,7 +777,7 @@ function getSystemNpmVersion(callback) {
         .join(path.delimiter)
         ;
 
-    exec('npm -v', function (error, stdout) {//, stderr) {
+    exec('npm -v', { encoding: "utf8", env: newEnv }, function (error, stdout) {//, stderr) {
         if (stdout) stdout = semver.valid(stdout.trim());
         if (callback) callback(error, stdout);
     });

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "url": "https://github.com/ioBroker/ioBroker.js-controller"
   },
   "scripts": {
+    "preinstall": "node lib/preinstall_check.js",
     "install": "node iobroker.js setup first",
     "start": "node iobroker.js start",
     "stop": "node iobroker.js stop",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "ncp": "^2.0.0",
     "node-schedule": "^1.3.0",
     "node.extend": "^2.0.0",
-    "npm": "^2.15.12",
     "prompt": "^1.0.0",
     "pyconf": "^1.1.2",
     "request": "^2.83.0",


### PR DESCRIPTION
This is an extended version of #174, which also checks the npm version BEFORE installing and disables the package-lock check if necessary.

Note: This only warns on a non-supported NPM version as I don't want to leave the user without a js-controller.