### PR TITLE
Add a wrapper method to safely expose ES6 classes to legacy code

### DIFF
--- a/lib/tools.js
+++ b/lib/tools.js
@@ -1291,6 +1291,44 @@ function disablePackageLock(callback) {
     });
 }
 
+/**
+ * @template T
+ * @typedef {{new (...args: any[]): T}} ES6Class<T>
+ */
+/**
+ * @template T
+ * @typedef {{new (...args: any[]): T; (...args: any[]): T; prototype: Function}} Class<T>
+ */
+
+/**
+ * Wraps an ES6 class so it can be called from legacy code without the new keyword.
+ * Usage e.g.:
+ * ```js
+ // filename: foo.js
+ class Foo {
+     constructor() { this.bar = 1; }
+ }
+ module.exports = wrapES6Class(Foo);
+ 
+ // filename: index.js
+ const Foo = require("./foo");
+ var x = new Foo(); // works!
+ var y = Foo(); // works too!
+ ```
+ * @template T
+ * @param {ES6Class<T>} Class
+ * @returns {Class<T>}
+ */
+function wrapES6Class(Class) {
+    const _Class = function _Class() {
+        const args = sliceArgs(arguments);
+        return new (Function.prototype.bind.apply(Class, [null].concat(args)))();
+    };
+    _Class.prototype = Class.prototype;
+    // @ts-ignore
+    return _Class;
+};
+
 module.exports = {
     appName: getAppName(),
     createUuid,
@@ -1318,5 +1356,6 @@ module.exports = {
     upToDate,
     checkNonEditable,
     copyAttributes,
-    getDiskInfo
+    getDiskInfo,
+    wrapES6Class
 };

--- a/test/lib/testClass.js
+++ b/test/lib/testClass.js
@@ -1,0 +1,20 @@
+// Warning! This test should only be run on NodeJS 6+
+
+'use strict';
+
+const wrapES6Class = require('../../lib/tools').wrapES6Class;
+
+class TestClass {
+
+	constructor(arg1, arg2) {
+		if (arg1 && arg2) {
+			this.test = arg1 + arg2;
+		} else {
+			this.test = "ok";
+		}
+		
+	}
+
+}
+
+module.exports = wrapES6Class(TestClass);

--- a/test/testClasses.js
+++ b/test/testClasses.js
@@ -1,0 +1,44 @@
+// @ts-check
+'use strict';
+
+var expect = require('chai').expect;
+
+let nodeVersion;
+try {
+	nodeVersion = parseInt(process.versions.node.split(".")[0]);
+} catch (e) {
+	// nothing to do, skip test
+}
+
+// This test should only be run on NodeJS 6+
+if (nodeVersion && nodeVersion >= 6) {
+	describe(`Test ES6 class interoperability`, () => {
+		const TestClass = require("./lib/testClass");
+
+		it(`TestClass should be defined`, () => {
+			expect(TestClass).to.not.be.undefined;
+		});
+
+		it(`TestClass should be creatable with "new"`, () => {
+			const instance = new TestClass();
+			expect(instance).to.be.an.instanceof(TestClass);
+			expect(instance.test).to.equal("ok");
+		});
+
+		it(`TestClass should be creatable without "new"`, () => {
+			const instance = TestClass();
+			expect(instance).to.be.an.instanceof(TestClass);
+			expect(instance.test).to.equal("ok");
+		});
+
+		it(`The constructor args should be passed in both cases`, () => {
+			let instance = new TestClass("a", "b");
+			expect(instance).to.be.an.instanceof(TestClass);
+			expect(instance.test).to.equal("ab");
+
+			instance = TestClass("c", "d");
+			expect(instance).to.be.an.instanceof(TestClass);
+			expect(instance.test).to.equal("cd");
+		});
+	});	
+}


### PR DESCRIPTION
Fixes: #219 

Usage e.g.:
```js
// filename: foo.js
class Foo {
    constructor() { this.bar = 1; }
}
module.exports = wrapES6Class(Foo);

// filename: index.js
const Foo = require("./foo");
var x = new Foo(); // works!
var y = Foo(); // works too!
```