### PR TITLE
FreeBSD: df: invalid option -- B

### DIFF
--- a/lib/tools.js
+++ b/lib/tools.js
@@ -948,7 +948,7 @@ function getDiskInfo(platform, callback) {
                     callback && callback(error, null);
                 });
             } else {
-                exec('df -B 1024 /', {encoding: 'utf8'}, (error, stdout) => {//, stderr) {
+                exec('df -k /', {encoding: 'utf8'}, (error, stdout) => {//, stderr) {
                     // Filesystem            1K-blocks    Used Available Use% Mounted on
                     // /dev/mapper/vg00-lv01 162544556 9966192 145767152   7% /
                     try {


### PR DESCRIPTION
df -B 1024 not working on FreeBSD, df -k is the same as df -B 1024