### PR TITLE
Simplify testConsole.js by using async methods

### DIFF
--- a/lib/setup.js
+++ b/lib/setup.js
@@ -15,7 +15,7 @@
 // TODO need info about progress of stopping
 
 const fs    = require('fs');
-const tools = require(__dirname + '/tools');
+const tools = require('./tools');
 
 require('events').EventEmitter.prototype._maxListeners = 100;
 process.setMaxListeners(0);
@@ -3175,6 +3175,10 @@ module.exports.processCommand = function (_objects, _states, command, args, para
     states  = _states;
     processCommand(command, args, params, callback);
 };
+const processCommandAsync = tools.promisifyNoError(module.exports.processCommand);
+module.exports.processCommandAsync = function (_objects, _states, command, args, params) {
+    return processCommandAsync.apply(undefined, arguments)
+}
 
 module.exports.execute = function () {
     // direct call

--- a/test/lib/testConsole.js
+++ b/test/lib/testConsole.js
@@ -484,11 +484,11 @@ function register(it, expect, context) {
         expect(err).to.be.not.ok;
         let obj = yield context.objects.getObjectAsync('system.adapter.vis.0');
         expect(obj.native.license).to.be.equal(licenseText);
-        
+
         // license must be taken
         err = yield setup.processCommandAsync(context.objects, context.states, 'license', [licenseText], {});
         expect(err).to.be.not.ok;
-        obj = context.objects.getObjectAsync('system.adapter.vis.0')
+        obj = yield context.objects.getObjectAsync('system.adapter.vis.0');
         expect(obj.native.license).to.be.equal(licenseText);
     }));
     

--- a/test/lib/testConsole.js
+++ b/test/lib/testConsole.js
@@ -67,280 +67,227 @@ function register(it, expect, context) {
     })).timeout(2000);
 
     // user get
-    it(testName + 'user get', function (done) {
+    it(testName + 'user get', tools.poorMansAsync(function* () {
+        let err;
+
         // check if no args set
-        setup.processCommand(context.objects, context.states, 'user', [], {}, err => {
-            expect(err).to.be.ok;
-            // no user defined
-            setup.processCommand(context.objects, context.states, 'user', ['get'], {}, err => {
-                expect(err).to.be.ok;
-                // check admin
-                setup.processCommand(context.objects, context.states, 'user', ['get', 'admin'], {}, err => {
-                    expect(err).to.be.not.ok;
-                    // check invalid user
-                    setup.processCommand(context.objects, context.states, 'user', ['get', 'aaaa'], {}, err => {
-                        expect(err).to.be.ok;
-                        done();
-                    });
-                });
-            });
-        });
-    });
+        err = yield setup.processCommandAsync(context.objects, context.states, 'user', [], {});
+        expect(err).to.be.ok;
+        // no user defined
+        err = yield setup.processCommandAsync(context.objects, context.states, 'user', ['get'], {});
+        expect(err).to.be.ok;
+        // check admin
+        err = yield setup.processCommandAsync(context.objects, context.states, 'user', ['get', 'admin'], {});
+        expect(err).to.be.not.ok;
+        // check invalid user
+        err = yield setup.processCommandAsync(context.objects, context.states, 'user', ['get', 'aaaa'], {});
+        expect(err).to.be.ok;
+
+    }));
 
     // adduser user add
-    it(testName + 'user add', function (done) {
+    it(testName + 'user add', tools.poorMansAsync(function* () {
+        let err;
         // check if no args set
-        setup.processCommand(context.objects, context.states, 'user', ['add'], {}, err => {
-            expect(err).to.be.ok;
-            // add admin not allowed
-            setup.processCommand(context.objects, context.states, 'user', ['add', 'admin'], {password: 'aaa'}, err => {
-                expect(err).to.be.ok;
-                // add user
-                setup.processCommand(context.objects, context.states, 'user', ['add', 'user'], {ingroup: 'user', password: 'user'}, err => {
-                    expect(err).to.be.not.ok;
-                    // add existing user not allowed
-                    setup.processCommand(context.objects, context.states, 'user', ['add', 'user'], {password: 'user'}, err => {
-                        expect(err).to.be.ok;
-                        // add with invalid group
-                        setup.processCommand(context.objects, context.states, 'user', ['add', 'user1'], {ingroup: 'invalid', password: 'bbb'}, err => {
-                            expect(err).to.be.ok;
-                            // check adduser
-                            setup.processCommand(context.objects, context.states, 'adduser', ['user2'], {ingroup: 'user', password: 'bbb'}, err => {
-                                expect(err).to.be.not.ok;
-                                done();
-                            });
-                        });
-                    });
-                });
-            });
-        });
-    });
+        err = yield setup.processCommandAsync(context.objects, context.states, 'user', ['add'], {});
+        expect(err).to.be.ok;
+        // add admin not allowed
+        err = yield setup.processCommandAsync(context.objects, context.states, 'user', ['add', 'admin'], { password: 'aaa' });
+        expect(err).to.be.ok;
+        // add user
+        err = yield setup.processCommandAsync(context.objects, context.states, 'user', ['add', 'user'], { ingroup: 'user', password: 'user' });
+        expect(err).to.be.not.ok;
+        // add existing user not allowed
+        err = yield setup.processCommandAsync(context.objects, context.states, 'user', ['add', 'user'], { password: 'user' });
+        expect(err).to.be.ok;
+        // add with invalid group
+        err = yield setup.processCommandAsync(context.objects, context.states, 'user', ['add', 'user1'], { ingroup: 'invalid', password: 'bbb' });
+        expect(err).to.be.ok;
+        // check adduser
+        err = yield setup.processCommandAsync(context.objects, context.states, 'adduser', ['user2'], { ingroup: 'user', password: 'bbb' });
+        expect(err).to.be.not.ok;
+    }));
 
     // user disable / enable
