### PR TITLE
Ability to define secured objects in io-pack access only via own adapter and admin

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -1839,7 +1839,14 @@ function Adapter(options) {
                 callback = options;
                 options = null;
             }
-            that.objects.getObject(id, options, callback);
+            that.objects.getObject(id, options, (err, obj) => {
+                if(obj._id.startsWith('system.adapter') && that.namespace.split('.')[0] !== 'admin' &&
+                    that.namespace.split('.')[0] !== obj._id.split('.')[2]) {
+                    delete obj.protectedNative;
+                } // endIf
+                logger.warn('test: ' + err + JSON.stringify(obj) + that.namespace);
+                if (callback && typeof callback === 'function') callback(err, obj);
+            });
         };
         /**
          * Promise-version of Adapter.getForeignObject
@@ -2344,7 +2351,7 @@ function Adapter(options) {
                     that.setState(id, common.def, common.defAck, options);
                 } else {
                     that.setState(id, common.def, options);
-                } 	
+                }
             } else {
                 that.setState(id, null, true, options);
             }
@@ -5423,6 +5430,7 @@ function Adapter(options) {
 
     function initAdapter(adapterConfig) {
         initLogging(() => {
+            logger.warn('adapterConf: ' + JSON.stringify(adapterConfig)); // test
             if (options.instance === undefined) {
                 if (!adapterConfig || !adapterConfig.common || !adapterConfig.common.enabled) {
                     if (adapterConfig && adapterConfig.common && adapterConfig.common.enabled !== undefined) {
@@ -5473,7 +5481,7 @@ function Adapter(options) {
                 } else {
                     name = options.name;
                     instance = 0;
-                    adapterConfig = adapterConfig || {common: {mode: 'once', name: name}, native: {}};
+                    adapterConfig = adapterConfig || {common: {mode: 'once', name: name}, native: {}, protectedNative: {}};
                 }
 
                 for (const tp in logger.transports) {
@@ -5488,6 +5496,7 @@ function Adapter(options) {
                 process.title = 'io.' + that.namespace;
 
                 that.config = adapterConfig.native;
+                that.protectedConfig = adapterConfig.protectedNative;
                 that.host = adapterConfig.common.host;
                 that.common = adapterConfig.common;
 
@@ -5522,6 +5531,7 @@ function Adapter(options) {
                 that.namespace = that.name + '.' + that.instance;
 
                 that.config = adapterConfig.native || {};
+                that.protectedConfig = adapterConfig.protectedNative || {};
                 that.common = adapterConfig.common || {};
                 that.host = that.common.host || tools.getHostName() || require('os').hostname();
             }

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -1053,11 +1053,21 @@ function Adapter(options) {
                 if ((options.noNamespace || config.noNamespace) && that._namespaceRegExp.test(id)) {
                     // emit 'objectChange' event instantly
                     setImmediate(() => {
+                        // remove protectedNative if not admin or own adapter
+                        if(obj._id.startsWith('system.adapter') && that.namespace.split('.')[0] !== 'admin' &&
+                            that.namespace.split('.')[0] !== obj._id.split('.')[2]) {
+                            delete obj.protectedNative;
+                        } // endIf
                         if (typeof options.objectChange === 'function') options.objectChange(id.substring(that.namespace.length + 1), obj);
                         that.emit('objectChange', id.substring(that.namespace.length + 1), obj);
                     });
                 } else {
                     setImmediate(() => {
+                        // remove protectedNative if not admin or own adapter
+                        if(obj._id.startsWith('system.adapter') && that.namespace.split('.')[0] !== 'admin' &&
+                            that.namespace.split('.')[0] !== obj._id.split('.')[2]) {
+                            delete obj.protectedNative;
+                        } // endIf
                         if (typeof options.objectChange === 'function') options.objectChange(id, obj);
                         // emit 'objectChange' event instantly
                         that.emit('objectChange', id, obj);

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -1821,6 +1821,10 @@ function Adapter(options) {
                 callback = options;
                 options = null;
             }
+            if (typeof type === 'function') {
+                callback = type;
+                type = null;
+            }
             that.objects.findObject(id, type, options, callback);
         };
         /**

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -1844,7 +1844,6 @@ function Adapter(options) {
                     that.namespace.split('.')[0] !== obj._id.split('.')[2]) {
                     delete obj.protectedNative;
                 } // endIf
-                logger.warn('test: ' + err + JSON.stringify(obj) + that.namespace);
                 if (callback && typeof callback === 'function') callback(err, obj);
             });
         };
@@ -5430,7 +5429,6 @@ function Adapter(options) {
 
     function initAdapter(adapterConfig) {
         initLogging(() => {
-            logger.warn('adapterConf: ' + JSON.stringify(adapterConfig)); // test
             if (options.instance === undefined) {
                 if (!adapterConfig || !adapterConfig.common || !adapterConfig.common.enabled) {
                     if (adapterConfig && adapterConfig.common && adapterConfig.common.enabled !== undefined) {


### PR DESCRIPTION
-this implements the idea of #250 
-adapter dev can define in io-package:

```json
    "native": {
        "ip": "",
        "liveId": ""
    },
    "protectedNative": {
	"mail": "",
        "password": ""
    }
```

-the PR makes the protectedNative accessible for developers e. g. via ``adapter.protectedConfig.password``
-theres also a small fix included for ``adapter.findForeignObject`` which is now working according to the documentation (defining type is optional)
-everytime the system.adapter.<adaptername> object of an adapter is triying to got via ``getForeignObject`` or is subscribed the protectedNative will be removed by the controller.