### PR TITLE
Uninstall adapters using npm

### DIFF
--- a/lib/setup/setupInstall.js
+++ b/lib/setup/setupInstall.js
@@ -1200,7 +1200,7 @@ function Install(options) {
         const deleteStates = tools.poorMansAsync(function*() {
             if (delState.length > 1000) {
                 console.log('host.' + hostname + ' Deleting ' + delState.length + ' state(s). Be patient...');
-            } else if (delObj.length) {
+            } else if (delState.length) {
                 console.log('host.' + hostname + ' Deleting ' + delState.length + ' state(s).');
             }
 

--- a/lib/setup/setupInstall.js
+++ b/lib/setup/setupInstall.js
@@ -1,3 +1,5 @@
+//@ts-check
+
 'use strict';
 
 function Install(options) {
@@ -338,7 +340,7 @@ function Install(options) {
 
             console.log(cmd + ' (System call)');
             // Install node modules as system call
-    
+
             // System call used for update of js-controller itself,
             // because during installation npm packet will be deleted too, but some files must be loaded even during the install process.
             var exec = require('child_process').exec;
@@ -359,6 +361,54 @@ function Install(options) {
                 }
                 // command succeeded
                 if (callback) callback(npmUrl, cwd + '/node_modules');
+            });
+        });
+    };
+
+    this.npmUninstall = function (packageName, options, debug, callback) {
+        if (typeof options !== 'object') {
+            options = {};
+        }
+
+        // TODO: fine nicer way to find the root directory
+
+        // Install node modules
+        /** @type {string|string[]} */
+        var cwd = __dirname.replace(/\\/g, '/');
+        if (fs.existsSync(__dirname + '/../../../../node_modules/' + tools.appName + '.js-controller')) {
+            // js-controller installed as npm
+            cwd = cwd.split('/');
+            cwd.splice(cwd.length - 4, 4);
+            cwd = cwd.join('/');
+        } else {
+            // remove lib
+            cwd = cwd.split('/');
+            cwd.pop();
+            cwd.pop();
+            cwd = cwd.join('/');
+        }
+
+        tools.disablePackageLock(function (err) {
+            let cmd = `npm uninstall ${packageName} --silent --save --prefix "${cwd}"`;
+
+            console.log(cmd + ' (System call)');
+            // Install node modules as system call
+
+            // System call used for update of js-controller itself,
+            // because during installation npm packet will be deleted too, but some files must be loaded even during the install process.
+            var exec = require('child_process').exec;
+            var child = exec(cmd);
+            child.stderr.pipe(process.stdout);
+            if (debug || params.debug) {
+                child.stdout.pipe(process.stdout);
+            }
+            child.on('exit', function (code /* , signal */) {
+                // code 1 is strange error that cannot be explained. Everything is installed but error :(
+                if (code && code !== 1) {
+                    if (typeof callback === "function") callback(`host.${hostname}: Cannot uninstall ${packageName}: ${code}`);
+                }
+                // command succeeded
+                if (callback) callback();
             });
         });
     };