-    it(testName + 'user disable/enable', function (done) {
+    it(testName + 'user disable/enable', tools.poorMansAsync(function* () {
+        let err;
         // add second user
-        setup.processCommand(context.objects, context.states, 'user', ['add', 'user1'], {ingroup: 'user', password: ' bbb'}, err => {
-            expect(err).to.be.not.ok;
-            // check if no args set
-            setup.processCommand(context.objects, context.states, 'user', ['enable'], {}, err => {
-                expect(err).to.be.ok;
-                // enable admin
-                setup.processCommand(context.objects, context.states, 'user', ['enable', 'admin'], {}, err => {
-                    expect(err).to.be.not.ok;
-                    // test short command
-                    setup.processCommand(context.objects, context.states, 'user', ['e', 'admin'], {}, err => {
-                        expect(err).to.be.not.ok;
-                        // check invalid user
-                        setup.processCommand(context.objects, context.states, 'user', ['enable', 'aaa'], {}, err => {
-                            expect(err).to.be.ok;
-                            // admin cannot be disabled
-                            setup.processCommand(context.objects, context.states, 'user', ['disable', 'admin'], {}, err => {
-                                expect(err).to.be.ok;
-                                // user can be disabled
-                                setup.processCommand(context.objects, context.states, 'user', ['disable', 'user1'], {}, err => {
-                                    expect(err).to.be.not.ok;
-                                    // user can be disabled
-                                    setup.processCommand(context.objects, context.states, 'user', ['get', 'user1'], {}, err => {
-                                        expect(err).to.be.not.ok;
-                                        done();
-                                    });
-                                });
-                            });
-                        });
-                    });
-                });
-            });
-        });
-    });
+        err = yield setup.processCommandAsync(context.objects, context.states, 'user', ['add', 'user1'], { ingroup: 'user', password: ' bbb' });
+        expect(err).to.be.not.ok;
+        // check if no args set
+        err = yield setup.processCommandAsync(context.objects, context.states, 'user', ['enable'], {});
+        expect(err).to.be.ok;
+        // enable admin
+        err = yield setup.processCommandAsync(context.objects, context.states, 'user', ['enable', 'admin'], {});
+        expect(err).to.be.not.ok;
+        // test short command
+        err = yield setup.processCommandAsync(context.objects, context.states, 'user', ['e', 'admin'], {});
+        expect(err).to.be.not.ok;
+        // check invalid user
+        err = yield setup.processCommandAsync(context.objects, context.states, 'user', ['enable', 'aaa'], {});
+        expect(err).to.be.ok;
+        // admin cannot be disabled
+        err = yield setup.processCommandAsync(context.objects, context.states, 'user', ['disable', 'admin'], {});
+        expect(err).to.be.ok;
+        // user can be disabled
+        err = yield setup.processCommandAsync(context.objects, context.states, 'user', ['disable', 'user1'], {});
+        expect(err).to.be.not.ok;
+        // user can be disabled
+        err = yield setup.processCommandAsync(context.objects, context.states, 'user', ['get', 'user1'], {});
+        expect(err).to.be.not.ok;
+    }));
 
     // ud udel userdel deluser user del
-    it(testName + 'user del', function (done) {
+    it(testName + 'user del', tools.poorMansAsync(function* () {
+        let err;
         // check if no args set
-        setup.processCommand(context.objects, context.states, 'user', ['del'], {}, err => {
-            expect(err).to.be.ok;
-            // delete admin not allowed
-            setup.processCommand(context.objects, context.states, 'user', ['del', 'admin'], {}, err => {
-                expect(err).to.be.ok;
-                // delete user
-                setup.processCommand(context.objects, context.states, 'user', ['del', 'user'], {}, err => {
-                    expect(err).to.be.not.ok;
-                    // delete invalid user
-                    setup.processCommand(context.objects, context.states, 'user', ['del', 'user'], {}, err => {
-                        expect(err).to.be.ok;
-                        // check adduser
-                        setup.processCommand(context.objects, context.states, 'userdel', ['user2'], {}, err => {
-                            expect(err).to.be.not.ok;
-                            done();
-                        });
-                    });
-                });
-            });
-        });
-    });
+        err = yield setup.processCommandAsync(context.objects, context.states, 'user', ['del'], {});
+        expect(err).to.be.ok;
+        // delete admin not allowed
+        err = yield setup.processCommandAsync(context.objects, context.states, 'user', ['del', 'admin'], {});
+        expect(err).to.be.ok;
+        // delete user
+        err = yield setup.processCommandAsync(context.objects, context.states, 'user', ['del', 'user'], {});
+        expect(err).to.be.not.ok;
+        // delete invalid user
+        err = yield setup.processCommandAsync(context.objects, context.states, 'user', ['del', 'user'], {});
+        expect(err).to.be.ok;
+        // check adduser
+        err = yield setup.processCommandAsync(context.objects, context.states, 'userdel', ['user2'], {});
+        expect(err).to.be.not.ok;
+    }));
 
     // group add
