### PR TITLE
Usage information hard wrap on colum 80 removed; <add adapter 0> not working

### DIFF
--- a/lib/setup.js
+++ b/lib/setup.js
@@ -101,6 +101,7 @@ function initYargs() {
             //.default('objects',   '127.0.0.1')
             //.default('states',   '127.0.0.1')
             //.default('lang',    'en')
+	.wrap(null)
         ;
     return yargs;
 }

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -101,7 +101,6 @@ function initYargs() {
             //.default('objects',   '127.0.0.1')
             //.default('states',   '127.0.0.1')
             //.default('lang',    'en')
-	.wrap(null)
         ;
     return yargs;
 }
@@ -786,7 +785,10 @@ function processCommand(command, args, params, callback) {
                 let name =      args[0];
                 let instance =  args[1];
                 let repoUrl =   args[2];
-
+		
+		if (instance===0) instance = '0';
+                if (repoUrl===0) repoUrl = '0';
+		 
                 if (parseInt(instance, 10).toString() !== (instance || '').toString()) {
                     repoUrl = instance;
                     instance = null;

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -787,8 +787,8 @@ function processCommand(command, args, params, callback) {
                 let instance =  args[1];
                 let repoUrl =   args[2];
 		
-		if (instance===0) instance = '0';
-                if (repoUrl===0) repoUrl = '0';
+		if (instance === 0) instance = '0';
+                if (repoUrl === 0) repoUrl = '0';
 		 
                 if (parseInt(instance, 10).toString() !== (instance || '').toString()) {
                     repoUrl = instance;


### PR DESCRIPTION
A) Usage help is always wraped at column 80. For yargs by default wrap will be set to Math.min(80, windowWidth). Use .wrap(null) to specify no column limit (no right-align). Use .wrap(yargs.terminalWidth()) to maximize the width of yargs' usage instructions. Looks way better :-)

B) It is not possible to add an adapter instance.0 when instance number 0 is specified. This is happening because when instance=0 --> (instance || '') equals to '' and not to '0'.