@@ -937,106 +987,76 @@ function Install(options) {
         var adapterRegex    = new RegExp('^' + adapter);
         var sysAdapterRegex = new RegExp('^system\\.adapter\\.' + adapter);
 
-        function delStates() {
-            if (delState.length && (delState.length % 200) === 0) {
-                console.log('host.' + hostname + ' Only ' + delState.length + ' states left to be deleted.');
-            }
-            if (!delState.length) {
-                if (callback) callback(adapter, resultCode);
-            } else {
-                states.delState(delState.pop(), function (err) {
-                    if (err) console.error(err);
-                    setImmediate(delStates);
-                });
-            }
-        }
+        // create promise-wrappers for delState and delObject
+        // TODO: promisify States and Objects at some point
+        /** @type {(stateId: string) => Promise<void>} */
+        const delStateAsync = tools.promisify(states.delState, states);
+        /** @type {(objId: string) => Promise<void>} */
+        const delObjectAsync = tools.promisify(objects.delObject, objects);
+        /** @type {(id: string, name: string) => Promise<void>} */
+        const unlinkAsync = tools.promisify(objects.unlink, objects);
+        /** @type {(packageName: string, options: any, debug: boolean) => Promise<void>} */
+        const npmUninstallAsync = tools.promisify(that.npmUninstall, that);
+        /** @type {(design: string, search: string, params: any, options?: any) => Promise<{rows: {id: string, value: any}[]}>} */
+        const getObjectViewAsync = tools.promisify(objects.getObjectView, objects);
+        /** @type {(objId: string) => Promise<any>} */
+        const getObjectAsync = tools.promisify(objects.getObject, objects);
+        /** @type {(objId: string, newObj: any) => Promise<void>} */
+        const setObjectAsync = tools.promisify(objects.setObject, objects);
+        /** @type {(pattern: string) => Promise<string[]>} */
+        const getKeysAsync = tools.promisify(states.getKeys, states);
 
-        function startDeleteStates() {
-            if (delState.length > 1000) {
-                console.log('host.' + hostname + ' Deleting ' + delState.length + ' state(s). Be patient...');
-            } else if (delObj.length) {
-                console.log('host.' + hostname + ' Deleting ' + delState.length + ' state(s).');
-            }
-            delStates();
-        }
-
-        function delObjects() {
-            if (delObj.length && (delObj.length % 200) === 0) {
-                console.log('host.' + hostname + ' Only ' + delObj.length + ' objects left to be deleted.');
-            }
-            if (!delObj.length) {
-                setTimeout(startDeleteStates, 50);
-            } else {
-                objects.delObject(delObj.pop(), function (err) {
-                    if (err) console.error(err);
-                    setImmediate(delObjects);
-                });
-            }
-        }
-
-        function delStatesAndObjects() {
-            if (delObj.length > 1000) {
-                console.log('host.' + hostname + ' Deleting ' + delObj.length + ' object(s). Be patient...');
-            } else if (delObj.length) {
-                console.log('host.' + hostname + ' Deleting ' + delObj.length + ' object(s).');
-            }
-
-            delObjects();
-        }
-
-        // Delete instances
-        taskCnt++;
-        objects.getObjectView('system', 'instance', {startkey: 'system.adapter.' + adapter, endkey: 'system.adapter.' + adapter + '\u9999'}, null, function (err, doc) {
-            if (err) {
-                if (err !== 'Not exists') console.error('host.' + hostname + ' error: ' + err);
-            } else {
+        function enumerateInstances() {
+            return getObjectViewAsync('system', 'instance', {startkey: 'system.adapter.' + adapter, endkey: 'system.adapter.' + adapter + '\u9999'}, null).then(doc => {
                 if (doc.rows.length === 0) {
                     console.log('host.' + hostname + ' no instances of adapter ' + adapter + ' found');
                 } else {
-                    var count = 0;
-
-                    for (var i = 0; i < doc.rows.length; i++) {
-                        if (delObj.indexOf(doc.rows[i].value._id) === -1) delObj.push(doc.rows[i].value._id);
-                        count++;
+                    // add non-duplicates to the list
+                    const newObjs = doc.rows
+                        .map(row => row.value._id)
+                        .filter(id => delObj.indexOf(id) === -1)
+                    ;
+                    delObj.push.apply(delObj, newObjs);
+                    if (newObjs.length > 0) {
+                        console.log(`host.${hostname} Counted ${newObjs.length} instances of ${adapter}`);
                     }
-                    if (count) console.log('host.' + hostname + ' Counted ' + count + ' instances of ' + adapter);
                 }
-            }
-            if (!--taskCnt) delStatesAndObjects();
-        });
-
-        taskCnt++;
-        objects.getObjectView('system', 'meta', {startkey: adapter + '.meta', endkey: adapter + '.meta\u9999'}, function (err, doc) {
-            if (err) {
+            }).catch(err => {
                 if (err !== 'Not exists') console.error('host.' + hostname + ' error: ' + err);
-            } else {
+            })
+        }
+
+        function enumerateMeta() {
+            return getObjectViewAsync('system', 'meta', {startkey: adapter + '.meta', endkey: adapter + '.meta\u9999'}).then(doc => {
                 if (doc.rows.length !== 0) {
-                    for (var i = 0; i < doc.rows.length; i++) {
-                        if (delObj.indexOf(doc.rows[i].value._id) === -1) delObj.push(doc.rows[i].value._id);
+                    // add non-duplicates to the list
+                    const newObjs = doc.rows
+                        .map(row => row.value._id)
+                        .filter(id => delObj.indexOf(id) === -1)
+                    ;
+                    delObj.push.apply(delObj, newObjs);
+                    if (newObjs.length > 0) {
+                        console.log(`host.${hostname} Counted ${newObjs.length} meta of ${adapter}`);
                     }
-                    console.log('host.' + hostname + ' Counted ' + doc.rows.length + ' meta of ' + adapter);
                 }
-            }
-            if (!--taskCnt) delStatesAndObjects();
-        });
-
-        taskCnt++;
-        objects.getObjectView('system', 'adapter', {startkey: 'system.adapter.' + adapter, endkey: 'system.adapter.' + adapter + '\u9999'}, function (err, doc) {
-            if (err) {
+            }).catch(err => {
                 if (err !== 'Not exists') console.error('host.' + hostname + ' error: ' + err);
-            } else {
+            })
+        }
+
+        const enumerateAdapters = tools.poorMansAsync(function*() {
+            try {
+                const doc = yield getObjectViewAsync('system', 'adapter', {startkey: 'system.adapter.' + adapter, endkey: 'system.adapter.' + adapter + '\u9999'})
                 if (doc.rows.length !== 0) {
-                    var count = 0;
-
-                    for (var i = 0; i < doc.rows.length; i++) {
-                        var adapterConf = doc.rows[i].value;
-
-                        if (adapterConf.common.nondeletable) {
-                            console.log('host.' + hostname + ' Adapter ' + adapter + ' cannot be deleted completely, because non-deletable.');
-                            resultCode = 22;
-                            taskCnt++;
-                            objects.getObject(adapterConf._id, function (err, oldObj) {
-                                if (err) console.error(err);
+                    // change nondeletable adapters
+                    const nondeletable = doc.rows.filter(row => row.value.common.nondeletable);
+                    if (nondeletable.length > 0) {
+                        console.log('host.' + hostname + ' Adapter ' + adapter + ' cannot be deleted completely, because non-deletable.');
+                        resultCode = 22;
+                        for (const row of nondeletable) {
+                            const adapterConf = row.value;
+                            try {
+                                let oldObj = yield getObjectAsync(adapterConf._id);
                                 if (oldObj) {
                                     oldObj = extend(true, oldObj, {installedVersion: ''});
                                 } else {
@@ -1044,222 +1064,210 @@ function Install(options) {
                                 }
                                 oldObj.from = 'system.host.' + tools.getHostName() + '.cli';
                                 oldObj.ts = new Date().getTime();
-                                objects.setObject(adapterConf._id, oldObj, function () {
-                                    taskCnt--;
-                                    if (!taskCnt) delStatesAndObjects();
-                                });
-                            });
-
-                            continue;
-                        }
-
-                        if (delObj.indexOf(adapterConf._id) === -1) delObj.push(adapterConf._id);
-
-                        objects.delObject(adapterConf._id);
-                        count++;
-
-                        // Delete adapter folder
-                        if (!adapterConf.common.noRepository) {
-                            if (fs.existsSync(__dirname + '/../../node_modules/' + tools.appName + '.' + adapter)) {
-                                console.log('host.' + hostname + ' delete ' + __dirname + '/../../node_modules/' + tools.appName + '.' + adapter);
-                                tools.rmdirRecursiveSync(__dirname + '/../../node_modules/' + tools.appName + '.' + adapter);
-                            }
-                            if (fs.existsSync(__dirname + '/../../../../node_modules/' + tools.appName + '.js-controller') &&
-                                fs.existsSync(__dirname + '/../../../../node_modules/' + tools.appName + '.' + adapter)) {
-                                console.log('host.' + hostname + ' delete ' + __dirname + '/../../../' + tools.appName + '.' + adapter);
-                                tools.rmdirRecursiveSync(__dirname + '/../../../' + tools.appName + '.' + adapter);
+                                yield setObjectAsync(adapterConf._id, oldObj);
+                            } catch (e) {
+                                console.error(e);
                             }
                         }
                     }
-                    if (count) console.log('host.' + hostname + ' Counted ' + count + ' adapters for ' + adapter);
-                }
-            }
-            if (!--taskCnt) delStatesAndObjects();
-        });
 
-        // Delete devices
-        taskCnt++;
-        objects.getObjectView('system', 'device', {}, function (err, doc) {
-            if (err) {
-                if (err !== 'Not exists') console.error('host.' + hostname + ' error: ' + err);
-            } else {
-                if (doc.rows.length !== 0) {
-                    var count = 0;
-                    for (var i = 0; i < doc.rows.length; i++) {
-                        if (adapterRegex.test(doc.rows[i].value._id)) {
-                            if (delObj.indexOf(doc.rows[i].value._id) === -1) delObj.push(doc.rows[i].value._id);
-                            count++;
+                    // remember deletable adapters
+                    const deletable = doc.rows.filter(row => !row.value.common.nondeletable);
+                    if (deletable.length > 0) {
+                        // add non-duplicates to the list
+                        const newObjs = deletable
+                            .map(row => row.value._id)
+                            .filter(id => delObj.indexOf(id) === -1)
+                        ;
+                        delObj.push.apply(delObj, newObjs);
+                        if (newObjs.length > 0) {
+                            console.log(`host.${hostname} Counted ${newObjs.length} adapters for ${adapter}`);
                         }
                     }
-                    if (count) console.log('host.' + hostname + ' Counted ' + count + ' devices of ' + adapter);
                 }
+            } catch (e) {
+                if (e.message !== 'Not exists') console.error('host.' + hostname + ' error: ' + e);
             }
-            if (!--taskCnt) delStatesAndObjects();
         });
 
-        // Delete channels
-        taskCnt++;
-        objects.getObjectView('system', 'channel', {}, function (err, doc) {
-            if (err) {
-                if (err !== 'Not exists') console.error('host.' + hostname + ' error: ' + err);
-            } else {
+        function enumerateDevices() {
+            return getObjectViewAsync('system', 'device', {}, null).then(doc => {
                 if (doc.rows.length !== 0) {
-                    var count = 0;
-                    for (var i = 0; i < doc.rows.length; i++) {
-                        if (adapterRegex.test(doc.rows[i].value._id)) {
-                            if (delObj.indexOf(doc.rows[i].value._id) === -1) delObj.push(doc.rows[i].value._id);
-                            count++;
+                    // add non-duplicates to the list
+                    const newObjs = doc.rows
+                        .map(row => row.value._id)
+                        .filter(id => adapterRegex.test(id))
+                        .filter(id => delObj.indexOf(id) === -1)
+                    ;
+                    delObj.push.apply(delObj, newObjs);
+                    if (newObjs.length > 0) {
+                        console.log(`host.${hostname} Counted ${newObjs.length} devices of ${adapter}`);
+                    }
+                }
+            }).catch(err => {
+                if (err !== 'Not exists') console.error('host.' + hostname + ' error: ' + err);
+            })
+        }
+
+        function enumerateChannels() {
+            return getObjectViewAsync('system', 'channel', {}, null).then(doc => {
+                if (doc.rows.length !== 0) {
+                    // add non-duplicates to the list
+                    const newObjs = doc.rows
+                        .map(row => row.value._id)
+                        .filter(id => adapterRegex.test(id))
+                        .filter(id => delObj.indexOf(id) === -1)
+                    ;
+                    delObj.push.apply(delObj, newObjs);
+                    if (newObjs.length > 0) {
+                        console.log(`host.${hostname} Counted ${newObjs.length} channels of ${adapter}`);
+                    }
+                }
+            }).catch(err => {
+                if (err !== 'Not exists') console.error('host.' + hostname + ' error: ' + err);
+            })
+        }
+
+        function enumerateStateObjects() {
+            return getObjectViewAsync('system', 'state', {}, null).then(doc => {
+                if (doc.rows.length !== 0) {
+                    // add non-duplicates to the list
+                    const newObjs = doc.rows
+                        .map(row => row.value._id)
+                        .filter(id => adapterRegex.test(id) || sysAdapterRegex.test(id))
+                        .filter(id => delObj.indexOf(id) === -1)
+                    ;
+                    delObj.push.apply(delObj, newObjs);
+                    if (newObjs.length > 0) {
+                        console.log(`host.${hostname} Counted ${newObjs.length} states of ${adapter}`);
+                    }
+                }
+            }).catch(err => {
+                if (err !== 'Not exists') console.error('host.' + hostname + ' error: ' + err);
+            })
+        }
+
+        const enumerateStates = tools.poorMansAsync(function* () {
+            for (const pattern of [
+                `io.${adapter}.*`,
+                `messagebox.${adapter}.*`,
+                `log.${adapter}.*`,
+                `${adapter}.*`,
+                `system.adapter.${adapter}.*`
+            ]) {
+                try {
+                    const ids = yield getKeysAsync(pattern);
+                    if (ids && ids.length) {
+                        // add non-duplicates to the list
+                        const newStates = ids
+                            .filter(id => delState.indexOf(id) === -1)
+                            ;
+                        delState.push.apply(delState, newStates);
+                        if (newStates.length > 0) {
+                            console.log(`host.${hostname} Counted ${newStates.length} states (${pattern}) from states`);
                         }
                     }
-                    if (count) console.log('host.' + hostname + ' Counted ' + count + ' channels of ' + adapter);
+                } catch (e) {
+                    console.error(e);
                 }
             }
-            if (!--taskCnt) delStatesAndObjects();
         });
 
-        // Delete states
-        taskCnt++;
-        objects.getObjectView('system', 'state', {}, function (err, doc) {
-            if (err) {
-                if (err !== 'Not exists') console.error('host.' + hostname + ' error: ' + err);
-            } else {
-                if (doc.rows.length !== 0) {
-                    var count = 0;
-
-                    for (var i = 0; i < doc.rows.length; i++) {
-                        if (adapterRegex.test(doc.rows[i].value._id) || sysAdapterRegex.test(doc.rows[i].value._id)) {
-                            if (delObj.indexOf(doc.rows[i].value._id) === -1) delObj.push(doc.rows[i].value._id);
-                            count++;
-                        }
-                    }
-                    if (count) console.log('host.' + hostname + ' Counted ' + count + ' states of ' + adapter);
+        // delete WWW pages and objects
+        const deleteWWW = tools.poorMansAsync(function* () {
+            for (const file of [
+                adapter, adapter + '.admin'
+            ]) {
+                try {
+                    yield unlinkAsync(file, '');
+                } catch (e) {
+                    if (e.message !== 'Not exists') console.error(`Cannot delete ${file} files folder: ${e}`);
                 }
             }
-            if (!--taskCnt) delStatesAndObjects();
-        });
 
-        // Delete WWW pages
-        taskCnt++;
-        objects.delObject(adapter, function (err, obj, id) {
-            if (err) {
-                if (err !== 'Not exists') console.error('host.' + hostname + ' error: ' + err);
-            } else {
-                if (obj) console.log('host.' + hostname + ' object ' + adapter + ' deleted');
-            }
-            if (!--taskCnt) delStatesAndObjects();
-        });
-
-        // Delete WWW/admin pages
-        taskCnt++;
-        objects.delObject(adapter + '.admin', function (err, obj, id) {
-            if (err) {
-                if (err !== 'Not exists') console.error('host.' + hostname + ' error: ' + err);
-            } else {
-                if (obj) console.log('host.' + hostname + ' object ' + adapter + '.admin deleted');
-            }
-            if (!--taskCnt) delStatesAndObjects();
-        });
-
-        taskCnt++;
-        states.getKeys('io.' + adapter + '.*', function (err, obj) {
-            if (err) console.error(err);
-            if (obj) {
-                for (var i = 0; i < obj.length; i++) {
-                    if (delState.indexOf(obj[i]) === -1) delState.push(obj[i]);
+            for (const objId of [
+                adapter, adapter + '.admin'
+            ]) {
+                try {
+                    const obj = yield delObjectAsync(objId);
+                    if (obj) console.log(`host.${hostname} object ${objId} deleted`);
+                } catch (e) {
+                    if (e.message !== 'Not exists') console.error('host.' + hostname + ' error: ' + e);
                 }
-                if (obj.length) console.log('host.' + hostname + ' Counted ' + obj.length + ' states (io.' + adapter + '.*) from states');
             }
-            if (!--taskCnt) delStatesAndObjects();
         });
 
-        taskCnt++;
-        states.getKeys('messagebox.' + adapter + '.*', function (err, obj) {
-            if (obj) {
-                for (var i = 0; i < obj.length; i++) {
-                    if (delState.indexOf(obj[i]) === -1) delState.push(obj[i]);
+        const deleteStates = tools.poorMansAsync(function*() {
+            if (delState.length > 1000) {
+                console.log('host.' + hostname + ' Deleting ' + delState.length + ' state(s). Be patient...');
+            } else if (delObj.length) {
+                console.log('host.' + hostname + ' Deleting ' + delState.length + ' state(s).');
+            }
+
+            while (delState.length > 0) {
+                if (delState.length % 200 === 0) {
+                    // write progress report
+                    console.log(`host.${hostname}: Only ${delState.length} states left to be deleted.`);
                 }
-                if (obj.length) console.log('host.' + hostname + ' Counted ' + obj.length + ' states (' + adapter + '.*) from states');
-            }
-            if (!--taskCnt) delStatesAndObjects();
-        });
-
-        taskCnt++;
-        states.getKeys('log.' + adapter + '.*', function (err, obj) {
-            if (obj) {
-                for (var i = 0; i < obj.length; i++) {
-                    if (delState.indexOf(obj[i]) === -1) delState.push(obj[i]);
+                // try to delete the current state
+                try {
+                    yield delStateAsync(delState.pop());
+                } catch (e) { // yep that works!
+                    if (e.message !== 'Not exists') console.error(e);
                 }
-                if (obj.length) console.log('host.' + hostname + ' Counted ' + obj.length + ' states (' + adapter + '.*) from states');
             }
-            if (!--taskCnt) delStatesAndObjects();
         });
 
-        taskCnt++;
-        states.getKeys(adapter + '.*', function (err, obj) {
-            if (obj) {
-                for (var i = 0; i < obj.length; i++) {
-                    if (delState.indexOf(obj[i]) === -1) delState.push(obj[i]);
+        const deleteObjects = tools.poorMansAsync(function*() {
+            if (delObj.length > 1000) {
+                console.log('host.' + hostname + ' Deleting ' + delObj.length + ' object(s). Be patient...');
+            } else if (delObj.length) {
+                console.log('host.' + hostname + ' Deleting ' + delObj.length + ' object(s).');
+            }
+
+            while (delObj.length > 0) {
+                if (delObj.length % 200 === 0) {
+                    // write progress report
+                    console.log(`host.${hostname}: Only ${delObj.length} objects left to be deleted.`);
                 }
-                if (obj.length) console.log('host.' + hostname + ' Counted ' + obj.length + ' states (' + adapter + '.*) from states');
-            }
-            if (!--taskCnt) delStatesAndObjects();
-        });
-
-        taskCnt++;
-        states.getKeys('system.adapter.' + adapter + '.*', function (err, obj) {
-            if (obj) {
-                for (var i = 0; i < obj.length; i++) {
-                    if (delState.indexOf(obj[i]) === -1) delState.push(obj[i]);
+                // try to delete the current state
+                try {
+                    yield delObjectAsync(delObj.pop());
+                } catch (e) {
+                    if (e.message !== 'Not exists') console.error('host.' + hostname + ' error: ' + e);
                 }
-                if (obj.length) console.log('host.' + hostname + ' Counted ' + obj.length + ' states (system.adapter.' + adapter + '.*) from states');
             }
-
-            if (!--taskCnt) delStatesAndObjects();
         });
 
-        taskCnt++;
-        objects.unlink(adapter, '', function (err) {
-            if (err && err !== 'Not exists') console.error('Cannot delete adapter files folder: ' + err);
-            if (!--taskCnt) delStatesAndObjects();
+        const uninstall = tools.poorMansAsync(function*() {
+            try {
+                // find the adapter's io-package.json
+                const adapterNpm = `${tools.appName}.${adapter}`;
+                const ioPack = require(`${adapterNpm}/io-package.json`); // yep, it's that easy
+                if (!ioPack.common || !ioPack.common.nondeletable) {
+                    yield npmUninstallAsync(adapterNpm, null, false);
+                }
+            } catch (e) {
+                console.error(`Error deleting adapter ${adapter} from disk: ${e}`);
+                console.error(`You might have to delete it yourself!`);
+            }
         });
 
-        taskCnt++;
-        objects.unlink(adapter + '.admin', '', function (err) {
-            if (err && err !== 'Not exists') console.error('Cannot delete adapter.admin files folder: ' + err);
-            if (!--taskCnt) delStatesAndObjects();
-        });
+        enumerateInstances()
+            .then(enumerateMeta)
+            .then(enumerateAdapters)
+            .then(enumerateDevices)
+            .then(enumerateChannels)
+            .then(enumerateStateObjects)
+            .then(enumerateStates)
+            .then(deleteWWW)
+            .then(deleteObjects)
+            .then(deleteStates)
+            .then(uninstall)
+            .catch(err => console.error(`There was an error uninstalling ${adapter}: ${err}`))
+            .then(() => callback(adapter, resultCode))
+        ;
 
-        if (!taskCnt) delStatesAndObjects();
-
-        // todo: npm remove ' + tools.appName + '.' + adapter because of npm5
-
-        try {
-            var dir   = require.resolve(tools.appName + '.' + adapter + '/package.json');
-            var pack1 = require(path.join(path.dirname(dir), 'io-package.json'));
-            if (!pack1.common || !pack1.common.nondeletable) {
-                console.log('host.' + hostname + ' delete ' + path.normalize(path.dirname(dir)));
-                tools.rmdirRecursiveSync(path.normalize(path.dirname(dir)));
-            }
-        } catch (e) {
-            // ignore
-        }
-
-        // Delete physically adapter from disk
-        if (fs.existsSync(__dirname + '/../../node_modules/' + tools.appName + '.' + adapter + '/io-package.json')) {
-            var _pack = require(__dirname + '/../../node_modules/' + tools.appName + '.' + adapter + '/io-package.json');
-            if (!_pack.common || !_pack.common.nondeletable) {
-                console.log('host.' + hostname + ' delete ' + path.normalize(__dirname + '/../../node_modules/' + tools.appName + '.' + adapter));
-                tools.rmdirRecursiveSync(__dirname + '/../../node_modules/' + tools.appName + '.' + adapter);
-            }
-        }
-        if (fs.existsSync(__dirname + '/../../../../node_modules/' + tools.appName + '.js-controller') &&
-            fs.existsSync(__dirname + '/../../../../node_modules/' + tools.appName + '.' + adapter + '/io-package.json')) {
-            var __pack = require(__dirname + '/../../../' + tools.appName + '.' + adapter + '/io-package.json');
-            if (!__pack.common || !__pack.common.nondeletable) {
-                console.log('host.' + hostname + ' delete ' + path.normalize(__dirname + '/../../../' + tools.appName + '.' + adapter));
-                tools.rmdirRecursiveSync(__dirname + '/../../../' + tools.appName + '.' + adapter);
-            }
-        }
     };
 
     this.deleteInstance = function (adapter, instance, callback) {

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -1009,6 +1009,46 @@ function promiseSequence(promiseFactories) {
     }, Promise.resolve([]));
 }
 
+/**
+ * Poor man's async/await using generator functions. Turns a generator function into a promise returning function.
+ * yield equals await.
+ * @template TReturn
+ * @param {(...args: any[]) => IterableIterator<TReturn>} makeGenerator A generator function to sequentially execute.
+ * @returns {(...args: any[]) => Promise<TReturn>}
+ */
+function poorMansAsync(makeGenerator) {
+    return function () {
+        var generator = makeGenerator.apply(this, arguments);
+
+        function handle(result) {
+            // result => { done: [Boolean], value: [Object] }
+            if (result.done) return Promise.resolve(result.value);
+
+            return Promise.resolve(result.value).then(function (res) {
+                return handle(generator.next(res));
+            }, function (err) {
+                if (typeof err === "string") err = new Error(err);
+                return handle(generator.throw(err));
+            });
+        }
+
+        try {
+            return handle(generator.next());
+        } catch (ex) {
+            return Promise.reject(ex);
+        }
+    }
+}
+// // Example usage:
+// function *test(a, b, c) {
+//     yield somethingAsyncThatReturnsAPromise(a);
+//     // write progress report
+//     yield somethingElseThatReturnsAPromise(b);
+//     // white progress report
+//     yield c;
+// }
+// var testAsync = gen2Async(test);
+// testAsync(1,2,3).then(() => /* we're done */ );
 
 let packageLockDisabled = false;
 /**
@@ -1040,6 +1080,7 @@ module.exports = {
     disablePackageLock,
     encryptPhrase,
     findIPs,
+    poorMansAsync,
     getAdapterDir,
     getConfigFileName,
     getDefaultDataDir,


### PR DESCRIPTION
Fixes: #176 

I also took the opportunity to massively rework the `deleteAdapter` method itself to use Promises and generators for a control flow that is easier to understand.
Once we have confirmed this has no issues (I found none), I'm going to apply this to `deleteInstance` aswell.

The promisified functions should be moved into `States` and `Objects` at some point (like we did with the `Adapter` class).

---
Some background on the new stuff you're seeing:
```js
tools.poorMansAsync(function*() {
    yield something();
});
```
is basically equal to (but supported in NodeJS 4.x!)
```js
async function() {
    await something();
}
```
where `something()` is a promise-returning function. That way we can enumerate the states asynchronically in a `while` loop without creating a loop through calling the function itself:
```js
            while (delState.length > 0) {
                if (delState.length % 200 === 0) {
                    // write progress report
                    console.log(`host.${hostname}: Only ${delState.length} states left to be deleted.`);
                }
                // try to delete the current state
                try {
                    yield delStateAsync(delState.pop());
                } catch (e) { // yep that works!
                    if (e.message !== 'Not exists') console.error(e);
                }
            }
```
Once NodeJS 8 is the minimum, we can replace this with real `async` functions.