-    it(testName + 'group add', function (done) {
+    it(testName + 'group add', tools.poorMansAsync(function* () {
+        let err;
         // check if no args set
-        setup.processCommand(context.objects, context.states, 'group', ['add'], {}, err => {
-            expect(err).to.be.ok;
-            // add administrator not allowed
-            setup.processCommand(context.objects, context.states, 'group', ['add', 'administrator'], {}, err => {
-                expect(err).to.be.ok;
-                // add user
-                setup.processCommand(context.objects, context.states, 'group', ['add', 'users'], {}, err => {
-                    expect(err).to.be.not.ok;
-                    // add existing user not allowed
-                    setup.processCommand(context.objects, context.states, 'group', ['add', 'users'], {}, err => {
-                        expect(err).to.be.ok;
-                        done();
-                    });
-                });
-            });
-        });
-    });
+        err = yield setup.processCommandAsync(context.objects, context.states, 'group', ['add'], {});
+        expect(err).to.be.ok;
+        // add administrator not allowed
+        err = yield setup.processCommandAsync(context.objects, context.states, 'group', ['add', 'administrator'], {});
+        expect(err).to.be.ok;
+        // add user
+        err = yield setup.processCommandAsync(context.objects, context.states, 'group', ['add', 'users'], {});
+        expect(err).to.be.not.ok;
+        // add existing user not allowed
+        err = yield setup.processCommandAsync(context.objects, context.states, 'group', ['add', 'users'], {});
+        expect(err).to.be.ok;
+    }));
 
     // group del
-    it(testName + 'group del', function (done) {
+    it(testName + 'group del', tools.poorMansAsync(function* () {
+        let err;
         // check if no args set
-        setup.processCommand(context.objects, context.states, 'group', ['del'], {}, err => {
-            expect(err).to.be.ok;
-            // delete admin not allowed
-            setup.processCommand(context.objects, context.states, 'group', ['del', 'administrator'], {}, err => {
-                expect(err).to.be.ok;
-                // delete users
-                setup.processCommand(context.objects, context.states, 'group', ['del', 'users'], {}, err => {
-                    expect(err).to.be.not.ok;
-                    // delete invalid group
-                    setup.processCommand(context.objects, context.states, 'group', ['del', 'users'], {}, err => {
-                        expect(err).to.be.ok;
-                        done();
-                    });
-                });
-            });
-        });
-    });
+        err = yield setup.processCommandAsync(context.objects, context.states, 'group', ['del'], {});
+        expect(err).to.be.ok;
+        // delete admin not allowed
+        err = yield setup.processCommandAsync(context.objects, context.states, 'group', ['del', 'administrator'], {});
+        expect(err).to.be.ok;
+        // delete users
+        err = yield setup.processCommandAsync(context.objects, context.states, 'group', ['del', 'users'], {});
+        expect(err).to.be.not.ok;
+        // delete invalid group
+        err = yield setup.processCommandAsync(context.objects, context.states, 'group', ['del', 'users'], {});
+        expect(err).to.be.ok;
+    }));
 
     // group list
-    it(testName + 'group list', function (done) {
+    it(testName + 'group list', tools.poorMansAsync(function* () {
+        let err;
         // check if no args set
         // no user defined
-        setup.processCommand(context.objects, context.states, 'group', ['list'], {}, err => {
-            expect(err).to.be.ok;
-            // check admin
-            setup.processCommand(context.objects, context.states, 'group', ['list', 'administrator'], {}, err => {
-                expect(err).to.be.not.ok;
-                // check invalid user
-                setup.processCommand(context.objects, context.states, 'group', ['list', 'aaaa'], {}, err => {
-                    expect(err).to.be.ok;
-                    done();
-                });
-            });
-        });
-    });
+        err = yield setup.processCommandAsync(context.objects, context.states, 'group', ['list'], {});
+        expect(err).to.be.ok;
+        // check admin
+        err = yield setup.processCommandAsync(context.objects, context.states, 'group', ['list', 'administrator'], {});
+        expect(err).to.be.not.ok;
+        // check invalid user
+        err = yield setup.processCommandAsync(context.objects, context.states, 'group', ['list', 'aaaa'], {});
+        expect(err).to.be.ok;
+    }));
 
     // group get
-    it(testName + 'group get', function (done) {
+    it(testName + 'group get', tools.poorMansAsync(function* () {
+        let err;
         // check if no args set
-        setup.processCommand(context.objects, context.states, 'group', [], {}, err => {
-            expect(err).to.be.ok;
-            // no user defined
-            setup.processCommand(context.objects, context.states, 'group', ['get'], {}, err => {
-                expect(err).to.be.ok;
-                // check admin
-                setup.processCommand(context.objects, context.states, 'group', ['get', 'administrator'], {}, err => {
-                    expect(err).to.be.not.ok;
-                    // check invalid user
-                    setup.processCommand(context.objects, context.states, 'group', ['get', 'aaaa'], {}, err => {
-                        expect(err).to.be.ok;
-                        done();
-                    });
-                });
-            });
-        });
-    });
+        err = yield setup.processCommandAsync(context.objects, context.states, 'group', [], {});
+        expect(err).to.be.ok;
+        // no user defined
+        err = yield setup.processCommandAsync(context.objects, context.states, 'group', ['get'], {});
+        expect(err).to.be.ok;
+        // check admin
+        err = yield setup.processCommandAsync(context.objects, context.states, 'group', ['get', 'administrator'], {});
+        expect(err).to.be.not.ok;
+        // check invalid user
+        err = yield setup.processCommandAsync(context.objects, context.states, 'group', ['get', 'aaaa'], {});
+        expect(err).to.be.ok;
+    }));
 
     // group disable / enable
