### PR TITLE
Add two cpu related counters for adapters

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -24,6 +24,7 @@ const extend =            require('node.extend');
 const util =              require('util');
 const EventEmitter =      require('events').EventEmitter;
 const tools =             require('./tools');
+const pidusage =          require('pidusage');
 const getConfigFileName = tools.getConfigFileName;
 let schedule;
 
@@ -5282,6 +5283,22 @@ function Adapter(options) {
             that.states.setState(id + '.connected', {val: true, ack: true, expire: 30, from: id});
             that.outputCount++;
         }
+        // pidusage([pid,pid,...], function (err, stats) {
+        // => {
+        //   cpu: 10.0,            // percentage (from 0 to 100*vcore)
+        //   memory: 357306368,    // bytes
+        //   ppid: 312,            // PPID
+        //   pid: 727,             // PID
+        //   ctime: 867000,        // ms user + system time
+        //   elapsed: 6650000,     // ms since the start of the process
+        //   timestamp: 864000000  // ms since epoch
+        // }
+        pidusage(process.pid, function (err, stats) {
+            if (!err) {
+                that.states.setState(id + '.load', {val: parseFloat(stats.cpu).toFixed(2), ack: true, from: id});
+                that.states.setState(id + '.cputime', {val: stats.ctime / 1000, ack: true, from: id});
+            }
+        });
         //RSS is the resident set size, the portion of the process's memory held in RAM (as opposed to the swap space or the part held in the filesystem).
         const mem = process.memoryUsage();
         that.states.setState(id + '.memRss', {val: parseFloat((mem.rss / 1048576/* 1MB */).toFixed(2)), ack: true, from: id});

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -101,7 +101,7 @@ function initYargs() {
             //.default('objects',   '127.0.0.1')
             //.default('states',   '127.0.0.1')
             //.default('lang',    'en')
-	.wrap(null)
+            .wrap(null)
         ;
     return yargs;
 }

--- a/lib/setup/setupInstall.js
+++ b/lib/setup/setupInstall.js
@@ -808,6 +808,32 @@ function Install(options) {
                                     native: {}
                                 },
                                 {
+                                  _id:    _id + '.load',
+                                    type:   'state',
+                                    common: {
+                                        name: adapter + '.' + instance + '.load',
+                                        type: 'number',
+                                        read: true,
+                                        write: false,
+                                        role: 'indicator.state',
+                                        unit: '% of one core'
+                                    },
+                                    native: {}
+                                },
+                                {
+                                    _id:    _id + '.cputime',
+                                    type:   'state',
+                                    common: {
+                                        name: adapter + '.' + instance + '.cputime',
+                                        type: 'number',
+                                        read: true,
+                                        write: false,
+                                        role: 'indicator.state',
+                                        unit: 'seconds'
+                                    },
+                                    native: {}
+                                },
+                                {
                                     _id:    _id + '.memHeapUsed',
                                     type:   'state',
                                     common: {
@@ -864,7 +890,7 @@ function Install(options) {
                                     _id:    _id + '.inputCount',
                                     type:   'state',
                                     common: {
-                                        name: hostname + ' - inputs level',
+                                        name: adapter + '.' + instance + '.inputCount',
                                         desc: 'State\'s inputs in 15 seconds',
                                         type: 'number',
                                         read: true,
@@ -878,7 +904,7 @@ function Install(options) {
                                     _id:    _id + '.outputCount',
                                     type:   'state',
                                     common: {
-                                        name: hostname + ' outputs level',
+                                        name: adapter + '.' + instance + '.outputCount',
                                         desc: 'State\'s outputs in 15 seconds',
                                         type: 'number',
                                         read: true,

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "ncp": "^2.0.0",
     "node-schedule": "^1.3.0",
     "node.extend": "^2.0.0",
+    "pidusage": "^2.0.13",
     "prompt": "^1.0.0",
     "pyconf": "^1.1.2",
     "request": "^2.85.0",


### PR DESCRIPTION
Usefull for investigating bottlenecks and cpu-bound ressource consumption of adapters. Works with nodejs v4+, *nix and Windows. See https://github.com/soyuka/pidusage