### PR TITLE
Give adapters a chance to handle their own uncaught errors instead of restarting them immediately.

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -5372,6 +5372,20 @@ function Adapter(options) {
     process.once('exit', stop);
 
     process.on('uncaughtException', err => {
+
+        // If the adapter has a callback to listen for unhandled errors
+        // give it a chance to handle the error itself instead of restarting it
+        if (typeof options.error === 'function') {
+            try {
+                // if error handler in the adapter returned exactly true,
+                // we expect the error to be handled and do nothing more
+                const wasHandled = options.error(err);
+                if (wasHandled === true) return;
+            } catch (e) {
+                console.error(`Error in adapter error handler: ${e}`);
+            }
+        }
+
         console.error(err);
 
         // catch it on windows


### PR DESCRIPTION
When an adapter provides an `error` method on the `options` object during its creation, this will be called with any uncaught errors, giving the adapter a chance to handle them. A return value of `true` is interpreted as a handled error.

This is required for https://github.com/ioBroker/ioBroker.javascript/pull/161