-    it(testName + 'group disable/enable', function (done) {
+    it(testName + 'group disable/enable', tools.poorMansAsync(function* () {
+        let err;
         // add second group
-        setup.processCommand(context.objects, context.states, 'group', ['add', 'group1'], {}, err => {
-            expect(err).to.be.not.ok;
-            // check if no args set
-            setup.processCommand(context.objects, context.states, 'group', ['enable'], {}, err => {
-                expect(err).to.be.ok;
-                // enable administrator
-                setup.processCommand(context.objects, context.states, 'group', ['enable', 'administrator'], {}, err => {
-                    expect(err).to.be.not.ok;
-                    // test short command
-                    setup.processCommand(context.objects, context.states, 'group', ['e', 'administrator'], {}, err => {
-                        expect(err).to.be.not.ok;
-                        // check invalid group
-                        setup.processCommand(context.objects, context.states, 'group', ['enable', 'aaa'], {}, err => {
-                            expect(err).to.be.ok;
-                            // administrator cannot be disabled
-                            setup.processCommand(context.objects, context.states, 'group', ['disable', 'administrator'], {}, err => {
-                                expect(err).to.be.ok;
-                                // group can be disabled
-                                setup.processCommand(context.objects, context.states, 'group', ['disable', 'group1'], {}, err => {
-                                    expect(err).to.be.not.ok;
-                                    // group can be disabled
-                                    setup.processCommand(context.objects, context.states, 'group', ['get', 'group1'], {}, err => {
-                                        expect(err).to.be.not.ok;
-                                        done();
-                                    });
-                                });
-                            });
-                        });
-                    });
-                });
-            });
-        });
-    });
+        err = yield setup.processCommandAsync(context.objects, context.states, 'group', ['add', 'group1'], {});
+        expect(err).to.be.not.ok;
+        // check if no args set
+        err = yield setup.processCommandAsync(context.objects, context.states, 'group', ['enable'], {});
+        expect(err).to.be.ok;
+        // enable administrator
+        err = yield setup.processCommandAsync(context.objects, context.states, 'group', ['enable', 'administrator'], {});
+        expect(err).to.be.not.ok;
+        // test short command
+        err = yield setup.processCommandAsync(context.objects, context.states, 'group', ['e', 'administrator'], {});
+        expect(err).to.be.not.ok;
+        // check invalid group
+        err = yield setup.processCommandAsync(context.objects, context.states, 'group', ['enable', 'aaa'], {});
+        expect(err).to.be.ok;
+        // administrator cannot be disabled
+        err = yield setup.processCommandAsync(context.objects, context.states, 'group', ['disable', 'administrator'], {});
+        expect(err).to.be.ok;
+        // group can be disabled
+        err = yield setup.processCommandAsync(context.objects, context.states, 'group', ['disable', 'group1'], {});
+        expect(err).to.be.not.ok;
+        // group can be disabled
+        err = yield setup.processCommandAsync(context.objects, context.states, 'group', ['get', 'group1'], {});
+        expect(err).to.be.not.ok;
+    }));
 
     // group useradd
-    it(testName + 'group useradd', function (done) {
+    it(testName + 'group useradd', tools.poorMansAsync(function* () {
+        let err;
         // add non existing user
-        setup.processCommand(context.objects, context.states, 'group', ['useradd', 'group1', 'user4'], {}, err => {
-            expect(err).to.be.ok;
-            // add user for tests
-            setup.processCommand(context.objects, context.states, 'user', ['add', 'user4'], {ingroup: 'user', password: 'bbb'}, err => {
-                expect(err).to.be.not.ok;
-                // add normal user to normal group
-                setup.processCommand(context.objects, context.states, 'group', ['useradd', 'group1', 'user4'], {}, err => {
-                    expect(err).to.be.not.ok;
-                    // admin yet added
-                    setup.processCommand(context.objects, context.states, 'group', ['useradd', 'administrator', 'admin'], {}, err => {
-                        expect(err).to.be.not.ok;
-                        // add to invalid group
-                        setup.processCommand(context.objects, context.states, 'group', ['useradd', 'group5', 'admin'], {}, err => {
-                            expect(err).to.be.ok;
-                            done();
-                        });
-                    });
-                });
-            });
-        });
-    });
+        err = yield setup.processCommandAsync(context.objects, context.states, 'group', ['useradd', 'group1', 'user4'], {});
+        expect(err).to.be.ok;
+        // add user for tests
+        err = yield setup.processCommandAsync(context.objects, context.states, 'user', ['add', 'user4'], { ingroup: 'user', password: 'bbb' });
+        expect(err).to.be.not.ok;
+        // add normal user to normal group
+        err = yield setup.processCommandAsync(context.objects, context.states, 'group', ['useradd', 'group1', 'user4'], {});
+        expect(err).to.be.not.ok;
+        // admin yet added
+        err = yield setup.processCommandAsync(context.objects, context.states, 'group', ['useradd', 'administrator', 'admin'], {});
+        expect(err).to.be.not.ok;
+        // add to invalid group
+        err = yield setup.processCommandAsync(context.objects, context.states, 'group', ['useradd', 'group5', 'admin'], {});
+        expect(err).to.be.ok;
+    }));
 
     // group userdel
