### PR TITLE
Change JSDoc params in tools.js so they are marked as optional

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -23,11 +23,11 @@ const fs =                require('fs');
 const extend =            require('node.extend');
 const util =              require('util');
 const EventEmitter =      require('events').EventEmitter;
-const tools =             require(__dirname + '/tools');
+const tools =             require('./tools');
 const getConfigFileName = tools.getConfigFileName;
 let schedule;
 
-const password =          require(__dirname + '/password');
+const password =          require('./password');
 let config =            null;
 let that;
 let defaultObjs;

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -1176,8 +1176,8 @@ function promisify(fn, context, returnArgNames) {
 /**
  * Promisifies a function which does not provide an error as the first argument in its callback
  * @param {Function} fn The function to promisify
- * @param {any} context (optional) The context (value of `this` to bind the function to)
- * @param {string[]} returnArgNames (optional) If the callback contains multiple arguments, 
+ * @param {any} [context] (optional) The context (value of `this` to bind the function to)
+ * @param {string[]} [returnArgNames] (optional) If the callback contains multiple arguments, 
  * you can combine them into one object by passing the names as an array. 
  * Otherwise the Promise will resolve with an array
  * @returns {(...args: any[]) => Promise<any>}


### PR DESCRIPTION
I found this by changing the import in adapter.js to use relative paths ('./tools'). This way, VSCode shows Intellisense for the methods in `tools` and complained that some (actually optional) parameters were not given.