### PR TITLE
Revert the changes to `del[Foreign]State`, so the object is not deleted.

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -993,8 +993,8 @@ function Adapter(options) {
                 if (options.useFormatDate) {
                     that.getForeignObject('system.config', (err, data) => {
                         if (data && data.common) {
-                        	that.dateFormat   = data.common.dateFormat;
-                        	that.isFloatComma = data.common.isFloatComma;
+                            that.dateFormat   = data.common.dateFormat;
+                            that.isFloatComma = data.common.isFloatComma;
                         }
                         if (data && data.native) {
                             systemSecret = data.native.secret;
@@ -1076,6 +1076,10 @@ function Adapter(options) {
 
         that._namespaceRegExp = new RegExp('^' + that.namespace);       // chache the regex object 'adapter.0'
 
+        /**
+         * @param {string | {device?: string, channel?: string, state?: string}} id
+         * @param {boolean} [isPattern=false]
+         */
         that._fixId = function _fixId(id, isPattern/* , type */) {
             let result  = '';
             // If id is an object
@@ -1332,7 +1336,7 @@ function Adapter(options) {
                 (obj.native && obj.native.repositories) ||
                 (obj.native && obj.native.certificates) ||
                 (obj.native && obj.native.devices))
-                ) {
+            ) {
                 // Read whole object
                 that.objects.getObject(id, options, (err, oldObj) => {
                     if (err) {
@@ -1773,7 +1777,7 @@ function Adapter(options) {
                                     if (_enums[es][e].common.members.indexOf(id)      !== -1 ||
                                         _enums[es][e].common.members.indexOf(channel) !== -1 ||
                                         _enums[es][e].common.members.indexOf(device)  !== -1) {
-                                            list[id].enums[e] = _enums[es][e].common.name;
+                                        list[id].enums[e] = _enums[es][e].common.name;
                                     }
                                 }
                             }
@@ -1847,10 +1851,12 @@ function Adapter(options) {
         that.getForeignObjectAsync = tools.promisify(that.getForeignObject, that);
 
         /**
-         * Delete object of this instance.
+         * Delete an object of this instance.
          *
-         * It is not required, that ID consists namespace. E.g. to get object of "adapterName.X.myObject", only "myObject" is required as ID.
-         * State will be deleted too if the object has type "state".
+         * It is not required to provice the adapter namespace, because it will automatically be added.
+         * E.g. to delete "adapterName.X.myObject", only "myObject" is required as ID.
+         *
+         * The corresponding state will be deleted too if the object has type "state".
          *
          * @alias delObject
          * @memberof Adapter
@@ -1864,36 +1870,9 @@ function Adapter(options) {
          *        </code></pre>
          */
         that.delObject = function delObject(id, options, callback) {
-            if (typeof options === 'function') {
-                callback = options;
-                options = null;
-            }
-
-            that.objects.getObject(that._fixId(id), options, (err, obj) => {
-                if (err || !obj) {
-                    return (typeof callback === 'function') && callback(err || ERROR_OBJ_NOT_FOUND);
-                } else {
-                    that.objects.delObject(obj._id, options, err => {
-                        if (err || obj.type !== 'state') {
-                            return (typeof callback === 'function') && callback(err);
-                        } else {
-                            id = that._fixId(id, false, 'state');
-
-                            if (options && options.user && options.user !== 'system.user.admin') {
-                                checkStates(id, options, 'delState', err => {
-                                    if (err) {
-                                        if (typeof callback === 'function') callback(err);
-                                    } else {
-                                        that.states.delState(id, callback);
-                                    }
-                                });
-                            } else {
-                                that.states.delState(id, callback);
-                            }
-                        }
-                    });
-                }
-            });
+            // delObject does the same as delForeignObject, but fixes the ID first
+            id = that._fixId(id);
+            that.delForeignObject(id, options, callback);
         };
         /**
          * Promise-version of Adapter.delObject
@@ -1903,7 +1882,7 @@ function Adapter(options) {
         /**
          * Delete any object.
          *
-         * ID must be specified with namespace. It deletes state of object too if type of object is "state".
+         * The full ID with namespace must be specified. The corresponding state will be deleted too if the object has type "state".
          *
          * @alias delForeignObject
          * @memberof Adapter
@@ -1930,17 +1909,7 @@ function Adapter(options) {
                         if (err || obj.type !== 'state') {
                             return (typeof callback === 'function') && callback(err);
                         } else {
-                            if (options && options.user && options.user !== 'system.user.admin') {
-                                checkStates(id, options, 'delState', err => {
-                                    if (err) {
-                                        if (typeof callback === 'function') callback(err);
-                                    } else {
-                                        that.states.delState(id, callback);
-                                    }
-                                });
-                            } else {
-                                that.states.delState(id, callback);
-                            }
+                            that.delForeignState(id, options, callback);
                         }
                     });
                 }
@@ -2344,7 +2313,7 @@ function Adapter(options) {
                     that.setState(id, common.def, common.defAck, options);
                 } else {
                     that.setState(id, common.def, options);
-                } 	
+                }
             } else {
                 that.setState(id, null, true, options);
             }
@@ -3586,7 +3555,7 @@ function Adapter(options) {
             const errors = [];
             let count = ids.length;
             if (count === 0) {
-	        callback(null, ids);
+                callback(null, ids);
                 return;
             }
             for (let i = 0; i < ids.length; i++) {
@@ -3614,10 +3583,10 @@ function Adapter(options) {
             options.checked = true;
             that.objects.getObject(ids, options, (err, obj) => {
                 if (originalChecked !== undefined) {
-					options.checked = originalChecked;
-				} else {
-					options.checked = undefined;
-				}
+                    options.checked = originalChecked;
+                } else {
+                    options.checked = undefined;
+                }
                 if (err) {
                     callback(err, {_id: ids});
                     return;
@@ -4658,10 +4627,13 @@ function Adapter(options) {
         };
 
         /**
-         * Same as @delObject
+         * Deletes a state of this instance.
+         * The object will NOT be deleted. If you want to delete it too, use @delObject instead.
          *
-         * It is not required, that ID consists namespace. E.g. to get object of "adapterName.X.myObject", only "myObject" is required as ID.
-         * State will be deleted too if the object has type "state". Returns no error if state does not exist.
+         * It is not required to provice the adapter namespace, because it will automatically be added.
+         * E.g. to delete "adapterName.X.myObject", only "myObject" is required as ID.
+         *
+         * No error is returned if state does not exist.
          *
          * @alias delState
          * @memberof Adapter
@@ -4675,16 +4647,9 @@ function Adapter(options) {
          *        </code></pre>
          */
         that.delState = function (id, options, callback) {
-            if (typeof options === 'function') {
-                callback = options;
-                options = null;
-            }
-            that.delObject(id, options, err => {
-                if (typeof callback === 'function') {
-                    // ignore "not found" error
-                    callback(err === ERROR_OBJ_NOT_FOUND ? null : err);
-                }
-            });
+            // delState does the same as delForeignState, but fixes the ID first
+            id = that._fixId(id);
+            that.delForeignState(id, options, callback);
         };
         /**
          * Promise-version of Adapter.delState
@@ -4692,15 +4657,10 @@ function Adapter(options) {
         that.delStateAsync = tools.promisify(that.delState, that);
 
         /**
-         * Delete one state of any adapter. Same as @delForeignObject
+         * Deletes a state of any adapter.
+         * The object is NOT deleted. If you want to delete it too, use @delForeignObject instead.
          *
-         * Deletes the state and object. If State does not exist, no error will be returned.
-         * Do not forget do delete the object for the state too (with delObject)
-         * <pre><code>
-         *     adapter.delState('adapterName.0.stateID', function (err) {
-         *         console.log('adapterName.0.stateID is deleted');
-         *     });
-         * </code></pre>
+         * No error is returned if state does not exist.
          *
          * @alias delForeignState
          * @memberof Adapter
@@ -4713,12 +4673,17 @@ function Adapter(options) {
                 callback = options;
                 options = null;
             }
-            that.delForeignObject(id, options, err => {
-                if (typeof callback === 'function') {
-                    // ignore "not found" error
-                    callback(err === ERROR_OBJ_NOT_FOUND ? null : err);
-                }
-            });
+            if (options && options.user && options.user !== 'system.user.admin') {
+                checkStates(id, options, 'delState', function (err) {
+                    if (err) {
+                        if (typeof callback === 'function') callback(err);
+                    } else {
+                        that.states.delState(id, callback);
+                    }
+                });
+            } else {
+                that.states.delState(id, callback);
+            }
         };
         /**
          * Promise-version of Adapter.delForeignState
@@ -5142,7 +5107,7 @@ function Adapter(options) {
          * @memberof Adapter
          *
          * @param {string} id of state
-         * @param {buffer} binary data
+         * @param {Buffer} binary data
          * @param {object} options optional
          * @param {function} callback
          *
@@ -5170,7 +5135,7 @@ function Adapter(options) {
          * @alias setBinaryStateAsync
          * @memberof Adapter
          * @param {string} id of state
-         * @param {buffer} binary data
+         * @param {Buffer} binary data
          * @param {object} options optional
          * @return promise
          *
@@ -5715,12 +5680,12 @@ function Adapter(options) {
         logger.error(that.namespace + ' uncaught exception: ' + (err.message || err));
         if (err.stack) logger.error(that.namespace + ' ' + err.stack);
 
-		try {
-			stop();
-			setTimeout(() => that.terminate(EXIT_CODES.UNCAUGHT_EXCEPTION), 1000);
-		} catch (err) {
-			logger.error(that.namespace + ' exception by stop: ' + (err.message || err));
-		}
+        try {
+            stop();
+            setTimeout(() => that.terminate(EXIT_CODES.UNCAUGHT_EXCEPTION), 1000);
+        } catch (err) {
+            logger.error(that.namespace + ' exception by stop: ' + (err.message || err));
+        }
     });
 
     return this;


### PR DESCRIPTION
Read this PR with *ignore whitespace* on!
Fixes: #268 

`del[Foreign]Object` still deletes the states because that makes sense.

Additionally:
* Combine the logic of delForeignState and delState
* Combine the logic of delForeignObject and delObject