### PR TITLE
Refactored `deleteAdapter` so `deleteInstance` can use the same logic

### DIFF
--- a/lib/setup/setupInstall.js
+++ b/lib/setup/setupInstall.js
@@ -32,6 +32,23 @@ function Install(options) {
     var params            = options.params || {};
     var mime;
 
+    // TODO: promisify States and Objects at some point
+    /** @type {(stateId: string) => Promise<void>} */
+    const delStateAsync = tools.promisify(states.delState, states);
+    /** @type {(objId: string) => Promise<void>} */
+    const delObjectAsync = tools.promisify(objects.delObject, objects);
+    /** @type {(id: string, name: string) => Promise<void>} */
+    const unlinkAsync = tools.promisify(objects.unlink, objects);
+    /** @type {(design: string, search: string, params: any, options?: any) => Promise<{rows: {id: string, value: any}[]}>} */
+    const getObjectViewAsync = tools.promisify(objects.getObjectView, objects);
+    /** @type {(objId: string) => Promise<any>} */
+    const getObjectAsync = tools.promisify(objects.getObject, objects);
+    /** @type {(objId: string, newObj: any) => Promise<void>} */
+    const setObjectAsync = tools.promisify(objects.setObject, objects);
+    /** @type {(pattern: string) => Promise<string[]>} */
+    const getKeysAsync = tools.promisify(states.getKeys, states);
+
+
     var installCount      = 0;
 
     var Upload = require(__dirname + '/setupUpload.js');
@@ -412,6 +429,8 @@ function Install(options) {
             });
         });
     };
