### PR TITLE
Root should always npm install with --unsafe-perm

### DIFF
--- a/lib/setup/setupInstall.js
+++ b/lib/setup/setupInstall.js
@@ -11,6 +11,7 @@ function Install(options) {
     const child_process    = require('child_process');
     // todo solve it somehow
     const unsafePermAlways = [tools.appName.toLowerCase() + '.zwave', tools.appName.toLowerCase() + '.amazon-dash', tools.appName.toLowerCase() + '.xbox'];
+    const isRootOnUnix     = typeof process.getuid === 'function' && process.getuid() === 0;
     let  JSZip;
 
     /** @type {Install} */
@@ -336,11 +337,13 @@ function Install(options) {
         }
 
         // zwave for example requires always unsafe-perm option
-        for (let a = 0; a < unsafePermAlways.length; a++) {
-            if (npmUrl.indexOf(unsafePermAlways[a]) !== -1) {
-                options.unsafePerm = true;
-                break;
-            }
+        if (unsafePermAlways.some(adapter => npmUrl.indexOf(adapter) > -1)) {
+            options.unsafePerm = true;
+        } else if (isRootOnUnix) {
+            // If ioBroker or the CLI is executed as root on unix platforms,
+            // not providing the --unsafe-perm options means that every pre/postinstall
+            // script fails when it uses npm commands.
+            options.unsafePerm = true;
         }
 
         const cmd = 'npm install ' + npmUrl + (options.unsafePerm ? ' --unsafe-perm' : '') + ' --production --save --prefix "' + cwd + '"';


### PR DESCRIPTION
This prevents errors during adapter installation when a pre/postinstall script needs to use npm commands.
Otherwise this happens:
`Error: EACCES: permission denied, scandir '/root/.npm/_logs'npm ERR!`

Should I backport this to master aswell?