### PR TITLE
Don't disable package-lock

### DIFF
--- a/lib/preinstallCheck.js
+++ b/lib/preinstallCheck.js
@@ -61,13 +61,7 @@ function checkNpmVersion() {
 }
 
 checkNpmVersion()
-    .then(version => {
-        if (gte(version, '5.0.0')) {
-            // disables NPM's package-lock.json on NPM >= 5 because that creates heaps of problems
-            console.log('npm version >= 5: disabling package-lock');
-            fs.writeFileSync(path.join(rootDir, '.npmrc'), 'package-lock=false' + os.EOL, 'utf8');
-        }
-    }).catch(err => {
+    .catch(err => {
         console.error('Could not check npm version: ' + err);
         console.error('Assuming that correct version is installed.');
     }).then(() => {

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -2753,26 +2753,24 @@ function installNpm(adapter, callback) {
 
     // iob_npm.done file was created if "npm i" yet called there
     if (fs.existsSync(path + '/package.json') && !fs.existsSync(path + '/iob_npm.done')) {
-        tools.disablePackageLock(err => {
-            const cmd = 'npm install --production';
-            console.log(cmd + ' (System call) in "' + path + '"');
-            // Install node modules as system call
+        const cmd = 'npm install --production';
+        console.log(cmd + ' (System call) in "' + path + '"');
+        // Install node modules as system call
 
-            // System call used for update of js-controller itself,
-            // because during installation npm packet will be deleted too, but some files must be loaded even during the install process.
-            const exec = require('child_process').exec;
-            let child = exec(cmd, {
-                cwd: path
-            });
-            child.stderr.pipe(process.stdout);
-            child.on('exit', (code, signal) => {
-                if (code) {
-                    console.log('Cannot install ' + tools.appName + '.' + adapter + ': ' + code);
-                    (callback || processExit)(25);
-                }
-                // command succeeded
-                if (callback) callback(null, adapter);
-            });
+        // System call used for update of js-controller itself,
+        // because during installation npm packet will be deleted too, but some files must be loaded even during the install process.
+        const exec = require('child_process').exec;
+        let child = exec(cmd, {
+            cwd: path
+        });
+        child.stderr.pipe(process.stdout);
+        child.on('exit', (code, signal) => {
+            if (code) {
+                console.log('Cannot install ' + tools.appName + '.' + adapter + ': ' + code);
+                (callback || processExit)(25);
+            }
+            // command succeeded
+            if (callback) callback(null, adapter);
         });
     } else {
         if (callback) callback(null, adapter);

--- a/lib/setup/setupInstall.js
+++ b/lib/setup/setupInstall.js
@@ -344,33 +344,31 @@ function Install(options) {
             }
         }
 
-        tools.disablePackageLock(err => {
-            const cmd = 'npm install ' + npmUrl + (options.unsafePerm ? ' --unsafe-perm' : '') + ' --production --save --prefix "' + cwd + '"';
+        const cmd = 'npm install ' + npmUrl + (options.unsafePerm ? ' --unsafe-perm' : '') + ' --production --save --prefix "' + cwd + '"';
 
-            console.log(cmd + ' (System call)');
-            // Install node modules as system call
+        console.log(cmd + ' (System call)');
+        // Install node modules as system call
 
-            // System call used for update of js-controller itself,
-            // because during installation npm packet will be deleted too, but some files must be loaded even during the install process.
-            const exec = require('child_process').exec;
-            const child = exec(cmd);
-            child.stderr.pipe(process.stdout);
-            if (debug || params.debug) {
-                child.stdout.pipe(process.stdout);
+        // System call used for update of js-controller itself,
+        // because during installation npm packet will be deleted too, but some files must be loaded even during the install process.
+        const exec = require('child_process').exec;
+        const child = exec(cmd);
+        child.stderr.pipe(process.stdout);
+        if (debug || params.debug) {
+            child.stdout.pipe(process.stdout);
+        }
+        child.on('exit', (code /* , signal */) => {
+            // code 1 is strange error that cannot be explained. Everything is installed but error :(
+            if (code && code !== 1) {
+                console.error('host.' + hostname + ' Cannot install ' + npmUrl + ': ' + code);
+                processExit(25);
             }
-            child.on('exit', (code /* , signal */) => {
-                // code 1 is strange error that cannot be explained. Everything is installed but error :(
-                if (code && code !== 1) {
-                    console.error('host.' + hostname + ' Cannot install ' + npmUrl + ': ' + code);
-                    processExit(25);
-                }
-                // create file that indicates, that npm was called there
-                if (npmUrl.indexOf(':') === -1 && fs.existsSync(cwd + '/node_modules/' + npmUrl)) {
-                    fs.writeFileSync(cwd + '/node_modules/' + npmUrl + '/iob_npm.done', ' ');
-                }
-                // command succeeded
-                if (callback) callback(npmUrl, cwd + '/node_modules');
-            });
+            // create file that indicates, that npm was called there
+            if (npmUrl.indexOf(':') === -1 && fs.existsSync(cwd + '/node_modules/' + npmUrl)) {
+                fs.writeFileSync(cwd + '/node_modules/' + npmUrl + '/iob_npm.done', ' ');
+            }
+            // command succeeded
+            if (callback) callback(npmUrl, cwd + '/node_modules');
         });
     };
 
@@ -397,30 +395,28 @@ function Install(options) {
             cwd = cwd.join('/');
         }
 
-        tools.disablePackageLock(err => {
-            let cmd = `npm uninstall ${packageName} --silent --save --prefix "${cwd}"`;
+        let cmd = `npm uninstall ${packageName} --silent --save --prefix "${cwd}"`;
 
-            console.log(cmd + ' (System call)');
-            // Install node modules as system call
+        console.log(cmd + ' (System call)');
+        // Install node modules as system call
 
-            // System call used for update of js-controller itself,
-            // because during installation npm packet will be deleted too, but some files must be loaded even during the install process.
-            const exec = require('child_process').exec;
-            const child = exec(cmd);
-            child.stderr.pipe(process.stdout);
-            if (debug || params.debug) {
-                child.stdout.pipe(process.stdout);
-            }
-            child.on('exit', (code /* , signal */) => {
-                // code 1 is strange error that cannot be explained. Everything is installed but error :(
-                if (code && code !== 1) {
-                    if (typeof callback === 'function') {
-                        callback(`host.${hostname}: Cannot uninstall ${packageName}: ${code}`);
-                    }
+        // System call used for update of js-controller itself,
+        // because during installation npm packet will be deleted too, but some files must be loaded even during the install process.
+        const exec = require('child_process').exec;
+        const child = exec(cmd);
+        child.stderr.pipe(process.stdout);
+        if (debug || params.debug) {
+            child.stdout.pipe(process.stdout);
+        }
+        child.on('exit', (code /* , signal */) => {
+            // code 1 is strange error that cannot be explained. Everything is installed but error :(
+            if (code && code !== 1) {
+                if (typeof callback === 'function') {
+                    callback(`host.${hostname}: Cannot uninstall ${packageName}: ${code}`);
                 }
-                // command succeeded
-                if (callback) callback();
-            });
+            }
+            // command succeeded
+            if (callback) callback();
         });
     };
     /** @type {(packageName: string, options: any, debug: boolean) => Promise<void>} */
@@ -1044,16 +1040,16 @@ function Install(options) {
 
     /**
      * Enumerate all instances of an adapter
-     * @type {(knownObjIDs: string[], notDeleted: array, adapter: string, instance: string) => Promise<void>}
+     * @type {(knownObjIDs: string[], notDeleted: array, adapter: string, instance?: string) => Promise<void>}
      */
     this.enumerateAdapterInstances = function enumerateInstances(knownObjIDs, notDeleted, adapter, instance) {
         if (!notDeleted) {
             notDeleted = [];
         }
-        const startkey = instance !== undefined && instance !== null ?
+        const startkey = instance != undefined ?
             `system.adapter.${adapter}.${instance}` :
             `system.adapter.${adapter}`;
-        const endkey = instance !== undefined && instance !== null ?
+        const endkey = instance != undefined ?
             `system.adapter.${adapter}.${instance}` :
             `system.adapter.${adapter}.\u9999`;
 

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -1272,29 +1272,6 @@ function poorMansAsync(makeGenerator) {
 // var testAsync = poorMansAsync(test);
 // testAsync(1,2,3).then(() => /* we're done */ );
 
-let packageLockDisabled = false;
-/**
- * Ensures that package-lock.json gets ignored. Fixes installation issues on npm5
- * @param {(err?) => void} callback The callback to invoke after the command has finished
- */
-function disablePackageLock(callback) {
-    if (packageLockDisabled) return callback();
-    
-    const npmrcPath = path.join(__dirname, '../../..', '.npmrc');
-    getSystemNpmVersion(function (err, version) {
-        packageLockDisabled = true;
-        if (version && semver.gte(version, '5.0.0')) {
-            // we need to disable the package lock
-            if (!fs.existsSync(npmrcPath)) {
-                // create the file
-                fs.writeFile(npmrcPath, 'package-lock=false\n', {encoding: 'utf8'}, callback);
-                return;
-            }
-        }
-        callback();
-    });
-}
-
 function _setQualityForStates(states, keys, quality, cb) {
     if (!keys || !states || !keys.length) {
         cb();
@@ -1465,7 +1442,6 @@ module.exports = {
     appName: getAppName(),
     createUuid,
     decryptPhrase,
-    disablePackageLock,
     encryptPhrase,
     findIPs,
     poorMansAsync,


### PR DESCRIPTION
Fixes #251 
On existing installations we should also not *enable* it again, because it is really only fixed for fresh installs.

Edit:  
To clarify, this PR does not enable package-lock again when it is disabled. It just doesn't disable it anymore. So fresh installs get the benefit, existing installs are unchanged.