### PR TITLE
Fix the return type of `set[Foreign]Object[NotExists]`

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -1106,6 +1106,29 @@ function Adapter(options) {
         };
 
         /**
+         * Helper method for `set[Foreign]Object[NotExists]` that also sets the default value if one is configured
+         * @param {string} id of the object
+         * @param obj The object to set
+         * @param {unknown} [options]
+         * @param callback
+         */
+        function setObjectWithDefaultValue(id, obj, options, callback) {
+            if (typeof options === 'function') {
+                callback = options;
+                options = undefined;
+            }
+            that.objects.setObject(id, obj, options, (err, result) => {
+                if (!err && obj.common.def !== undefined) {
+                    that.setState(id, obj.common.def, true, null, () => {
+                        if (typeof callback === 'function') callback(err, result);
+                    });
+                } else if (typeof callback === 'function') {
+                    callback(err, result);
+                }
+            });
+        }
+
+        /**
          * Creates or overwrites object in objectDB.
          *
          * This function can create or overwrite objects in objectDB for this adapter.
@@ -1191,13 +1214,8 @@ function Adapter(options) {
                 if (!obj.from) obj.from = 'system.adapter.' + that.namespace;
                 if (!obj.user) obj.user = (options ? options.user : '') || 'system.user.admin';
                 if (!obj.ts) obj.ts = Date.now();
-                that.objects.setObject(id, obj, options, (err) => {
-                    if (err) {
-                        if (typeof callback === 'function') callback(err);
-                    } else if (obj.common.def !== undefined) {
-                        that.setState(id, obj.common.def, true, null, callback);
-                    } else if (typeof callback === 'function') callback(err);
-                });
+
+                setObjectWithDefaultValue(id, obj, options, callback);
 
             } else {
                 logger.error(that.namespace + ' setObject ' + id + ' mandatory property type missing!');
@@ -1416,7 +1434,7 @@ function Adapter(options) {
                 id = mId;
             }
 
-            that.objects.setObject(id, obj, options, callback);
+            setObjectWithDefaultValue(id, obj, options, callback);
         };
         /**
          * Promise-version of Adapter.setForeignObject
@@ -2096,13 +2114,7 @@ function Adapter(options) {
                     if (!obj.user) obj.user = (options ? options.user : '') || 'system.user.admin';
                     if (!obj.ts) obj.ts = Date.now();
 
-                    that.objects.setObject(id, obj, (err) => {
-                        if (err) {
-                            if (typeof callback === 'function') callback(err);
-                        } else if (obj.common.def !== undefined) {
-                            that.setState(id, obj.common.def, true, null, callback);
-                        } else if (typeof callback === 'function') callback(err);
-                    });
+                    setObjectWithDefaultValue(id, obj, callback);
                 } else {
                     if (typeof callback === 'function') callback(null);
                 }
@@ -2143,7 +2155,7 @@ function Adapter(options) {
                     if (!obj.user) obj.user = (options ? options.user : '') || 'system.user.admin';
                     if (!obj.ts) obj.ts = Date.now();
 
-                    that.objects.setObject(id, obj, callback);
+                    setObjectWithDefaultValue(id, obj, callback);
                 } else {
                     if (typeof callback === 'function') callback(null);
                 }


### PR DESCRIPTION
#273 broke the return type of `setObject[NotExists]`, which used to be `{id: string}` and now is just null in most cases.

This PR fixes that and also adds default value to setForeignObject[NotExists]