+    /** @type {(packageName: string, options: any, debug: boolean) => Promise<void>} */
+    this.npmUninstallAsync = tools.promisify(this.npmUninstall, this);
 
     this.uploadStaticObjects = function (adapter, adapterConf, callback) {
         if (typeof adapterConf === 'function') {
@@ -987,25 +1006,6 @@ function Install(options) {
         var adapterRegex    = new RegExp('^' + adapter);
         var sysAdapterRegex = new RegExp('^system\\.adapter\\.' + adapter);
 
-        // create promise-wrappers for delState and delObject
-        // TODO: promisify States and Objects at some point
-        /** @type {(stateId: string) => Promise<void>} */
-        const delStateAsync = tools.promisify(states.delState, states);
-        /** @type {(objId: string) => Promise<void>} */
-        const delObjectAsync = tools.promisify(objects.delObject, objects);
-        /** @type {(id: string, name: string) => Promise<void>} */
-        const unlinkAsync = tools.promisify(objects.unlink, objects);
-        /** @type {(packageName: string, options: any, debug: boolean) => Promise<void>} */
-        const npmUninstallAsync = tools.promisify(that.npmUninstall, that);
-        /** @type {(design: string, search: string, params: any, options?: any) => Promise<{rows: {id: string, value: any}[]}>} */
-        const getObjectViewAsync = tools.promisify(objects.getObjectView, objects);
-        /** @type {(objId: string) => Promise<any>} */
-        const getObjectAsync = tools.promisify(objects.getObject, objects);
-        /** @type {(objId: string, newObj: any) => Promise<void>} */
-        const setObjectAsync = tools.promisify(objects.setObject, objects);
-        /** @type {(pattern: string) => Promise<string[]>} */
-        const getKeysAsync = tools.promisify(states.getKeys, states);
-
         function enumerateInstances() {
             return getObjectViewAsync('system', 'instance', {startkey: 'system.adapter.' + adapter, endkey: 'system.adapter.' + adapter + '\u9999'}, null).then(doc => {
                 if (doc.rows.length === 0) {
@@ -1245,7 +1245,7 @@ function Install(options) {
                 const adapterNpm = `${tools.appName}.${adapter}`;
                 const ioPack = require(`${adapterNpm}/io-package.json`); // yep, it's that easy
                 if (!ioPack.common || !ioPack.common.nondeletable) {
-                    yield npmUninstallAsync(adapterNpm, null, false);
+                    yield that.npmUninstallAsync(adapterNpm, null, false);
                 }
             } catch (e) {
                 console.error(`Error deleting adapter ${adapter} from disk: ${e}`);

--- a/lib/setup/setupInstall.js
+++ b/lib/setup/setupInstall.js
@@ -4,7 +4,7 @@
 
 function Install(options) {
     var fs       = require('fs');
-    var tools    = require(__dirname + '/../tools.js');
+    var tools    = require('../tools.js');
     var extend   = require('node.extend');
     var hostname = tools.getHostName();
     var path     = require('path');
@@ -14,6 +14,7 @@ function Install(options) {
     var unsafePermAlways = [tools.appName.toLowerCase() + '.zwave'];
     var JSZip;
 
+    /** @type {Install} */
     var that = this;
 
     options = options || {};
@@ -41,6 +42,8 @@ function Install(options) {
     const unlinkAsync = tools.promisify(objects.unlink, objects);
     /** @type {(design: string, search: string, params: any, options?: any) => Promise<{rows: {id: string, value: any}[]}>} */
     const getObjectViewAsync = tools.promisify(objects.getObjectView, objects);
+    /** @type {(params: any | null) => Promise<{rows: {id: string, value: any}[]}>} */
+    const getObjectListAsync = tools.promisify(objects.getObjectList, objects);
     /** @type {(objId: string) => Promise<any>} */
     const getObjectAsync = tools.promisify(objects.getObject, objects);
     /** @type {(objId: string, newObj: any) => Promise<void>} */
@@ -998,248 +1001,339 @@ function Install(options) {
         });
     };
 
-    this.deleteAdapter = function (adapter, callback) {
-        var delObj          = [];
-        var delState        = [];
-        var taskCnt         = 0;
-        var resultCode      = 0;
-        var adapterRegex    = new RegExp('^' + adapter);
-        var sysAdapterRegex = new RegExp('^system\\.adapter\\.' + adapter);
+    /**
+     * Enumerate all instances of an adapter
+     * @type {(knownObjIDs: string[], adapter: string, instance: string) => Promise<void>}
+     */
+    this.enumerateAdapterInstances = function enumerateInstances(knownObjIDs, adapter, instance) {
+        const startkey = instance ?
+            'system.adapter.' + adapter + '.' + instance :
+            'system.adapter.' + adapter;
+        const endkey = instance ?
+            'system.adapter.' + adapter + '.' + instance :
+            'system.adapter.' + adapter + '\u9999';
 
-        function enumerateInstances() {
-            return getObjectViewAsync('system', 'instance', {startkey: 'system.adapter.' + adapter, endkey: 'system.adapter.' + adapter + '\u9999'}, null).then(doc => {
-                if (doc.rows.length === 0) {
-                    console.log('host.' + hostname + ' no instances of adapter ' + adapter + ' found');
-                } else {
-                    // add non-duplicates to the list
-                    const newObjs = doc.rows
-                        .map(row => row.value._id)
-                        .filter(id => delObj.indexOf(id) === -1)
-                    ;
-                    delObj.push.apply(delObj, newObjs);
-                    if (newObjs.length > 0) {
-                        console.log(`host.${hostname} Counted ${newObjs.length} instances of ${adapter}`);
-                    }
+        return getObjectViewAsync('system', 'instance', {startkey, endkey}, null).then(doc => {
+            if (doc.rows.length === 0) {
+                console.log('host.' + hostname + ' no instances of adapter ' + adapter + ' found');
+            } else {
+                // add non-duplicates to the list
+                const newObjs = doc.rows
+                    .filter(row => row && row.value && row.value._id)
+                    .map(row => row.value._id)
+                    .filter(id => knownObjIDs.indexOf(id) === -1)
+                ;
+                knownObjIDs.push.apply(knownObjIDs, newObjs);
+                if (newObjs.length > 0) {
+                    console.log(`host.${hostname} Counted ${newObjs.length} instances of ${adapter}`);
                 }
-            }).catch(err => {
-                if (err !== 'Not exists') console.error('host.' + hostname + ' error: ' + err);
-            })
-        }
+            }
+        }).catch(err => {
+            if (err !== 'Not exists') console.error('host.' + hostname + ' error: ' + err);
+        })
+    }
 
-        function enumerateMeta() {
-            return getObjectViewAsync('system', 'meta', {startkey: adapter + '.meta', endkey: adapter + '.meta\u9999'}).then(doc => {
-                if (doc.rows.length !== 0) {
-                    // add non-duplicates to the list
-                    const newObjs = doc.rows
-                        .map(row => row.value._id)
-                        .filter(id => delObj.indexOf(id) === -1)
-                    ;
-                    delObj.push.apply(delObj, newObjs);
-                    if (newObjs.length > 0) {
-                        console.log(`host.${hostname} Counted ${newObjs.length} meta of ${adapter}`);
-                    }
+    /**
+     * Enumerate all meta objects of an adapter
+     * @type {(knownObjIDs: string[], adapter: string) => Promise<void>}
+     */
+    this.enumerateAdapterMeta = function enumerateMeta(knownObjIDs, adapter) {
+        return getObjectViewAsync('system', 'meta', {startkey: adapter + '.meta', endkey: adapter + '.meta\u9999'}).then(doc => {
+            if (doc.rows.length !== 0) {
+                // add non-duplicates to the list
+                const newObjs = doc.rows
+                    .filter(row => row && row.value && row.value._id)
+                    .map(row => row.value._id)
+                    .filter(id => knownObjIDs.indexOf(id) === -1)
+                ;
+                knownObjIDs.push.apply(knownObjIDs, newObjs);
+                if (newObjs.length > 0) {
+                    console.log(`host.${hostname} Counted ${newObjs.length} meta of ${adapter}`);
                 }
-            }).catch(err => {
-                if (err !== 'Not exists') console.error('host.' + hostname + ' error: ' + err);
-            })
-        }
+            }
+        }).catch(err => {
+            if (err !== 'Not exists') console.error('host.' + hostname + ' error: ' + err);
+        })
+    }
 
-        const enumerateAdapters = tools.poorMansAsync(function*() {
-            try {
-                const doc = yield getObjectViewAsync('system', 'adapter', {startkey: 'system.adapter.' + adapter, endkey: 'system.adapter.' + adapter + '\u9999'})
-                if (doc.rows.length !== 0) {
-                    // change nondeletable adapters
-                    const nondeletable = doc.rows.filter(row => row.value.common.nondeletable);
-                    if (nondeletable.length > 0) {
-                        console.log('host.' + hostname + ' Adapter ' + adapter + ' cannot be deleted completely, because non-deletable.');
-                        resultCode = 22;
-                        for (const row of nondeletable) {
-                            const adapterConf = row.value;
-                            try {
-                                let oldObj = yield getObjectAsync(adapterConf._id);
-                                if (oldObj) {
-                                    oldObj = extend(true, oldObj, {installedVersion: ''});
-                                } else {
-                                    oldObj = {installedVersion: ''};
-                                }
-                                oldObj.from = 'system.host.' + tools.getHostName() + '.cli';
-                                oldObj.ts = new Date().getTime();
-                                yield setObjectAsync(adapterConf._id, oldObj);
-                            } catch (e) {
-                                console.error(e);
+    /**
+     * @type {(knownObjIDs: string[], adapter: string) => Promise<number>}
+     * @returns 22 if the adapter could not be deleted, 0 otherwise
+     */
+    this.enumerateAdapters = tools.poorMansAsync(function*(knownObjIDs, adapter) {
+        let resultCode = 0;
+        try {
+            const doc = yield getObjectViewAsync('system', 'adapter', {startkey: 'system.adapter.' + adapter, endkey: 'system.adapter.' + adapter + '\u9999'})
+            if (doc.rows.length !== 0) {
+                // change nondeletable adapters
+                const nondeletable = doc.rows.filter(row => row.value.common.nondeletable);
+                if (nondeletable.length > 0) {
+                    console.log('host.' + hostname + ' Adapter ' + adapter + ' cannot be deleted completely, because non-deletable.');
+                    resultCode = 22;
+                    for (const row of nondeletable) {
+                        const adapterConf = row.value;
+                        try {
+                            let oldObj = yield getObjectAsync(adapterConf._id);
+                            if (oldObj) {
+                                oldObj = extend(true, oldObj, {installedVersion: ''});
+                            } else {
+                                oldObj = {installedVersion: ''};
                             }
+                            oldObj.from = 'system.host.' + tools.getHostName() + '.cli';
+                            oldObj.ts = new Date().getTime();
+                            yield setObjectAsync(adapterConf._id, oldObj);
+                        } catch (e) {
+                            console.error(e);
                         }
                     }
+                }
 
-                    // remember deletable adapters
-                    const deletable = doc.rows.filter(row => !row.value.common.nondeletable);
-                    if (deletable.length > 0) {
-                        // add non-duplicates to the list
-                        const newObjs = deletable
-                            .map(row => row.value._id)
-                            .filter(id => delObj.indexOf(id) === -1)
+                // remember deletable adapters
+                const deletable = doc.rows.filter(row => !row.value.common.nondeletable);
+                if (deletable.length > 0) {
+                    // add non-duplicates to the list
+                    const newObjs = deletable
+                        .map(row => row.value._id)
+                        .filter(id => knownObjIDs.indexOf(id) === -1)
+                    ;
+                    knownObjIDs.push.apply(knownObjIDs, newObjs);
+                    if (newObjs.length > 0) {
+                        console.log(`host.${hostname} Counted ${newObjs.length} adapters for ${adapter}`);
+                    }
+                }
+            }
+        } catch (e) {
+            if (e.message !== 'Not exists') console.error('host.' + hostname + ' error: ' + e);
+        }
+        return resultCode;
+    });
+
+    /**
+     * Enumerates the devices of an adapter (or instance)
+     * @param {string[]} knownObjIDs The already known object ids
+     * @param {string} adapter The adapter to enumerate the devices for
+     * @param {string} [instance] The instance to enumerate the devices for (optional)
+     */
+    this.enumerateAdapterDevices = function enumerateAdapterDevices(knownObjIDs, adapter, instance) {
+        const adapterRegex = new RegExp(`^${adapter}${instance ? `\\.${instance}` : ''}`);
+
+        return getObjectViewAsync('system', 'device', {}, null).then(doc => {
+            if (doc.rows.length !== 0) {
+                // add non-duplicates to the list
+                const newObjs = doc.rows
+                    .filter(row => row && row.value && row.value._id)
+                    .map(row => row.value._id)
+                    .filter(id => adapterRegex.test(id))
+                    .filter(id => knownObjIDs.indexOf(id) === -1)
+                ;
+                knownObjIDs.push.apply(knownObjIDs, newObjs);
+                if (newObjs.length > 0) {
+                    console.log(`host.${hostname} Counted ${newObjs.length} devices of ${adapter}${instance ? `.${instance}` : ''}`);
+                }
+            }
+        }).catch(err => {
+            if (err !== 'Not exists') console.error('host.' + hostname + ' error: ' + err);
+        })
+    }
+
+    /**
+     * Enumerates the channels of an adapter (or instance)
+     * @param {string[]} knownObjIDs The already known object ids
+     * @param {string} adapter The adapter to enumerate the channels for
+     * @param {string} [instance] The instance to enumerate the channels for (optional)
+     */
+    this.enumerateAdapterChannels = function enumerateAdapterChannels(knownObjIDs, adapter, instance) {
+        const adapterRegex = new RegExp(`^${adapter}${instance ? `\\.${instance}` : ''}`);
+
+        return getObjectViewAsync('system', 'channel', {}, null).then(doc => {
+            if (doc.rows.length !== 0) {
+                // add non-duplicates to the list
+                const newObjs = doc.rows
+                    .filter(row => row && row.value && row.value._id)
+                    .map(row => row.value._id)
+                    .filter(id => adapterRegex.test(id))
+                    .filter(id => knownObjIDs.indexOf(id) === -1)
+                ;
+                knownObjIDs.push.apply(knownObjIDs, newObjs);
+                if (newObjs.length > 0) {
+                    console.log(`host.${hostname} Counted ${newObjs.length} channels of ${adapter}${instance ? `.${instance}` : ''}`);
+                }
+            }
+        }).catch(err => {
+            if (err !== 'Not exists') console.error('host.' + hostname + ' error: ' + err);
+        })
+    }
+
+    /**
+     * Enumerates the states of an adapter (or instance)
+     * @param {string[]} knownObjIDs The already known object ids
+     * @param {string} adapter The adapter to enumerate the states for
+     * @param {string} [instance] The instance to enumerate the states for (optional)
+     */
+    this.enumerateAdapterStateObjects = function enumerateAdapterStateObjects(knownObjIDs, adapter, instance) {
+        const adapterRegex = new RegExp(`^${adapter}${instance ? `\\.${instance}` : ''}`);
+        const sysAdapterRegex = new RegExp(`^system\\.adapter\\.${adapter}${instance ? `\\.${instance}` : ''}`);
+
+        return getObjectViewAsync('system', 'state', {}, null).then(doc => {
+            if (doc.rows.length !== 0) {
+                // add non-duplicates to the list
+                const newObjs = doc.rows
+                    .filter(row => row && row.value && row.value._id)
+                    .map(row => row.value._id)
+                    .filter(id => adapterRegex.test(id) || sysAdapterRegex.test(id))
+                    .filter(id => knownObjIDs.indexOf(id) === -1)
+                ;
+                knownObjIDs.push.apply(knownObjIDs, newObjs);
+                if (newObjs.length > 0) {
+                    console.log(`host.${hostname} Counted ${newObjs.length} states of ${adapter}${instance ? `.${instance}` : ''}`);
+                }
+            }
+        }).catch(err => {
+            if (err !== 'Not exists') console.error('host.' + hostname + ' error: ' + err);
+        })
+    }
+
+    // TODO: is enumerateAdapterDocs the correct name???
+    /**
+     * Enumerates the docs of an adapter (or instance)
+     * @param {string[]} knownObjIDs The already known object ids
+     * @param {string} adapter The adapter to enumerate the states for
+     * @param {string} [instance] The instance to enumerate the states for (optional)
+     */
+    this.enumerateAdapterDocs = function enumerateAdapterDocs(knownObjIDs, adapter, instance) {
+        const adapterRegex = new RegExp(`^${adapter}${instance ? `\\.${instance}` : ''}`);
+        const sysAdapterRegex = new RegExp(`^system\\.adapter\\.${adapter}${instance ? `\\.${instance}` : ''}`);
+
+        return getObjectListAsync({include_docs: true}).then(doc => {
+            if (doc.rows.length !== 0) {
+                // add non-duplicates to the list
+                const newObjs = doc.rows
+                    .filter(row => row && row.value && row.value._id)
+                    .map(row => row.value._id)
+                    .filter(id => adapterRegex.test(id) || sysAdapterRegex.test(id))
+                    .filter(id => knownObjIDs.indexOf(id) === -1)
+                ;
+                knownObjIDs.push.apply(knownObjIDs, newObjs);
+                if (newObjs.length > 0) {
+                    console.log(`host.${hostname} Counted ${newObjs.length} objects of ${adapter}${instance ? `.${instance}` : ''}`);
+                }
+            }
+        }).catch(err => {
+            if (err !== 'Not exists') console.error('host.' + hostname + ' error: ' + err);
+        });
+    }
+
+    /**
+     * Enumerate all state IDs of an adapter (or instance)
+     * @type {(knownStateIDs: string[], adapter: string, instance?: string) => Promise<void>}
+     */
+    this.enumerateAdapterStates = tools.poorMansAsync(function* (knownStateIDs, adapter, instance) {
+        for (const pattern of [
+            `io.${adapter}.${instance ? instance + '.' : ''}*`,
+            `messagebox.${adapter}.${instance ? instance + '.' : ''}*`,
+            `log.${adapter}.${instance ? instance + '.' : ''}*`,
+            `${adapter}.${instance ? instance + '.' : ''}*`,
+            `system.adapter.${adapter}.${instance ? instance + '.' : ''}*`
+        ]) {
+            try {
+                const ids = yield getKeysAsync(pattern);
+                if (ids && ids.length) {
+                    // add non-duplicates to the list
+                    const newStates = ids
+                        .filter(id => knownStateIDs.indexOf(id) === -1)
                         ;
-                        delObj.push.apply(delObj, newObjs);
-                        if (newObjs.length > 0) {
-                            console.log(`host.${hostname} Counted ${newObjs.length} adapters for ${adapter}`);
-                        }
+                    knownStateIDs.push.apply(knownStateIDs, newStates);
+                    if (newStates.length > 0) {
+                        console.log(`host.${hostname} Counted ${newStates.length} states (${pattern}) from states`);
                     }
                 }
             } catch (e) {
+                console.error(e);
+            }
+        }
+    });
+
+    /**
+     * delete WWW pages and objects
+     * @type {(adapter: string) => Promise<void>}
+     */
+    this.deleteWWW = tools.poorMansAsync(function* (adapter) {
+        for (const file of [
+            adapter, adapter + '.admin'
+        ]) {
+            try {
+                yield unlinkAsync(file, '');
+            } catch (e) {
+                if (e.message !== 'Not exists') console.error(`Cannot delete ${file} files folder: ${e}`);
+            }
+        }
+
+        for (const objId of [
+            adapter, adapter + '.admin'
+        ]) {
+            try {
+                const obj = yield delObjectAsync(objId);
+                if (obj) console.log(`host.${hostname} object ${objId} deleted`);
+            } catch (e) {
                 if (e.message !== 'Not exists') console.error('host.' + hostname + ' error: ' + e);
             }
-        });
+        }
+    });
 
-        function enumerateDevices() {
-            return getObjectViewAsync('system', 'device', {}, null).then(doc => {
-                if (doc.rows.length !== 0) {
-                    // add non-duplicates to the list
-                    const newObjs = doc.rows
-                        .map(row => row.value._id)
-                        .filter(id => adapterRegex.test(id))
-                        .filter(id => delObj.indexOf(id) === -1)
-                    ;
-                    delObj.push.apply(delObj, newObjs);
-                    if (newObjs.length > 0) {
-                        console.log(`host.${hostname} Counted ${newObjs.length} devices of ${adapter}`);
-                    }
-                }
-            }).catch(err => {
-                if (err !== 'Not exists') console.error('host.' + hostname + ' error: ' + err);
-            })
+    /**
+     * @type {(stateIDs: string[]) => Promise<void>}
+     */
+    this.deleteAdapterStates = tools.poorMansAsync(function*(stateIDs) {
+        if (stateIDs.length > 1000) {
+            console.log('host.' + hostname + ' Deleting ' + stateIDs.length + ' state(s). Be patient...');
+        } else if (stateIDs.length) {
+            console.log('host.' + hostname + ' Deleting ' + stateIDs.length + ' state(s).');
         }
 
-        function enumerateChannels() {
-            return getObjectViewAsync('system', 'channel', {}, null).then(doc => {
-                if (doc.rows.length !== 0) {
-                    // add non-duplicates to the list
-                    const newObjs = doc.rows
-                        .map(row => row.value._id)
-                        .filter(id => adapterRegex.test(id))
-                        .filter(id => delObj.indexOf(id) === -1)
-                    ;
-                    delObj.push.apply(delObj, newObjs);
-                    if (newObjs.length > 0) {
-                        console.log(`host.${hostname} Counted ${newObjs.length} channels of ${adapter}`);
-                    }
-                }
-            }).catch(err => {
-                if (err !== 'Not exists') console.error('host.' + hostname + ' error: ' + err);
-            })
+        while (stateIDs.length > 0) {
+            if (stateIDs.length % 200 === 0) {
+                // write progress report
+                console.log(`host.${hostname}: Only ${stateIDs.length} states left to be deleted.`);
+            }
+            // try to delete the current state
+            try {
+                yield delStateAsync(stateIDs.pop());
+            } catch (e) { // yep that works!
+                if (e.message !== 'Not exists') console.error(e);
+            }
+        }
+    });
+
+    /**
+     * @type {(objIDs: string[]) => Promise<void>}
+     */
+    this.deleteAdapterObjects = tools.poorMansAsync(function*(objIDs) {
+        if (objIDs.length > 1000) {
+            console.log('host.' + hostname + ' Deleting ' + objIDs.length + ' object(s). Be patient...');
+        } else if (objIDs.length) {
+            console.log('host.' + hostname + ' Deleting ' + objIDs.length + ' object(s).');
         }
 
-        function enumerateStateObjects() {
-            return getObjectViewAsync('system', 'state', {}, null).then(doc => {
-                if (doc.rows.length !== 0) {
-                    // add non-duplicates to the list
-                    const newObjs = doc.rows
-                        .map(row => row.value._id)
-                        .filter(id => adapterRegex.test(id) || sysAdapterRegex.test(id))
-                        .filter(id => delObj.indexOf(id) === -1)
-                    ;
-                    delObj.push.apply(delObj, newObjs);
-                    if (newObjs.length > 0) {
-                        console.log(`host.${hostname} Counted ${newObjs.length} states of ${adapter}`);
-                    }
-                }
-            }).catch(err => {
-                if (err !== 'Not exists') console.error('host.' + hostname + ' error: ' + err);
-            })
+        while (objIDs.length > 0) {
+            if (objIDs.length % 200 === 0) {
+                // write progress report
+                console.log(`host.${hostname}: Only ${objIDs.length} objects left to be deleted.`);
+            }
+            // try to delete the current state
+            try {
+                yield delObjectAsync(objIDs.pop());
+            } catch (e) {
+                if (e.message !== 'Not exists') console.error('host.' + hostname + ' error: ' + e);
+            }
         }
+    });
 
-        const enumerateStates = tools.poorMansAsync(function* () {
-            for (const pattern of [
-                `io.${adapter}.*`,
-                `messagebox.${adapter}.*`,
-                `log.${adapter}.*`,
-                `${adapter}.*`,
-                `system.adapter.${adapter}.*`
-            ]) {
-                try {
-                    const ids = yield getKeysAsync(pattern);
-                    if (ids && ids.length) {
-                        // add non-duplicates to the list
-                        const newStates = ids
-                            .filter(id => delState.indexOf(id) === -1)
-                            ;
-                        delState.push.apply(delState, newStates);
-                        if (newStates.length > 0) {
-                            console.log(`host.${hostname} Counted ${newStates.length} states (${pattern}) from states`);
-                        }
-                    }
-                } catch (e) {
-                    console.error(e);
-                }
-            }
-        });
+    this.deleteAdapter = function (adapter, callback) {
+        const knownObjectIDs  = [];
+        const knownStateIDs   = [];
+        let resultCode      = 0;
 
-        // delete WWW pages and objects
-        const deleteWWW = tools.poorMansAsync(function* () {
-            for (const file of [
-                adapter, adapter + '.admin'
-            ]) {
-                try {
-                    yield unlinkAsync(file, '');
-                } catch (e) {
-                    if (e.message !== 'Not exists') console.error(`Cannot delete ${file} files folder: ${e}`);
-                }
-            }
-
-            for (const objId of [
-                adapter, adapter + '.admin'
-            ]) {
-                try {
-                    const obj = yield delObjectAsync(objId);
-                    if (obj) console.log(`host.${hostname} object ${objId} deleted`);
-                } catch (e) {
-                    if (e.message !== 'Not exists') console.error('host.' + hostname + ' error: ' + e);
-                }
-            }
-        });
-
-        const deleteStates = tools.poorMansAsync(function*() {
-            if (delState.length > 1000) {
-                console.log('host.' + hostname + ' Deleting ' + delState.length + ' state(s). Be patient...');
-            } else if (delObj.length) {
-                console.log('host.' + hostname + ' Deleting ' + delState.length + ' state(s).');
-            }
-
-            while (delState.length > 0) {
-                if (delState.length % 200 === 0) {
-                    // write progress report
-                    console.log(`host.${hostname}: Only ${delState.length} states left to be deleted.`);
-                }
-                // try to delete the current state
-                try {
-                    yield delStateAsync(delState.pop());
-                } catch (e) { // yep that works!
-                    if (e.message !== 'Not exists') console.error(e);
-                }
-            }
-        });
-
-        const deleteObjects = tools.poorMansAsync(function*() {
-            if (delObj.length > 1000) {
-                console.log('host.' + hostname + ' Deleting ' + delObj.length + ' object(s). Be patient...');
-            } else if (delObj.length) {
-                console.log('host.' + hostname + ' Deleting ' + delObj.length + ' object(s).');
-            }
-
-            while (delObj.length > 0) {
-                if (delObj.length % 200 === 0) {
-                    // write progress report
-                    console.log(`host.${hostname}: Only ${delObj.length} objects left to be deleted.`);
-                }
-                // try to delete the current state
-                try {
-                    yield delObjectAsync(delObj.pop());
-                } catch (e) {
-                    if (e.message !== 'Not exists') console.error('host.' + hostname + ' error: ' + e);
-                }
-            }
-        });
-
-        const uninstall = tools.poorMansAsync(function*() {
+        const uninstallNpm = tools.poorMansAsync(function*() {
             try {
                 // find the adapter's io-package.json
                 const adapterNpm = `${tools.appName}.${adapter}`;
@@ -1253,17 +1347,17 @@ function Install(options) {
             }
         });
 
-        enumerateInstances()
-            .then(enumerateMeta)
-            .then(enumerateAdapters)
-            .then(enumerateDevices)
-            .then(enumerateChannels)
-            .then(enumerateStateObjects)
-            .then(enumerateStates)
-            .then(deleteWWW)
-            .then(deleteObjects)
-            .then(deleteStates)
-            .then(uninstall)
+        that.enumerateAdapterInstances(knownObjectIDs, adapter)
+            .then(() => that.enumerateAdapterMeta(knownObjectIDs, adapter))
+            .then(() => that.enumerateAdapters(knownObjectIDs, adapter).then(ret => resultCode = ret))
+            .then(() => that.enumerateAdapterDevices(knownObjectIDs, adapter))
+            .then(() => that.enumerateAdapterChannels(knownObjectIDs, adapter))
+            .then(() => that.enumerateAdapterStateObjects(knownObjectIDs, adapter))
+            .then(() => that.enumerateAdapterStates(knownStateIDs, adapter))
+            .then(() => that.deleteWWW(adapter))
+            .then(() => that.deleteAdapterObjects(knownObjectIDs))
+            .then(() => that.deleteAdapterStates(knownStateIDs))
+            .then(uninstallNpm)
             .catch(err => console.error(`There was an error uninstalling ${adapter}: ${err}`))
             .then(() => callback(adapter, resultCode))
         ;
@@ -1271,207 +1365,21 @@ function Install(options) {
     };
 
     this.deleteInstance = function (adapter, instance, callback) {
-        var delObj =   [];
-        var delState = [];
-        var taskCnt =  0;
-        var adapterRegex    = new RegExp('^' + adapter + '\\.' + instance);
-        var sysAdapterRegex = new RegExp('^system\\.adapter\\.' + adapter + '\\.' + instance);
+        const knownObjectIDs  = [];
+        const knownStateIDs   = [];
 
-        function delStates() {
-            if (delState.length && (delState.length % 200) === 0) {
-                console.log('host.' + hostname + ' Only ' + delState.length + ' states left to be deleted.');
-            }
-            if (!delState.length) {
-                if (callback) callback(adapter, instance);
-            } else {
-                states.delState(delState.pop(), function (/* err */) {
-                    setImmediate(delStates);
-                });
-            }
-        }
-        function startDeleteStates() {
-            if (delState.length > 1000) {
-                console.log('host.' + hostname + ' Deleting ' + delState.length + ' state(s). Be patient...');
-            } else if (delObj.length) {
-                console.log('host.' + hostname + ' Deleting ' + delState.length + ' state(s).');
-            }
-            delStates();
-        }
-
-        function delObjects() {
-            if (delObj.length && (delObj.length % 200) === 0) {
-                console.log('host.' + hostname + ' Only ' + delObj.length + ' objects left to be deleted.');
-            }
-            if (!delObj.length) {
-                setTimeout(startDeleteStates, 50);
-            } else {
-                objects.delObject(delObj.pop(), function (/* err */) {
-                    setImmediate(delObjects);
-                });
-            }
-        }
-        function delStatesAndObjects() {
-            if (delObj.length > 1000) {
-                console.log('host.' + hostname + ' Deleting ' + delObj.length + ' object(s). Be patient...');
-            } else if (delObj.length) {
-                console.log('host.' + hostname + ' Deleting ' + delObj.length + ' object(s).');
-            }
-
-            delObjects();
-        }
-
-        // Delete instance
-        taskCnt++;
-        objects.getObjectView('system', "instance", {startkey: 'system.adapter.' + adapter + '.' + instance, endkey: 'system.adapter.' + adapter + '.' + instance}, function (err, doc) {
-            if (err) {
-                if (err !== 'Not exists') console.error('host.' + hostname + ' error: ' + err);
-            } else {
-                if (doc.rows.length === 0) {
-                    console.log('no instances of adapter ' + adapter + '.' + instance + ' found');
-                } else {
-                    for (var i = 0; i < doc.rows.length; i++) {
-                        if (delObj.indexOf(doc.rows[i].value._id) === -1) delObj.push(doc.rows[i].value._id);
-                    }
-                    console.log('host.' + hostname + ' Counted ' + doc.rows.length + ' instances of ' + adapter + '.' + instance);
-                }
-            }
-            if (!--taskCnt) delStatesAndObjects();
-        });
-
-        taskCnt++;
-        objects.getObjectList({include_docs: true}, function (err, doc) {
-            if (err) {
-                if (err !== 'Not exists') console.error('host.' + hostname + ' error: ' + err);
-            } else {
-                if (doc.rows.length !== 0) {
-                    var count = 0;
-                    for (var i = 0; i < doc.rows.length; i++) {
-                        if (doc.rows[i] && doc.rows[i].value && doc.rows[i].value._id &&
-                            (adapterRegex.test(doc.rows[i].value._id) || sysAdapterRegex.test(doc.rows[i].value._id))) {
-                            if (delObj.indexOf(doc.rows[i].value._id) === -1) delObj.push(doc.rows[i].value._id);
-                            count++;
-                        }
-                    }
-                    if (count) console.log('host.' + hostname + ' Counted ' + count + ' objects of ' + adapter + '.' + instance);
-                }
-            }
-            if (!--taskCnt) delStatesAndObjects();
-        });
+        that.enumerateAdapterInstances(knownObjectIDs, adapter, instance)
+            .then(() => that.enumerateAdapterDevices(knownObjectIDs, adapter, instance))
+            .then(() => that.enumerateAdapterChannels(knownObjectIDs, adapter, instance))
+            .then(() => that.enumerateAdapterStateObjects(knownObjectIDs, adapter, instance))
+            .then(() => that.enumerateAdapterStates(knownStateIDs, adapter, instance))
+            .then(() => that.enumerateAdapterDocs(knownObjectIDs, adapter, instance))
+            .then(() => that.deleteAdapterObjects(knownObjectIDs))
+            .then(() => that.deleteAdapterStates(knownStateIDs))
+            .then(() => callback(adapter, instance))
+        ;
 
         // TODO delete meta objects - i think a recursive deletion of all child object would be less effort.
-
-        // Delete devices
-        taskCnt++;
-        objects.getObjectView('system', "device", {}, function (err, doc) {
-            if (err) {
-                if (err !== 'Not exists') console.error('host.' + hostname + ' error: ' + err);
-            } else {
-                if (doc.rows.length !== 0) {
-                    var count = 0;
-                    for (var i = 0; i < doc.rows.length; i++) {
-                        if (doc.rows[i] && doc.rows[i].value && doc.rows[i].value._id &&
-                            (adapterRegex.test(doc.rows[i].value._id) || sysAdapterRegex.test(doc.rows[i].value._id))) {
-                            if (delObj.indexOf(doc.rows[i].value._id) === -1) delObj.push(doc.rows[i].value._id);
-                            count++;
-                        }
-                    }
-                    if (count) console.log('host.' + hostname + ' Counted ' + count + ' devices of ' + adapter + '.' + instance);
-                }
-            }
-            if (!--taskCnt) delStatesAndObjects();
-        });
-
-        // Delete channels
-        taskCnt++;
-        objects.getObjectView('system', "channel", {}, function (err, doc) {
-            if (err) {
-                if (err !== 'Not exists') console.error('host.' + hostname + ' error: ' + err);
-            } else {
-                if (doc.rows.length !== 0) {
-                    var count = 0;
-                    for (var i = 0; i < doc.rows.length; i++) {
-                        if (doc.rows[i] && doc.rows[i].value && doc.rows[i].value._id &&
-                            (adapterRegex.test(doc.rows[i].value._id) || sysAdapterRegex.test(doc.rows[i].value._id))) {
-                            if (delObj.indexOf(doc.rows[i].value._id) === -1) delObj.push(doc.rows[i].value._id);
-                            count++;
-                        }
-                    }
-                    if (count) console.log('host.' + hostname + ' Counted ' + count + ' channels of ' + adapter + '.' + instance);
-                }
-            }
-            if (!--taskCnt) delStatesAndObjects();
-        });
-
-        // Delete states
-        taskCnt++;
-        objects.getObjectView('system', "state", {}, function (err, doc) {
-            if (err) {
-                if (err !== 'Not exists') console.error('host.' + hostname + ' error: ' + err);
-            } else {
-                if (doc.rows.length === 0) {
-                    console.log('host.' + hostname + ' no states ' + adapter + ' found');
-                } else {
-                    var count = 0;
-                    for (var i = 0; i < doc.rows.length; i++) {
-                        if (doc.rows[i] && doc.rows[i].value && doc.rows[i].value._id &&
-                            (adapterRegex.test(doc.rows[i].value._id) || sysAdapterRegex.test(doc.rows[i].value._id))) {
-                            if (delObj.indexOf(doc.rows[i].value._id) === -1) delObj.push(doc.rows[i].value._id);
-                            count++;
-                        }
-                    }
-                    if (count) console.log('host.' + hostname + ' Counted ' + count + ' objects of states of ' + adapter + '.' + instance);
-                }
-            }
-            if (!--taskCnt) delStatesAndObjects();
-        });
-
-        taskCnt++;
-        states.getKeys('system.adapter.' + adapter + '.' + instance + '*', function (err, obj) {
-            for (var i = 0; i < obj.length; i++) {
-                if (delState.indexOf(obj[i]) === -1) delState.push(obj[i]);
-            }
-            if (obj.length) console.log ('host.' + hostname + ' Counted ' + obj.length + ' states "system.adapter.' + adapter + '.' + instance + '*" from states');
-            if (!--taskCnt) delStatesAndObjects();
-        });
-
-        taskCnt++;
-        states.getKeys('io.' + adapter + '.' + instance + '*', function (err, obj) {
-            for (var i = 0; i < obj.length; i++) {
-                if (delState.indexOf(obj[i]) === -1) delState.push(obj[i]);
-            }
-            if (obj.length) console.log ('host.' + hostname + ' Counted ' + obj.length + ' states "io.' + adapter + '.' + instance + '*" from states');
-            if (!--taskCnt) delStatesAndObjects();
-        });
-
-        taskCnt++;
-        states.getKeys('log.' + adapter + '.' + instance + '*', function (err, obj) {
-            for (var i = 0; i < obj.length; i++) {
-                if (delState.indexOf(obj[i]) === -1) delState.push(obj[i]);
-            }
-            if (obj.length) console.log ('host.' + hostname + ' Counted ' + obj.length + ' states "log.' + adapter + '.' + instance + '*" from states');
-            if (!--taskCnt) delStatesAndObjects();
-        });
-
-        taskCnt++;
-        states.getKeys('messagebox.' + adapter + '.' + instance + '*', function (err, obj) {
-            for (var i = 0; i < obj.length; i++) {
-                if (delState.indexOf(obj[i]) === -1) delState.push(obj[i]);
-            }
-            if (obj.length) console.log ('host.' + hostname + ' Counted ' + obj.length + ' states "messagebox.' + adapter + '.' + instance + '*" from states');
-            if (!--taskCnt) delStatesAndObjects();
-        });
-
-        taskCnt++;
-        states.getKeys(adapter + '.' + instance + '*', function (err, obj) {
-            for (var i = 0; i < obj.length; i++) {
-                if (delState.indexOf(obj[i]) === -1) delState.push(obj[i]);
-            }
-            if (obj.length) console.log ('host.' + hostname + ' Counted ' + obj.length + ' states "' + adapter + '.' + instance + '*" from states');
-
-            if (!--taskCnt) delStatesAndObjects();
-        });
-
-        if (!taskCnt) delStatesAndObjects();
     };
 }
 

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -910,8 +910,8 @@ function sliceArgs(argsObj, startIndex) {
 /**
  * Promisifies a function which returns an error as the first argument in its callback
  * @param {Function} fn The function to promisify
- * @param {any} context (optional) The context (value of `this` to bind the function to)
- * @param {string[]} returnArgNames (optional) If the callback contains multiple arguments, 
+ * @param {any} [context=this] (optional) The context (value of `this` to bind the function to)
+ * @param {string[]} [returnArgNames] (optional) If the callback contains multiple arguments, 
  * you can combine them into one object by passing the names as an array. 
  * Otherwise the Promise will resolve with an array
  * @returns {(...args: any[]) => Promise<any>}


### PR DESCRIPTION
Followup to #177 - since that is not merged yet, the first 2 commits are the same.

Deduplicated a lot of the common logic between `deleteAdapter` and `deleteInstance`.