### PR TITLE
Add convenience methods to the adapter class

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -762,7 +762,10 @@ function Adapter(options) {
 
     /**
      * Updates the adapter config with new values. Only a subset of the configuration has to be provided,
-     * since merging with the existing config is done automatically.
+     * since merging with the existing config is done automatically, e.g. like this:
+     * 
+     * `adapter.updateConfig({prop1: "newValue1"})`
+     * 
      * After updating the configuration, the adapter is automatically restarted.
      * 
      * @param {Record<string, any>} newConfig The new config values to be stored

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -760,6 +760,27 @@ function Adapter(options) {
         ;
     }
 
+    /**
+     * Updates the adapter config with new values. Only a subset of the configuration has to be provided,
+     * since merging with the existing config is done automatically.
+     * After updating the configuration, the adapter is automatically restarted.
+     * 
+     * @param {Record<string, any>} newConfig The new config values to be stored
+     */
+    that.updateConfig = function updateConfig(newConfig) {
+        // merge the old and new configuration
+        const config = Object.assign({}, that.config, newConfig);
+        // update the adapter config object
+        const configObjId = `system.adapter.${that.namespace}`;
+        that.getForeignObjectAsync(configObjId)
+            .then(obj => {
+                obj.native = config;
+                return that.setForeignObjectAsync(configObjId, obj);
+            })
+            .catch(err => logger.error(`Updating the adapter config failed: ${err}`))
+        ;
+    }
+
     // Can be later deleted if no more appears
     that.inited = false;
 

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -269,7 +269,7 @@ function Adapter(options) {
     that.getPort = function adapterGetPort(port, callback) {
         if (!port) throw 'adapterGetPort: no port';
 
-        port = parseInt(port, 10);
+        if (typeof port === "string") port = parseInt(port, 10);
         that.getPortRunning = {port: port, callback: callback};
         const server = net.createServer();
         try {
@@ -444,7 +444,7 @@ function Adapter(options) {
      * @alias calculatePermissions
      * @memberof Adapter
      * @param {string} user user name as text
-     * @param {object} commandsPermissions object that describes the access rights like
+     * @param {CommandsPermissions} commandsPermissions object that describes the access rights like
      *     <pre><code>
      *         // static information
      *         var commandsPermissions = {
@@ -745,6 +745,20 @@ function Adapter(options) {
         if (reason) logger.warn('Terminated: ' + reason);
         process.exit(11);
     };
+
+    /**
+     * Restarts an instance of the adapter.
+     * 
+     * @memberof Adapter
+     */
+    that.restart = function restart() {
+        // Restarting an adapter can easily be done by writing the adapter object without changing it
+        const configObjId = `system.adapter.${that.namespace}`;
+        that.getForeignObjectAsync(configObjId)
+            .then(obj => that.setForeignObjectAsync(configObjId, obj))
+            .catch(err => logger.error(`Adapter could not be restarted: ${err}`))
+        ;
+    }
 
     // Can be later deleted if no more appears
     that.inited = false;

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -781,6 +781,21 @@ function Adapter(options) {
         ;
     }
 
+    /**
+     * Disables and stops the adapter instance.
+     */
+    that.disable = function disable() {
+        // update the adapter config object
+        const configObjId = `system.adapter.${that.namespace}`;
+        that.getForeignObjectAsync(configObjId)
+            .then(obj => {
+                obj.common.enabled = false;
+                return that.setForeignObjectAsync(configObjId, obj);
+            })
+            .catch(err => logger.error(`Disabling the adapter instance failed: ${err}`))
+        ;
+    }
+
     // Can be later deleted if no more appears
     that.inited = false;
 


### PR DESCRIPTION
As discussed in #202 this PR adds three methods to the `Adapter` class, so library devs can use those instead of the more complicated constructs editing the `system.adapter.${adapter.namespace}` object.

- `Adapter.restart()` simply restarts the adapter instance
- `Adapter.disable()` stops and disables the adapter instance (like clicking on the pause button in admin)
- `Adapter.updateConfig(newConfig)` updates the adapter config (native part) with new values. Only the changed values have to be provided as an object, merging with the existing properties is done automatically