### PR TITLE
Add additional attribute (defAck) to object type state

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -2248,11 +2248,15 @@ function Adapter(options) {
                 native:   _native
             }, options, callback);
 
-            if (common.def !== undefined) {
-                that.setState(id, common.def, options);
-            } else {
-                that.setState(id, null, true, options);
-            }
+            if(common.def !== undefined) {
+				if(common.defAck === true) {
+					that.setState (id, common.def, true, options)
+				} else {
+					that.setState (id, common.def, options)
+				} 	
+			} else {
+				that.setState (id, null, true, options)
+			}
         };
         /**
          * Promise-version of Adapter.createState

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -2249,14 +2249,14 @@ function Adapter(options) {
             }, options, callback);
 
             if(common.def !== undefined) {
-				if(common.defAck === true) {
-					that.setState (id, common.def, true, options)
-				} else {
-					that.setState (id, common.def, options)
-				} 	
-			} else {
-				that.setState (id, null, true, options)
-			}
+                if(common.defAck !== undefined) {
+                    that.setState (id, common.def, common.defAck, options)
+                } else {
+                    that.setState (id, common.def, options)
+                } 	
+            } else {
+                that.setState (id, null, true, options)
+            }
         };
         /**
          * Promise-version of Adapter.createState

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -2250,12 +2250,12 @@ function Adapter(options) {
 
             if(common.def !== undefined) {
                 if(common.defAck !== undefined) {
-                    that.setState (id, common.def, common.defAck, options)
+                    that.setState(id, common.def, common.defAck, options);
                 } else {
-                    that.setState (id, common.def, options)
+                    that.setState(id, common.def, options);
                 } 	
             } else {
-                that.setState (id, null, true, options)
+                that.setState(id, null, true, options);
             }
         };
         /**


### PR DESCRIPTION
The documentation should be completed at https://github.com/ioBroker/ioBroker/blob/master/doc/SCHEMA.md#state-commonrole.
E.g.: common.defAck (optional) - If true - no acknowledgment for the value at instance creation.