-    it(testName + 'group userdel', function (done) {
+    it(testName + 'group userdel', tools.poorMansAsync(function* () {
+        let err;
         // delete non existing user
-        setup.processCommand(context.objects, context.states, 'group', ['userdel', 'group1', 'user5'], {}, err => {
-            expect(err).to.be.ok;
-            // remove normal user from normal group
-            setup.processCommand(context.objects, context.states, 'group', ['userdel', 'group1', 'user4'], {}, err => {
-                expect(err).to.be.not.ok;
-                // admin not allowed
-                setup.processCommand(context.objects, context.states, 'group', ['userdel', 'administrator', 'admin'], {}, err => {
-                    expect(err).to.be.not.ok;
-                    // remove from invalid group
-                    setup.processCommand(context.objects, context.states, 'group', ['userdel', 'group5', 'admin'], {}, err => {
-                        expect(err).to.be.ok;
-                        done();
-                    });
-                });
-            });
-        });
-    });
+        err = yield setup.processCommandAsync(context.objects, context.states, 'group', ['userdel', 'group1', 'user5'], {});
+        expect(err).to.be.ok;
+        // remove normal user from normal group
+        err = yield setup.processCommandAsync(context.objects, context.states, 'group', ['userdel', 'group1', 'user4'], {});
+        expect(err).to.be.not.ok;
+        // admin not allowed
+        err = yield setup.processCommandAsync(context.objects, context.states, 'group', ['userdel', 'administrator', 'admin'], {});
+        expect(err).to.be.not.ok;
+        // remove from invalid group
+        err = yield setup.processCommandAsync(context.objects, context.states, 'group', ['userdel', 'group5', 'admin'], {});
+        expect(err).to.be.ok;
+    }));
 
     // start adapter
     // stop adapter
