### PR TITLE
Add/Enhance commands `iobroker object {get,set}`

### DIFF
--- a/lib/objects.js
+++ b/lib/objects.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const getConfigFileName = require(__dirname + '/tools').getConfigFileName;
+const getConfigFileName = require('./tools').getConfigFileName;
 const config = JSON.parse(require('fs').readFileSync(getConfigFileName(), 'utf8'));
 if (!config.objects) config.objects = {type: 'file'};
 

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -1031,14 +1031,17 @@ function processCommand(command, args, params, callback) {
                             });
                         });
                     } else if (cmd === 'set') {
-                        // iobroker object get objectid [propertypath=]value
+                        // iobroker object set objectid [propertypath=]value
                         // Overwrites the entire object or part of it
 
                         // Parse the last argument which contains the property path and value
                         // This also checks if the user is trying to assign a non-object to an object
-                        const parsedArg = parsePropPathAndAssignment(args[2]);
+                        // We need to concatenate all arguments after the 2nd because yargs
+                        // does not seem to handle spaces inside quotes correctly
+                        const lastArg = args.length >= 2 ? args.slice(2).join(' ') : undefined;
+                        const parsedArg = parsePropPathAndAssignment(lastArg);
                         if (!parsedArg) {
-                            console.log('The property path or value is not valid');
+                            console.log('The property path or value is not valid. Please make sure the value is valid JSON.');
                             callback(3);
                             return;
                         }

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -144,7 +144,7 @@ function processCommand(command, args, params, callback) {
             (function () {
                 // Start stop of adapter
                 if (args[0]) {
-                    Objects =       require(__dirname + '/objects');
+                    Objects =       require('./objects');
                     let adapter = args[0];
                     // If user accidentally wrote tools.appName.adapter => remove adapter
                     const regExp = new RegExp('^' + tools.appName + '\\.', 'i');
@@ -330,7 +330,7 @@ function processCommand(command, args, params, callback) {
         case 'restart':
             (function () {
                 if (args[0]) {
-                    Objects =       require(__dirname + '/objects');
+                    Objects =       require('./objects');
                     let adapter = args[0];
                     // If user accidentally wrote tools.appName.adapter => remove adapter
                     const regExp = new RegExp('^' + tools.appName + '\\.', 'i');
@@ -418,10 +418,10 @@ function processCommand(command, args, params, callback) {
 
         case 'update':
             (function () {
-                Objects     = require(__dirname + '/objects');
+                Objects     = require('./objects');
                 const repoUrl = args[0]; // Repo url or name
                 dbConnect(params, (_objects, _states) => {
-                    const Repo = require(__dirname + '/setup/setupRepo.js');
+                    const Repo = require('./setup/setupRepo.js');
                     const repo = new Repo({
                         objects:     _objects,
                         states:      _states
@@ -436,7 +436,7 @@ function processCommand(command, args, params, callback) {
 
         case 'setup':
             (function () {
-                const Setup = require(__dirname + '/setup/setupSetup.js');
+                const Setup = require('./setup/setupSetup.js');
                 const setup = new Setup({
                     dbConnect,
                     processExit:        callback,
@@ -462,7 +462,7 @@ function processCommand(command, args, params, callback) {
 
                     setup.setup((isFirst, isRedis) => {
                         if (isFirst) {
-                            const Install = require(__dirname + '/setup/setupInstall.js');
+                            const Install = require('./setup/setupInstall.js');
                             const install = new Install({
                                 objects:       objects,
                                 states:        states,
@@ -495,7 +495,7 @@ function processCommand(command, args, params, callback) {
 
         case 'url':
             (function () {
-                Objects =       require(__dirname + '/objects');
+                Objects =       require('./objects');
 
                 let url  =      args[0];
                 let name =      args[1];
@@ -513,7 +513,7 @@ function processCommand(command, args, params, callback) {
                 console.log('install ' + url);
 
                 dbConnect(params, () => {
-                    const Install = require(__dirname + '/setup/setupInstall.js');
+                    const Install = require('./setup/setupInstall.js');
                     const install = new Install({
                         objects:       objects,
                         states:        states,
@@ -524,7 +524,7 @@ function processCommand(command, args, params, callback) {
                     });
 
                     install.npmInstallWithCheck(url, true, false, (_url, installDir) => {
-                        const Upload = require(__dirname + '/setup/setupUpload.js');
+                        const Upload = require('./setup/setupUpload.js');
                         const upload = new Upload({
                             states:      states,
                             objects:     objects,
@@ -588,7 +588,7 @@ function processCommand(command, args, params, callback) {
 
         case 'info':
             (function () {
-                Objects =       require(__dirname + '/objects');
+                Objects =       require('./objects');
                 dbConnect(params, objects => {
                     tools.getHostInfo(objects, (err, data) => {
                         if (err) {
@@ -597,7 +597,7 @@ function processCommand(command, args, params, callback) {
                                 return callback(20);
                             }
                         }
-                        const formatters = require(__dirname + '/formatters');
+                        const formatters = require('./formatters');
                         const formatInfo = {
                             'Uptime':        formatters.formatSeconds,
                             'System uptime': formatters.formatSeconds,
@@ -623,7 +623,7 @@ function processCommand(command, args, params, callback) {
         case 'install':
         case 'i':
             (function () {
-                Objects =       require(__dirname + '/objects');
+                Objects =       require('./objects');
 
                 let name =      args[0];
                 let instance =  args[1];
@@ -655,7 +655,7 @@ function processCommand(command, args, params, callback) {
                 let adapterDir = tools.getAdapterDir(name);
 
                 dbConnect(params, () => {
-                    const Install = require(__dirname + '/setup/setupInstall.js');
+                    const Install = require('./setup/setupInstall.js');
                     let install = new Install({
                         objects:       objects,
                         states:        states,
@@ -670,7 +670,7 @@ function processCommand(command, args, params, callback) {
                             if (command !== 'install' && command !== 'i') {
                                 install.createInstance(name, params, () => callback());
                             } else {
-                                const Upload = require(__dirname + '/setup/setupUpload.js');
+                                const Upload = require('./setup/setupUpload.js');
                                 let upload = new Upload({
                                     states:      states,
                                     objects:     objects,
@@ -700,12 +700,12 @@ function processCommand(command, args, params, callback) {
         case 'upload':
         case 'u':
             (function () {
-                Objects     = require(__dirname + '/objects');
+                Objects     = require('./objects');
                 const name    = args[0];
                 const subTree = args[1];
                 if (name) {
                     dbConnect(params, () => {
-                        const Upload = require(__dirname + '/setup/setupUpload.js');
+                        const Upload = require('./setup/setupUpload.js');
                         const upload = new Upload({
                             states:      states,
                             objects:     objects,
@@ -779,7 +779,7 @@ function processCommand(command, args, params, callback) {
 
                 if (instance || instance === 0) {
                     dbConnect(params, () => {
-                        const Install = require(__dirname + '/setup/setupInstall.js');
+                        const Install = require('./setup/setupInstall.js');
                         const install = new Install({
                             objects:       objects,
                             states:        states,
@@ -794,7 +794,7 @@ function processCommand(command, args, params, callback) {
                     });
                 } else {
                     dbConnect(params, () => {
-                        const Install = require(__dirname + '/setup/setupInstall.js');
+                        const Install = require('./setup/setupInstall.js');
                         const install = new Install({
                             objects:       objects,
                             states:        states,
@@ -901,7 +901,7 @@ function processCommand(command, args, params, callback) {
                                 console.error(err);
                             } else {
                                 if (processed) {
-                                    const List = require(__dirname + '/setup/setupList.js');
+                                    const List = require('./setup/setupList.js');
                                     const list = new List({
                                         states:      states,
                                         objects:     objects,
@@ -948,7 +948,7 @@ function processCommand(command, args, params, callback) {
                                 console.error(err);
                             } else {
                                 if (processed) {
-                                    const List = require(__dirname + '/setup/setupList.js');
+                                    const List = require('./setup/setupList.js');
                                     const list = new List({
                                         states:      states,
                                         objects:     objects,
@@ -978,7 +978,7 @@ function processCommand(command, args, params, callback) {
                                 callback(33);
                             }
                             if (processed) {
-                                const List = require(__dirname + '/setup/setupList.js');
+                                const List = require('./setup/setupList.js');
                                 const list = new List({
                                     states:      states,
                                     objects:     objects,
@@ -994,7 +994,7 @@ function processCommand(command, args, params, callback) {
                     });
                 } else
                 if (id) {
-                    Objects = require(__dirname + '/objects');
+                    Objects = require('./objects');
 
                     if (cmd === 'get') {
                         dbConnect(params, () => {
@@ -1193,7 +1193,7 @@ function processCommand(command, args, params, callback) {
 
         case 'upgrade':
             (function () {
-                Objects = require(__dirname + '/objects');
+                Objects = require('./objects');
 
                 let adapter = args[0];
                 let repoUrl = args[1];
@@ -1210,7 +1210,7 @@ function processCommand(command, args, params, callback) {
                 }
 
                 dbConnect(params, () => {
-                    const Upgrade = require(__dirname + '/setup/setupUpgrade.js');
+                    const Upgrade = require('./setup/setupUpgrade.js');
                     const upgrade = new Upgrade({
                         objects:           objects,
                         states:            states,
@@ -1277,7 +1277,7 @@ function processCommand(command, args, params, callback) {
 
         case 'restore':
             (function () {
-                const Backup = require(__dirname + '/setup/setupBackup.js');
+                const Backup = require('./setup/setupBackup.js');
 
                 dbConnect(params, (obj, stat, isNotRun) => {
 
@@ -1306,7 +1306,7 @@ function processCommand(command, args, params, callback) {
         case 'backup':
             (function () {
                 const name = args[0];
-                const Backup = require(__dirname + '/setup/setupBackup.js');
+                const Backup = require('./setup/setupBackup.js');
 
                 dbConnect(params, () => {
                     const backup = new Backup({
@@ -1329,7 +1329,7 @@ function processCommand(command, args, params, callback) {
         case 'list':
             (function () {
                 dbConnect(params, () => {
-                    const List = require(__dirname + '/setup/setupList.js');
+                    const List = require('./setup/setupList.js');
                     const list = new List({
                         states:      states,
                         objects:     objects,
@@ -1367,7 +1367,7 @@ function processCommand(command, args, params, callback) {
                                             files.push({id: _id, processed: processed});
                                         }
                                         if (!--count) {
-                                            const List = require(__dirname + '/setup/setupList.js');
+                                            const List = require('./setup/setupList.js');
                                             const list = new List({
                                                 states:      states,
                                                 objects:     objects,
@@ -1400,7 +1400,7 @@ function processCommand(command, args, params, callback) {
                                 console.error(err);
                             } else {
                                 if (processed) {
-                                    const List = require(__dirname + '/setup/setupList.js');
+                                    const List = require('./setup/setupList.js');
                                     const list = new List({
                                         states:      states,
                                         objects:     objects,
@@ -1446,7 +1446,7 @@ function processCommand(command, args, params, callback) {
                                             files.push({id: _id, processed: processed});
                                         }
                                         if (!--count) {
-                                            const List = require(__dirname + '/setup/setupList.js');
+                                            const List = require('./setup/setupList.js');
                                             const list = new List({
                                                 states:      states,
                                                 objects:     objects,
@@ -1480,7 +1480,7 @@ function processCommand(command, args, params, callback) {
                                 console.error(err);
                             } else {
                                 if (processed) {
-                                    const List = require(__dirname + '/setup/setupList.js');
+                                    const List = require('./setup/setupList.js');
                                     const list = new List({
                                         states:      states,
                                         objects:     objects,
@@ -1537,7 +1537,7 @@ function processCommand(command, args, params, callback) {
                                             files.push({id: _id, processed: processed});
                                         }
                                         if (!--count) {
-                                            const List = require(__dirname + '/setup/setupList.js');
+                                            const List = require('./setup/setupList.js');
                                             const list = new List({
                                                 states:      states,
                                                 objects:     objects,
@@ -1571,7 +1571,7 @@ function processCommand(command, args, params, callback) {
                                 console.error(err);
                             } else {
                                 if (processed) {
-                                    const List = require(__dirname + '/setup/setupList.js');
+                                    const List = require('./setup/setupList.js');
                                     const list = new List({
                                         states:      states,
                                         objects:     objects,
@@ -1635,7 +1635,7 @@ function processCommand(command, args, params, callback) {
                                             files.push({id: _id, processed: processed});
                                         }
                                         if (!--count) {
-                                            const List = require(__dirname + '/setup/setupList.js');
+                                            const List = require('./setup/setupList.js');
                                             const list = new List({
                                                 states:      states,
                                                 objects:     objects,
@@ -1671,7 +1671,7 @@ function processCommand(command, args, params, callback) {
                             } else {
                                 // call here list
                                 if (processed) {
-                                    const List = require(__dirname + '/setup/setupList.js');
+                                    const List = require('./setup/setupList.js');
                                     const list = new List({
                                         states: states,
                                         objects: objects,
@@ -1700,7 +1700,7 @@ function processCommand(command, args, params, callback) {
                 }
 
                 dbConnect(params, () => {
-                    const Users = require(__dirname + '/setup/setupUsers.js');
+                    const Users = require('./setup/setupUsers.js');
                     const users = new Users({
                         objects:     objects,
                         processExit: callback
@@ -1811,7 +1811,7 @@ function processCommand(command, args, params, callback) {
                     return callback(30);
                 }
                 dbConnect(params, () => {
-                    const Users = require(__dirname + '/setup/setupUsers.js');
+                    const Users = require('./setup/setupUsers.js');
                     const users = new Users({
                         objects:     objects,
                         processExit: callback
@@ -1933,7 +1933,7 @@ function processCommand(command, args, params, callback) {
                 const password = params.password;
 
                 dbConnect(params, () => {
-                    const Users = require(__dirname + '/setup/setupUsers.js');
+                    const Users = require('./setup/setupUsers.js');
                     const users = new Users({
                         objects: objects,
                         processExit: callback
@@ -1956,7 +1956,7 @@ function processCommand(command, args, params, callback) {
                 const user     = args[0];
                 const password = params.password;
                 dbConnect(params, () => {
-                    const Users = require(__dirname + '/setup/setupUsers.js');
+                    const Users = require('./setup/setupUsers.js');
                     const users = new Users({
                         objects:     objects,
                         processExit: callback
@@ -1982,7 +1982,7 @@ function processCommand(command, args, params, callback) {
                 const user = args[0];
 
                 dbConnect(params, () => {
-                    const Users = require(__dirname + '/setup/setupUsers.js');
+                    const Users = require('./setup/setupUsers.js');
                     const users = new Users({
                         objects: objects,
                         processExit: callback
@@ -2057,14 +2057,13 @@ function processCommand(command, args, params, callback) {
                             for (let a = 0; a < process.argv.length; a++) {
                                 if (process.argv[a].match(/^--/) && process.argv[a + 1] && !process.argv[a + 1].match(/^--/)) {
                                     const attr = process.argv[a].substring(2);
+                                    /** @type {number | string | boolean} */
                                     let val = process.argv[a + 1];
                                     if (val === 'true')  {
                                         val = true;
-                                    }
-                                    if (val === 'false') {
+                                    } else if (val === 'false') {
                                         val = false;
-                                    }
-                                    if (parseFloat(val).toString() === val) {
+                                    } else if (parseFloat(val).toString() === val) {
                                         val = parseFloat(val);
                                     }
                                     if (attr.indexOf('.') !== -1) {
@@ -2284,7 +2283,7 @@ function processCommand(command, args, params, callback) {
                     widgetset = widgetset.substring(4);
                 }
 
-                const VisDebug = require(__dirname + '/setup/setupVisDebug.js');
+                const VisDebug = require('./setup/setupVisDebug.js');
 
                 dbConnect(params, _objects => {
                     const visDebug = new VisDebug({
@@ -2391,7 +2390,7 @@ function processCommand(command, args, params, callback) {
                         iopckg = {version: '"' + adapter + '" not found'};
                     }
                 } else {
-                    iopckg = require(__dirname + '/../package.json');
+                    iopckg = require('../package.json');
                 }
                 console.log(iopckg.version);
 
@@ -2426,7 +2425,7 @@ function processCommand(command, args, params, callback) {
 
         case 'repo':
             (function () {
-                Objects =       require(__dirname + '/objects');
+                Objects =       require('./objects');
                 let repoUrlOrCommand = args[0]; // Repo url or name or "add" / "del" / "set" / "show" / "addset"
                 const repoName       = args[1]; // Repo url or name
                 let repoUrl          = args[2]; // Repo url or name
@@ -2436,7 +2435,7 @@ function processCommand(command, args, params, callback) {
                 }
 
                 dbConnect(params, (_objects, _states) => {
-                    const Repo = require(__dirname + '/setup/setupRepo.js');
+                    const Repo = require('./setup/setupRepo.js');
                     const repo = new Repo({
                         objects:     _objects,
                         states:      _states
@@ -2516,7 +2515,7 @@ function processCommand(command, args, params, callback) {
                     callback(1);
                 } else {
                     dbConnect(params, () => {
-                        const Multihost = require(__dirname + '/setup/setupMultihost.js');
+                        const Multihost = require('./setup/setupMultihost.js');
                         const mh = new Multihost({
                             params:      params,
                             processExit: callback,
@@ -2629,7 +2628,7 @@ function processCommand(command, args, params, callback) {
                         iopckg = {version: '"' + command + '" not found'};
                     }
                 } else {
-                    iopckg = require(__dirname + '/../package.json');
+                    iopckg = require('./../package.json');
                 }
                 console.log(iopckg.version);
             } else {
@@ -2896,8 +2895,8 @@ function dbConnect(onlyCheck, params, callback) {
     if (!config.states)  config.states  = {type: 'file'};
     if (!config.objects) config.objects = {type: 'file'};
 
-    Objects =    require(__dirname + '/objects');
-    States =     require(__dirname + '/states');
+    Objects =    require('./objects');
+    States =     require('./states');
 
     // Give to controller 2 seconds for connection
     let isObjectConnected = false;
@@ -2915,7 +2914,7 @@ function dbConnect(onlyCheck, params, callback) {
         if (!isObjectConnected) {
             if (config.objects.type === 'file') {
                 // Just open in memory DB itself
-                Objects = require(__dirname + '/objects/objectsInMemServer');
+                Objects = require('./objects/objectsInMemServer');
                 objects = new Objects({
                     connection: config.objects,
                     logger: {
@@ -2941,7 +2940,7 @@ function dbConnect(onlyCheck, params, callback) {
         if (!isStatesConnected) {
             if (config.states.type === 'file') {
                 // Just open in memory DB itself
-                States = require(__dirname + '/states/statesInMemServer');
+                States = require('./states/statesInMemServer');
                 states = new States({
                     connection: config.states,
                     logger: {

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -997,12 +997,29 @@ function processCommand(command, args, params, callback) {
                     Objects = require('./objects');
 
                     if (cmd === 'get') {
+                        // iobroker object get objectid [propertypath]
+                        // Retrieves the entire object or part of it
+
+                        // propPath is a string representation of which property we want to select
+                        // "native.something[2].onething" selects `onething` of the 3rd array element of `object.native.something`.
+                        let propPath = args[2];
                         dbConnect(params, () => {
                             objects.getObject(id, (err, res) => {
                                 if (err || !res) {
                                     console.log('not found');
                                     callback(3);
+                                    return;
                                 } else {
+                                    if (typeof propPath === 'string') {
+                                        // We want to select a part of the object
+                                        try {
+                                            res = deepSelectProperty(res, propPath);
+                                        } catch (e) {
+                                            console.log(`The requested property "${propPath}" or one of its parents was not found in "${id}"`);
+                                            callback(3);
+                                            return;
+                                        }
+                                    }
                                     if (params.pretty) {
                                         console.log(JSON.stringify(res, null, 2));
                                     } else {
@@ -1012,8 +1029,52 @@ function processCommand(command, args, params, callback) {
                                 }
                             });
                         });
-                    } else
-                    if (cmd === 'del' || cmd === 'delete') {
+                    } else if (cmd === 'set') {
+                        // iobroker object get objectid [propertypath=]value
+                        // Overwrites the entire object or part of it
+
+                        // Parse the last argument which contains the property path and value
+                        // This also checks if the user is trying to assign a non-object to an object
+                        const parsedArg = parsePropPathAndAssignment(args[2]);
+                        if (!parsedArg) {
+                            console.log('The property path or value is not valid');
+                            callback(3);
+                            return;
+                        }
+                        const {propPath, value} = parsedArg;
+
+                        dbConnect(params, () => {
+                            function doSetObject(obj) {
+                                objects.setObject(id, obj, () => {
+                                    console.log(`The object ${id} was updated.`);
+                                    callback();
+                                    return;
+                                });
+                            }
+                            if (propPath == undefined) {
+                                // We set the entire object, no need to retrieve it first
+                                doSetObject(value);
+                            } else {
+                                // We want to update a part of the object
+                                // Retrieve the object first
+                                objects.getObject(id, (err, res) => {
+                                    if (err || !res) {
+                                        console.log('not found');
+                                        callback(3);
+                                        return;
+                                    }
+                                    try {
+                                        deepSetProperty(res, propPath, value);
+                                    } catch (e) {
+                                        console.log(`The requested property "${propPath}" or one of its parents was not found in "${id}"!`);
+                                        callback(3);
+                                        return;
+                                    }
+                                    doSetObject(res);
+                                });
+                            }
+                        });
+                    } else if (cmd === 'del' || cmd === 'delete') {
                         dbConnect(params, () => {
                             objects.delObject(id, err => {
                                 if (err) {
@@ -3010,6 +3071,144 @@ function dbConnect(onlyCheck, params, callback) {
             }
         }
     });
+}
+
+/**
+ * Tries to parse a CLI argument that could be used to set an object
+ * @param {string} arg The CLI argument containing the value to be set
+ * @returns {string | number | boolean | object | Array}
+ */
+function parseCLIValue(arg) {
+    try {
+        // JSON.parse does not allow plain strings
+        return JSON.parse(arg);
+    } catch (e) {
+        // arg is a string
+        return arg;
+    }
+}
+
+/**
+ * @typedef {object} ParsedPropPathAndAssignment
+ * @property {string} [propPath]
+ * @property {unknown} value
+ */
+/**
+ * Tries to parse a CLI argument of the form [propPath=]value.
+ * @param {string} arg The CLI argument containing an optional prop path and a JSON value
+ * @returns {ParsedPropPathAndAssignment | undefined}
+ */
+function parsePropPathAndAssignment(arg) {
+    const equalsIndex = arg.indexOf('=');
+    if (equalsIndex > -1) {
+        // This might contain a propPath AND a value
+        const propPath = arg.substr(0, equalsIndex);
+        const valueString = arg.substr(equalsIndex + 1);
+        // For partial assignments, allow strings as the value
+        const value = parseCLIValue(valueString);
+        return { propPath, value };
+    } else {
+        // This is a full assignment, allow only objects
+        try {
+            const value = JSON.parse(arg);
+            if (!tools.isObject(value)) return undefined;
+            return { value };
+        } catch (e) { 
+            // nope!
+            return undefined;
+        }
+    }
+}
+
+/**
+ * Reverses a string
+ * @param {string} str The string to reverse
+ */
+function reverseString(str) {
+    return Array.from(str).reverse().join('');
+}
+
+/**
+ * Normalizes a property path for use in deepSelectProperty and deepSetProperty
+ * @param {string} path The property path to normalize
+ * @returns {string}
+ */
+function normalizePropertyPath(path) {
+    // Basically we want to support paths like "obj[1][2]", but the other methods expect "obj.[1].[2]"
+    // So we need to replace all occurences of square brackets without leading dots
+    // JS Regex only supports negative lookbehind in ES 2018, so we fake it using reversed strings and
+    // negative lookahead
+    const arrayIndexRegex = /(\]\d+\[)(?!\.)/g; // Reversing the string reverses the brackets too
+    let ret = reverseString(path);
+    // Append the dot to each bracket, since we're going to reverse it
+    ret = ret.replace(arrayIndexRegex, '$1.');
+    return reverseString(ret);
+}
+
+/**
+ * Selects a property of an object or its sub-objects and returns it if it exists. E.g.
+ * `deepSelectProperty(obj, "common.asdf.qwer")` => `obj.common.asdf.qwer`
+ * @template T
+ * @param {Record<string, T>} object The object to select a property from
+ * @param {string} path The property path to search for
+ * @returns {unknown}
+ */
+function deepSelectProperty(object, path) {
+    /**
+     * @template T2
+     * @param {Record<string, T2>} obj
+     * @param {string[]} pathArr
+     * @returns {unknown}
+     */
+    function _deepSelectProperty(obj, pathArr) {
+        // are we there yet? then return obj
+        if (!pathArr.length) return obj;
+        // go deeper
+        /** @type {string | number} */
+        let propName = pathArr.shift();
+        if (/\[\d+\]/.test(propName)) {
+            // this is an array index
+            propName = +propName.slice(1, -1);
+        }
+        return _deepSelectProperty(obj[propName], pathArr);
+    }
+    path = normalizePropertyPath(path);
+    return _deepSelectProperty(object, path.split("."));
+}
+
+// Vergräbt eine Eigenschaft in einem Objekt (Gegenteil von dig)
+/**
+ * Changes a property of an object or its sub-objects if it exists. Opposite of `deepSelectProperty`.
+ * @template T
+ * @param {Record<string, T>} object The object to replace a property in
+ * @param {string} path The property path to search for
+ * @param {any} value
+ * @returns {void}
+ */
+function deepSetProperty(object, path, value) {
+    /**
+     * @template T2
+     * @param {Record<string, T2>} obj
+     * @param {string[]} pathArr
+     * @returns {void}
+     */
+    function _deepSetProperty(obj, pathArr) {
+        // are we there yet? then return obj
+        if (pathArr.length === 1) {
+            obj[pathArr[0]] = value;
+            return;
+        }
+        // go deeper
+        /** @type {string | number} */
+        let propName = pathArr.shift();
+        if (/\[\d+\]/.test(propName)) {
+            // this is an array index
+            propName = +propName.slice(1, -1);
+        }
+        _deepSetProperty(obj[propName], pathArr);
+    }
+    path = normalizePropertyPath(path);
+    _deepSetProperty(object, path.split("."));
 }
 
 module.exports.processCommand = function (_objects, _states, command, args, params, callback) {

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -1020,11 +1020,12 @@ function processCommand(command, args, params, callback) {
                                             return;
                                         }
                                     }
-                                    if (params.pretty) {
-                                        console.log(JSON.stringify(res, null, 2));
-                                    } else {
-                                        console.log(JSON.stringify(res));
-                                    }
+                                    // Only use JSON.stringify if we need it (for objects and arrays)
+                                    const needsStringify = tools.isObject(res) || tools.isArray(res);
+                                    const output = !needsStringify ? res
+                                        : params.pretty ? JSON.stringify(res, null, 2)
+                                        : JSON.stringify(res);
+                                    console.log(output);
                                     callback();
                                 }
                             });

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -1461,6 +1461,27 @@ function decrypt(key, value) {
     return result;
 }
 
+/**
+ * Tests whether the given variable is a real object and not an Array
+ * @param {any} it The variable to test
+ */
+function isObject(it) {
+	// This is necessary because:
+	// typeof null === 'object'
+	// typeof [] === 'object'
+	// [] instanceof Object === true
+	return Object.prototype.toString.call(it) === '[object Object]';
+}
+
+/**
+ * Tests whether the given variable is really an Array
+ * @param {any} it The variable to test
+ */
+function isArray(it) {
+	if (Array.isArray != null) return Array.isArray(it);
+	return Object.prototype.toString.call(it) === '[object Array]';
+}
+
 module.exports = {
     appName: getAppName(),
     createUuid,
@@ -1480,6 +1501,8 @@ module.exports = {
     getJson,
     getRepositoryFile,
     getSystemNpmVersion,
+    isObject,
+    isArray,
     promisify,
     promisifyNoError,
     promiseSequence,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -50,6 +50,7 @@
 	  /* Experimental Options */
 	  // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
 	  // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+	  "resolveJsonModule": true
 	},
 	"include": [
 	  "iobroker.js",


### PR DESCRIPTION
As discussed in #271. `iobroker object extend` is still missing.

We should probably add tests for the new commands.

Also I replaced a bunch of `require(__dirname + '/file.js')` with `require('./file.js')`, so this seems like more than it is.