### PR TITLE
Fix JSDoc comments for some parameters

### DIFF
--- a/lib/tools.js
+++ b/lib/tools.js
@@ -18,8 +18,8 @@ let diskusage;
  * @memberof tools
  * @param {object} oldObj source object
  * @param {object} newObj destination object
- * @param {object} originalObj optional object for read __no_change__ values
- * @param {boolean} isNonEdit optional indicator if copy is in nonEdit part
+ * @param {object} [originalObj] optional object for read __no_change__ values
+ * @param {boolean} [isNonEdit] optional indicator if copy is in nonEdit part
  *
  */
 function copyAttributes(oldObj, newObj, originalObj, isNonEdit) {
@@ -550,7 +550,7 @@ function getInstalledInfo(hostRunningVersion) {
 /**
  * Reads an adapter's npm version
  * @param {string | null} adapter The adapter to read the npm version from. Null for the root ioBroker packet
- * @param {(err: Error | null, version: string) => void} [callback]
+ * @param {(err: Error | null, version?: string) => void} [callback]
  */
 function getNpmVersion(adapter, callback) {
     adapter = adapter ? module.exports.appName + '.' + adapter : module.exports.appName;
@@ -1265,7 +1265,7 @@ function poorMansAsync(makeGenerator) {
 //     // white progress report
 //     yield c;
 // }
-// var testAsync = gen2Async(test);
+// var testAsync = poorMansAsync(test);
 // testAsync(1,2,3).then(() => /* we're done */ );
 
 let packageLockDisabled = false;


### PR DESCRIPTION
This stops VSCode from complaining that some optional parameters haven't
been provided.