### PR TITLE
Prevent installation of adapter and iobroker itself on unsupported npm version

### DIFF
--- a/controller.js
+++ b/controller.js
@@ -62,7 +62,21 @@ const errorCodes            = [
     'node.js: Cannot find module', // 8
     '', // 9
     'Cannot find start file of adapter', // 10
-    'Desired termination' // 11 - DESIRED_TERMINATION
+    'Desired termination', // 11 - DESIRED_TERMINATION
+    '', // 12
+    '', // 13
+    '', // 14
+    '', // 15
+    '', // 16
+    '', // 17
+    '', // 18
+    '', // 19
+    '', // 20
+    '', // 21
+    '', // 22
+    '', // 23
+    '', // 24
+    'Unsupported npm version' // 25
 ];
 let procs                   = {};
 let subscribe               = {};

--- a/lib/preinstallCheck.js
+++ b/lib/preinstallCheck.js
@@ -49,6 +49,7 @@ function checkNpmVersion() {
                         console.warn('use "npm install -g npm@latest" to install a supported version of npm!');
                         console.warn('You need to make sure to repeat this step after installing an update to NodeJS and/or npm.');
                         console.warn('!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!');
+                        process.exit(25);
                     }
                     resolve(npmVersion);
                 }

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -523,7 +523,7 @@ function processCommand(command, args, params, callback) {
                         params:        params
                     });
 
-                    install.npmInstall(url, true, false, (_url, installDir) => {
+                    install.npmInstallWithCheck(url, true, false, (_url, installDir) => {
                         const Upload = require(__dirname + '/setup/setupUpload.js');
                         const upload = new Upload({
                             states:      states,

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "iobroker.js-controller",
   "version": "1.5.0",
   "engines": {
-    "node": ">=4.8.7"
+    "node": ">=6.0.0"
   },
   "optionalDependencies": {
     "diskusage": "^0.2.4",


### PR DESCRIPTION
- when npm version is unsupported, refuse installation
- of iobroker itself
- as well as adapter installation
- also prevent github installations
- closes #233
- added error code 25 for unsupported npm version