### PR TITLE
Require Nodejs >= 6

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "iobroker.js-controller",
   "version": "1.5.0",
   "engines": {
-    "node": ">=4.8.7"
+    "node": ">=6.0.0"
   },
   "optionalDependencies": {
     "diskusage": "^0.2.4",


### PR DESCRIPTION
- Node v4 no longer supported
- Require at least 6.0.0