@@ -348,33 +295,29 @@ function register(it, expect, context) {
     // stop ??
 
     // status
-    it(testName + 'status', function (done) {
+    it(testName + 'status', tools.poorMansAsync(function* () {
+        let err;
         // delete non existing user
-        setup.processCommand(context.objects, context.states, 'status', [], {}, err => {
-            expect(err).to.be.not.ok;
-            // remove normal user from normal group
-            setup.processCommand(context.objects, context.states, 'isrun', [], {}, err => {
-                expect(err).to.be.not.ok;
-                done();
-            });
-        });
-    });
+        err = yield setup.processCommandAsync(context.objects, context.states, 'status', [], {});
+        expect(err).to.be.not.ok;
+        // remove normal user from normal group
+        err = yield setup.processCommandAsync(context.objects, context.states, 'isrun', [], {});
+        expect(err).to.be.not.ok;
+    }));
     // restart adapter
     // restart ??
 
     // update
     // setup
-    it(testName + 'setup', function (done) {
+    it(testName + 'setup', tools.poorMansAsync(function* () {
+        let err;
         // delete non existing user
-        setup.processCommand(context.objects, context.states, 'setup', [], {}, err => {
-            expect(err).to.be.not.ok;
-            // remove normal user from normal group
-            setup.processCommand(context.objects, context.states, 'setup', ['first'], {}, err => {
-                expect(err).to.be.not.ok;
-                done();
-            });
-        });
-    });
+        err = yield setup.processCommandAsync(context.objects, context.states, 'setup', [], {});
+        expect(err).to.be.not.ok;
+        // remove normal user from normal group
+        err = yield setup.processCommandAsync(context.objects, context.states, 'setup', ['first'], {});
+        expect(err).to.be.not.ok;
+    }));
 
     // setup custom
     // url
@@ -391,23 +334,21 @@ function register(it, expect, context) {
 
     // message
     // update
-    it(testName + 'update', function (done) {
+    it(testName + 'update', tools.poorMansAsync(function* () {
+        let err;
         // delete non existing user
-        setup.processCommand(context.objects, context.states, 'update', [], {}, err => {
-            expect(err).to.be.not.ok;
-            setup.processCommand(context.objects, context.states, 'update', ['http://download.iobroker.net/sources-dist.json'], {}, err => {
-                expect(err).to.be.not.ok;
-                done();
-            });
-        });
-    }).timeout(40000);
+        err = yield setup.processCommandAsync(context.objects, context.states, 'update', [], {});
+        expect(err).to.be.not.ok;
+        err = yield setup.processCommandAsync(context.objects, context.states, 'update', ['http://download.iobroker.net/sources-dist.json'], {});
+        expect(err).to.be.not.ok;
+    })).timeout(40000);
 
     // upgrade
 
     // clean
     // restore
     // backup
-    it(testName + 'backup', done => {
+    it(testName + 'backup', tools.poorMansAsync(function* () {
         // create backup
         var dir = getBackupDir();
         var fs = require('fs');
@@ -421,30 +362,28 @@ function register(it, expect, context) {
             }
         }
 
-        setup.processCommand(context.objects, context.states, 'backup', [], {}, err => {
-            expect(err).to.be.not.ok;
-            var files = fs.readdirSync(dir);
-            // check 2017_03_09-13_48_33_backupioBroker.tar.gz
-            var found = false;
-            console.log('Check ' + dir);
-            for (var f = files.length - 1; f > 0; f--) {
-                console.log('Detect ' + dir + files[f]);
-                if (files[f].match(/_backupioBroker\.tar\.gz$/)) {
-                    found = true;
-                    break;
-                }
+        let err;
+        err = yield setup.processCommandAsync(context.objects, context.states, 'backup', [], {});
+        expect(err).to.be.not.ok;
+        var files = fs.readdirSync(dir);
+        // check 2017_03_09-13_48_33_backupioBroker.tar.gz
+        var found = false;
+        console.log('Check ' + dir);
+        for (var f = files.length - 1; f > 0; f--) {
+            console.log('Detect ' + dir + files[f]);
+            if (files[f].match(/_backupioBroker\.tar\.gz$/)) {
+                found = true;
+                break;
             }
-            // TODO why this does not work on TRAVIS
-            //expect(found).to.be.true;
+        }
+        // TODO why this does not work on TRAVIS
+        //expect(found).to.be.true;
 
-            var name = Math.round(Math.random() * 10000).toString();
-            setup.processCommand(context.objects, context.states, 'backup', [name], {}, err => {
-                expect(err).to.be.not.ok;
-                expect(require('fs').existsSync(getBackupDir() + name + '.tar.gz')).to.be.true;
-            });
-            done();
-        });
-    }).timeout(20000);
+        var name = Math.round(Math.random() * 10000).toString();
+        err = yield setup.processCommandAsync(context.objects, context.states, 'backup', [name], {});
+        expect(err).to.be.not.ok;
+        expect(require('fs').existsSync(getBackupDir() + name + '.tar.gz')).to.be.true;
+    })).timeout(20000);
 
     // list l
     // touch
@@ -458,128 +397,107 @@ function register(it, expect, context) {
     // file f
 
     // id uuid
-    it(testName + 'uuid', function (done) {
+    it(testName + 'uuid', tools.poorMansAsync(function* () {
+        let err;
         // delete non existing user
-        setup.processCommand(context.objects, context.states, 'uuid', [], {}, err => {
-            expect(err).to.be.not.ok;
-            // remove normal user from normal group
-            setup.processCommand(context.objects, context.states, 'id', [], {}, err => {
-                expect(err).to.be.not.ok;
-                done();
-            });
-        });
-    });
+        err = yield setup.processCommandAsync(context.objects, context.states, 'uuid', [], {});
+        expect(err).to.be.not.ok;
+        // remove normal user from normal group
+        err = yield setup.processCommandAsync(context.objects, context.states, 'id', [], {});
+        expect(err).to.be.not.ok;
+    }));
 
     // v version
-    it(testName + 'version', function (done) {
+    it(testName + 'version', tools.poorMansAsync(function* () {
+        let err;
         // delete non existing user
-        setup.processCommand(context.objects, context.states, 'version', [], {}, err => {
-            expect(err).to.be.not.ok;
-            // remove normal user from normal group
-            setup.processCommand(context.objects, context.states, 'v', [], {}, err => {
-                expect(err).to.be.not.ok;
-                done();
-            });
-        });
-    });
+        err = yield setup.processCommandAsync(context.objects, context.states, 'version', [], {});
+        expect(err).to.be.not.ok;
+        // remove normal user from normal group
+        err = yield setup.processCommandAsync(context.objects, context.states, 'v', [], {});
+        expect(err).to.be.not.ok;
+    }));
 
     // repo
-    it(testName + 'repo', function (done) {
+    it(testName + 'repo', tools.poorMansAsync(function* () {
+        let err;
         // add non existing repo
-        setup.processCommand(context.objects, context.states, 'repo', ['add', 'local', 'some/path'], {}, err => {
-            expect(err).to.be.not.ok;
-            // set new repo as active
-            setup.processCommand(context.objects, context.states, 'repo', ['set', 'local'], {}, err => {
-                expect(err).to.be.not.ok;
-                // try to delete active repo
-                setup.processCommand(context.objects, context.states, 'repo', ['del', 'local'], {}, err => {
-                    expect(err).to.be.ok;
-                    // set active repo to default
-                    setup.processCommand(context.objects, context.states, 'repo', ['set', 'default'], {}, err => {
-                        expect(err).to.be.not.ok;
-                        // delete non-active repo
-                        setup.processCommand(context.objects, context.states, 'repo', ['del', 'local'], {}, err => {
-                            expect(err).to.be.not.ok;
-                            // add and set as active new repo, but with too less parameters
-                            setup.processCommand(context.objects, context.states, 'repo', ['addset', 'local1'], {}, err => {
-                                expect(err).to.be.ok;
-                                setup.processCommand(context.objects, context.states, 'repo', ['addset', 'local1', 'some/path'], {}, err => {
-                                    expect(err).to.be.not.ok;
-                                    // try to add new repo with existing name
-                                    setup.processCommand(context.objects, context.states, 'repo', ['add', 'local1', 'some/path1'], {}, err => {
-                                        expect(err).to.be.ok;
-                                        // set active repo to default
-                                        setup.processCommand(context.objects, context.states, 'repo', ['set', 'default'], {}, err => {
-                                            expect(err).to.be.not.ok;
-                                            // try to delete non-active repo
-                                            setup.processCommand(context.objects, context.states, 'repo', ['del', 'local1'], {}, err => {
-                                                expect(err).to.be.not.ok;
-                                                done();
-                                            });
-                                        });
-                                    });
-                                });
-                            });
-                        });
-                    });
-                });
-            });
-        });
-    });
+        err = yield setup.processCommandAsync(context.objects, context.states, 'repo', ['add', 'local', 'some/path'], {});
+        expect(err).to.be.not.ok;
+        // set new repo as active
+        err = yield setup.processCommandAsync(context.objects, context.states, 'repo', ['set', 'local'], {});
+        expect(err).to.be.not.ok;
+        // try to delete active repo
+        err = yield setup.processCommandAsync(context.objects, context.states, 'repo', ['del', 'local'], {});
+        expect(err).to.be.ok;
+        // set active repo to default
+        err = yield setup.processCommandAsync(context.objects, context.states, 'repo', ['set', 'default'], {});
+        expect(err).to.be.not.ok;
+        // delete non-active repo
+        err = yield setup.processCommandAsync(context.objects, context.states, 'repo', ['del', 'local'], {});
+        expect(err).to.be.not.ok;
+        // add and set as active new repo, but with too less parameters
+        err = yield setup.processCommandAsync(context.objects, context.states, 'repo', ['addset', 'local1'], {});
+        expect(err).to.be.ok;
+        err = yield setup.processCommandAsync(context.objects, context.states, 'repo', ['addset', 'local1', 'some/path'], {});
+        expect(err).to.be.not.ok;
+        // try to add new repo with existing name
+        err = yield setup.processCommandAsync(context.objects, context.states, 'repo', ['add', 'local1', 'some/path1'], {});
+        expect(err).to.be.ok;
+        // set active repo to default
+        err = yield setup.processCommandAsync(context.objects, context.states, 'repo', ['set', 'default'], {});
+        expect(err).to.be.not.ok;
+        // try to delete non-active repo
+        err = yield setup.processCommandAsync(context.objects, context.states, 'repo', ['del', 'local1'], {});
+        expect(err).to.be.not.ok;
+    }));
 
     // license
-    it(testName + 'license', function (done) {
+    it(testName + 'license', tools.poorMansAsync(function* () {
         // test license
         const licenseText = 'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoiaW9icm9rZXIudmlzIiwidHlwZSI6InRlc3QiLCJlbWFpbCI6InRlc3RAZ21haWwuY29tIiwiZXhwaXJlcyI6MjQ0NDM5ODA5NSwidmVyc2lvbiI6IjwyIiwiaWQiOiI5NTBkYWEwMC01MzcxLTExZTctYjQwNS14eHh4eHh4eHh4eHh4IiwiaWF0IjoxNDk3NzEzMjk1fQ.K9t9ZtvAsdeNFTJed4Sidq2jrr9UFOYpMt6VLmBdVzWueI9DnCXFS5PwBFTBTmF9WMhVk6LBw5ujIVl130B_5NrHl21PHkCLvJeW7jGsMgWDINuBK5F9k8LZABdsv7uDbqNDSOsVrFwEKOu2V3N5sMWYOVE4N_COIg9saaLvyN69oIP27PTgk1GHuyU4giFKGLPTp10L5p2hxLX0lEPjSdDggbl7dEqEe1-u5WwkyBizp03pMtHGYtjnACtP_KBuOly7QpmAnoPlfFoW79xgRjICbd41wT43IvhKAAo1zfnRAeWfQ7QoUViKsc6N1es87QC4KKw-eToLPXOO5UzWOg';
         let licenseFile = __dirname + '/visLicense.data';
         licenseFile = licenseFile.replace(/\\/g, '/');
         const fs = require('fs');
         fs.writeFileSync(licenseFile, licenseText);
+
         // expect warning about license
-        setup.processCommand(context.objects, context.states, 'license', [], {}, err => {
-            expect(err).to.be.ok;
-            // expect warning about invalid license
-            setup.processCommand(context.objects, context.states, 'license', ['invalidLicense'], {}, err => {
-                expect(err).to.be.ok;
-                context.objects.setObjectAsync('system.adapter.vis.0', {
-                    common: {
-                        name: 'iobroker.vis'
-                    },
-                    native: {
+        let err;
+        err = yield setup.processCommandAsync(context.objects, context.states, 'license', [], {});
+        expect(err).to.be.ok;
+        // expect warning about invalid license
+        err = yield setup.processCommandAsync(context.objects, context.states, 'license', ['invalidLicense'], {});
+        expect(err).to.be.ok;
 
-                    },
-                    type: 'instance'
-                }).then(() => // license must be taken
-                    setup.processCommand(context.objects, context.states, 'license', [licenseFile], {}, err => {
-                        fs.unlinkSync(licenseFile);
-                        expect(err).to.be.not.ok;
-                        context.objects.getObjectAsync('system.adapter.vis.0')
-                            .then(obj => {
-                                expect(obj.native.license).to.be.equal(licenseText);
-                                // license must be taken
-                                setup.processCommand(context.objects, context.states, 'license', [licenseText], {}, err => {
-                                    expect(err).to.be.not.ok;
-                                    context.objects.getObjectAsync('system.adapter.vis.0')
-                                        .then(obj => {
-                                            expect(obj.native.license).to.be.equal(licenseText);
-                                            done();
-                                        });
+        yield context.objects.setObjectAsync('system.adapter.vis.0', {
+            common: {
+                name: 'iobroker.vis'
+            },
+            native: {
 
-                                });
-                            });
-                    })
-                );
-            });
+            },
+            type: 'instance'
         });
-    });
+        // license must be taken
+        err = yield setup.processCommandAsync(context.objects, context.states, 'license', [licenseFile], {});
+        fs.unlinkSync(licenseFile);
+        expect(err).to.be.not.ok;
+        let obj = yield context.objects.getObjectAsync('system.adapter.vis.0');
+        expect(obj.native.license).to.be.equal(licenseText);
+        
+        // license must be taken
+        err = yield setup.processCommandAsync(context.objects, context.states, 'license', [licenseText], {});
+        expect(err).to.be.not.ok;
+        obj = context.objects.getObjectAsync('system.adapter.vis.0')
+        expect(obj.native.license).to.be.equal(licenseText);
+    }));
     
     // info
-    it(testName + 'info', done => {
-        setup.processCommand(context.objects, context.states, 'info', [], {}, err => {
-            expect(err).to.be.not.ok;
-            done();
-        });
-    }).timeout(6000)
+    it(testName + 'info', tools.poorMansAsync(function* () {
+        let err;
+        err = yield setup.processCommandAsync(context.objects, context.states, 'info', [], {});
+        expect(err).to.be.not.ok;
+    })).timeout(6000);
 }
 
 

--- a/test/lib/testConsole.js
+++ b/test/lib/testConsole.js
@@ -3,7 +3,7 @@
 /* jslint node:true */
 /* jshint expr:true */
 'use strict';
-const tools = require(__dirname + '/../../lib/tools.js');
+const tools = require('../../lib/tools.js');
 
 function getBackupDir() {
     let dataDir = tools.getDefaultDataDir();
@@ -28,47 +28,43 @@ function getBackupDir() {
 
 function register(it, expect, context) {
     const testName = context.name + ' ' + context.adapterShortName + ' console: ';
-    const setup    = require(__dirname + '/../../lib/setup.js');
+    const setup    = require('../../lib/setup.js');
     // passwd, user passwd, user check
-    it(testName + 'user passwd', function (done) {
-        // set initial password
-        setup.processCommand(context.objects, context.states, 'passwd', ['admin'], {password: context.appName.toLowerCase()}, err => {
-            expect(err).to.be.not.ok;
-            // check password
-            setup.processCommand(context.objects, context.states, 'user', ['check', 'admin'], {password: context.appName.toLowerCase()}, err => {
-                expect(err).to.be.not.ok;
-                // negative check
-                setup.processCommand(context.objects, context.states, 'user', ['check', 'admin'], {password: context.appName.toLowerCase() + '2'}, err => {
-                    expect(err).to.be.ok;
-                    // set new password
-                    setup.processCommand(context.objects, context.states, 'user', ['passwd', 'admin'], {password: context.appName.toLowerCase() + '1'}, err => {
-                        expect(err).to.be.not.ok;
-                        // check new Password
-                        setup.processCommand(context.objects, context.states, 'user', ['check', 'admin'], {password: context.appName.toLowerCase() + '1'}, err => {
-                            expect(err).to.be.not.ok;
-                            // set password back
-                            setup.processCommand(context.objects, context.states, 'passwd', ['admin'], {password: context.appName.toLowerCase()}, err => {
-                                expect(err).to.be.not.ok;
-                                // check password
-                                setup.processCommand(context.objects, context.states, 'user', ['check', 'admin'], {password: context.appName.toLowerCase()}, err => {
-                                    expect(err).to.be.not.ok;
-                                    // set password for non existing user
-                                    setup.processCommand(context.objects, context.states, 'passwd', ['uuuser'], {password: context.appName.toLowerCase()}, err => {
-                                        expect(err).to.be.ok;
-                                        // check password for non existing user
-                                        setup.processCommand(context.objects, context.states, 'user', ['check', 'uuuser'], {password: context.appName.toLowerCase()}, err => {
-                                            expect(err).to.be.ok;
-                                            done();
-                                        });
-                                    });
-                                });
-                            });
-                        });
-                    });
-                });
-            });
-        });
-    }).timeout(2000)
+    it(testName + 'user passwd', tools.poorMansAsync(function* () {
+        let err;
+
+        err = yield setup.processCommandAsync(context.objects, context.states, 'passwd', ['admin'], { password: context.appName.toLowerCase() });
+        expect(err).to.be.not.ok;
+
+        // check password
+        err = yield setup.processCommandAsync(context.objects, context.states, 'user', ['check', 'admin'], { password: context.appName.toLowerCase() });
+        expect(err).to.be.not.ok;
+        // negative check
+        err = yield setup.processCommandAsync(context.objects, context.states, 'user', ['check', 'admin'], { password: context.appName.toLowerCase() + '2' });
+        expect(err).to.be.ok;
+
+        // set new password
+        err = yield setup.processCommandAsync(context.objects, context.states, 'user', ['passwd', 'admin'], { password: context.appName.toLowerCase() + '1' });
+        expect(err).to.be.not.ok;
+        // check new Password
+        err = yield setup.processCommandAsync(context.objects, context.states, 'user', ['check', 'admin'], { password: context.appName.toLowerCase() + '1' });
+        expect(err).to.be.not.ok;
+
+        // set password back
+        err = yield setup.processCommandAsync(context.objects, context.states, 'passwd', ['admin'], { password: context.appName.toLowerCase() });
+        expect(err).to.be.not.ok;
+        // check password
+        err = yield setup.processCommandAsync(context.objects, context.states, 'user', ['check', 'admin'], { password: context.appName.toLowerCase() });
+        expect(err).to.be.not.ok;
+
+        // set password for non existing user
+        err = yield setup.processCommandAsync(context.objects, context.states, 'passwd', ['uuuser'], { password: context.appName.toLowerCase() });
+        expect(err).to.be.ok;
+        // check password for non existing user
+        err = yield setup.processCommandAsync(context.objects, context.states, 'user', ['check', 'uuuser'], { password: context.appName.toLowerCase() });
+        expect(err).to.be.ok;
+
+    })).timeout(2000);
 
     // user get
     it(testName + 'user get', function (done) {


### PR DESCRIPTION
Similar to how we simplified the adapter uninstallation by using async generators, the christmas tree structure of `testConsole.js` can be made much more readable aswell.