### PR TITLE
Add the CLI command `iobroker logs [adaptername] [--all]`

### DIFF
--- a/lib/cli/cliLogs.js
+++ b/lib/cli/cliLogs.js
@@ -1,0 +1,70 @@
+'use strict';
+// const CLI = require('./messages.js');
+const CLICommand = require('./cliCommand.js');
+const {getDefaultDataDir} = require('../tools');
+const chokidar = require('chokidar');
+const fs = require('fs');
+
+/** Command iobroker state ... */
+module.exports = class CLILogs extends CLICommand {
+
+    /** @param {import('./cliCommand').CLICommandOptions} options */
+    constructor(options) {
+        super(options);
+        /** @type {Map<string, number>} */
+        this.fileSizes = new Map();
+        this.isReady = false;
+    }
+
+    /**
+     * Executes a command
+     * @param {any[]} _args
+     */
+    execute(_args) {
+        // TODO: There must be a better way to find the log dir
+        const logDir = getDefaultDataDir().replace(/\/[^/]+\/?$/, '/log');
+        chokidar.watch(`${logDir}/iobroker*`)
+            .on('all', this.watchHandler.bind(this))
+            .on('ready', () => this.isReady = true)
+        ;
+    }
+
+    /**
+     * Called by chokidar when watched files change
+     * @param {string} event The type of change
+     * @param {*} path Which path has changed
+     * @param {*} stats Information about the file
+     */
+    watchHandler(event, path, stats) {
+        if (event === 'add' || !this.fileSizes.has(path)) {
+            this.fileSizes.set(path, stats.size);
+            if (this.isReady && stats.size > 0) {
+                this.streamChange(path, 0, stats.size);
+            }
+        } else if (event === 'change') {
+            const oldFileSize = this.fileSizes.get(path);
+            this.fileSizes.set(path, stats.size);
+            if (this.isReady && stats.size > oldFileSize) {
+                this.streamChange(path, oldFileSize, stats.size);
+            }
+        } else if (event === 'unlink') {
+            this.fileSizes.delete(path);
+        }
+    }
+
+    /**
+     * Streams a portion of a file to the console
+     * @param {string} path The file to stream
+     * @param {number} from The offset in bytes where to start
+     * @param {number} to The offset in bytes where to end (exclusive)
+     */
+    streamChange(path, from, to) {
+        fs.createReadStream(path, {
+            encoding: 'utf8',
+            start: from,
+            end: to - 1,
+            autoClose: true
+        }).pipe(process.stdout);
+    }
+};
+

--- a/lib/cli/cliLogs.js
+++ b/lib/cli/cliLogs.js
@@ -4,7 +4,9 @@ const CLICommand = require('./cliCommand.js');
 const { getDefaultDataDir } = require('../tools');
 const chokidar = require('chokidar');
 const fs = require('fs');
+const os = require('os');
 const path = require('path');
+const es = require('event-stream');
 
 /** Command iobroker state ... */
 module.exports = class CLILogs extends CLICommand {
@@ -23,11 +25,12 @@ module.exports = class CLILogs extends CLICommand {
      */
     execute(args) {
 
-        /** @type {string} */
-        const param = args[0];
-        /** @type {WatchHandlerOptions} */
+        /** @type {string | undefined} */
+        const adapterName = args[0];
+        /** @type {CLILogsOptions} */
         const options = {
-            complete: param === 'all'
+            complete: this.options['all'],
+            adapterName
         };
 
         // TODO: There must be a better way to find the log dir
@@ -44,13 +47,14 @@ module.exports = class CLILogs extends CLICommand {
     }
 
     /**
-     * @typedef WatchHandlerOptions
+     * @typedef CLILogsOptions
      * @property {boolean} [complete] Whether to show today's full log
+     * @property {string} [adapterName] An optional adapter name to filter by
      */
 
     /**
      * Called by chokidar when watched files change
-     * @param {WatchHandlerOptions} options some options
+     * @param {CLILogsOptions} options some options
      * @param {string} event The type of change
      * @param {*} path Which path has changed
      * @param {*} stats Information about the file
@@ -64,13 +68,13 @@ module.exports = class CLILogs extends CLICommand {
                     || (options.complete && this.isTodaysLogfile(path))
                 )
             ) {
-                this.streamChange(path, 0);
+                this.streamChange(path, 0, options);
             }
         } else if (event === 'change') {
             const oldFileSize = this.fileSizes.get(path);
             this.fileSizes.set(path, stats.size);
             if (this.isReady && stats.size > oldFileSize) {
-                this.streamChange(path, oldFileSize);
+                this.streamChange(path, oldFileSize, options);
             }
         } else if (event === 'unlink') {
             this.fileSizes.delete(path);
@@ -90,13 +94,27 @@ module.exports = class CLILogs extends CLICommand {
      * Streams a portion of a file to the console
      * @param {string} path The file to stream
      * @param {number} start The offset in bytes where to start
+     * @param {CLILogsOptions} options some options
      */
-    streamChange(path, start) {
-        fs.createReadStream(path, {
+    streamChange(path, start, options) {
+        const input = fs.createReadStream(path, {
             encoding: 'utf8',
             start: start,
             autoClose: true
-        }).pipe(process.stdout);
+        });
+        if (options.adapterName != undefined) {
+            // Read the input line by line and only include the lines matching the filter
+            input
+                .pipe(es.split())
+                // @ts-ignore
+                .pipe(es.filterSync(line => line.indexOf(options.adapterName) > -1))
+                .pipe(es.mapSync(line => line + os.EOL))
+                .pipe(process.stdout)
+            ;
+        } else {
+            // just pipe the input through
+            input.pipe(process.stdout);
+        }
     }
 };
 

--- a/lib/cli/cliLogs.js
+++ b/lib/cli/cliLogs.js
@@ -4,6 +4,7 @@ const CLICommand = require('./cliCommand.js');
 const { getDefaultDataDir } = require('../tools');
 const chokidar = require('chokidar');
 const fs = require('fs');
+const path = require('path');
 
 /** Command iobroker state ... */
 module.exports = class CLILogs extends CLICommand {
@@ -30,7 +31,12 @@ module.exports = class CLILogs extends CLICommand {
         };
 
         // TODO: There must be a better way to find the log dir
-        const logDir = getDefaultDataDir().replace(/\/[^/]+\/?$/, '/log');
+        const logDir = path.join(
+            __dirname, // from here
+            '../..', // go to js-controller root
+            // and from there to the logs dir
+            getDefaultDataDir().replace(/\/[^/]+\/?$/, '/log')
+        );
         chokidar.watch(`${logDir}/iobroker*`, { awaitWriteFinish: { stabilityThreshold: 500 } })
             .on('all', this.watchHandler.bind(this, options))
             .on('ready', () => this.isReady = true)

--- a/lib/cli/cliLogs.js
+++ b/lib/cli/cliLogs.js
@@ -1,7 +1,7 @@
 'use strict';
 // const CLI = require('./messages.js');
 const CLICommand = require('./cliCommand.js');
-const {getDefaultDataDir} = require('../tools');
+const { getDefaultDataDir } = require('../tools');
 const chokidar = require('chokidar');
 const fs = require('fs');
 
@@ -18,34 +18,53 @@ module.exports = class CLILogs extends CLICommand {
 
     /**
      * Executes a command
-     * @param {any[]} _args
+     * @param {any[]} args
      */
-    execute(_args) {
+    execute(args) {
+
+        /** @type {string} */
+        const param = args[0];
+        /** @type {WatchHandlerOptions} */
+        const options = {
+            complete: param === 'all'
+        };
+
         // TODO: There must be a better way to find the log dir
         const logDir = getDefaultDataDir().replace(/\/[^/]+\/?$/, '/log');
-        chokidar.watch(`${logDir}/iobroker*`)
-            .on('all', this.watchHandler.bind(this))
+        chokidar.watch(`${logDir}/iobroker*`, { awaitWriteFinish: { stabilityThreshold: 500 } })
+            .on('all', this.watchHandler.bind(this, options))
             .on('ready', () => this.isReady = true)
         ;
     }
 
     /**
+     * @typedef WatchHandlerOptions
+     * @property {boolean} [complete] Whether to show today's full log
+     */
+
+    /**
      * Called by chokidar when watched files change
+     * @param {WatchHandlerOptions} options some options
      * @param {string} event The type of change
      * @param {*} path Which path has changed
      * @param {*} stats Information about the file
      */
-    watchHandler(event, path, stats) {
+    watchHandler(options, event, path, stats) {
         if (event === 'add' || !this.fileSizes.has(path)) {
             this.fileSizes.set(path, stats.size);
-            if (this.isReady && stats.size > 0) {
-                this.streamChange(path, 0, stats.size);
+            if (
+                stats.size > 0 && (
+                    this.isReady
+                    || (options.complete && this.isTodaysLogfile(path))
+                )
+            ) {
+                this.streamChange(path, 0);
             }
         } else if (event === 'change') {
             const oldFileSize = this.fileSizes.get(path);
             this.fileSizes.set(path, stats.size);
             if (this.isReady && stats.size > oldFileSize) {
-                this.streamChange(path, oldFileSize, stats.size);
+                this.streamChange(path, oldFileSize);
             }
         } else if (event === 'unlink') {
             this.fileSizes.delete(path);
@@ -53,16 +72,23 @@ module.exports = class CLILogs extends CLICommand {
     }
 
     /**
+     * If the log file belongs to today
+     * @param {string} path The log file path
+     */
+    isTodaysLogfile(path) {
+        const YYYYMMDDDate = new Date().toJSON().slice(0, 10);
+        return path.indexOf(YYYYMMDDDate) > -1;
+    }
+
+    /**
      * Streams a portion of a file to the console
      * @param {string} path The file to stream
-     * @param {number} from The offset in bytes where to start
-     * @param {number} to The offset in bytes where to end (exclusive)
+     * @param {number} start The offset in bytes where to start
      */
-    streamChange(path, from, to) {
+    streamChange(path, start) {
         fs.createReadStream(path, {
             encoding: 'utf8',
-            start: from,
-            end: to - 1,
+            start: start,
             autoClose: true
         }).pipe(process.stdout);
     }

--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -9,6 +9,7 @@ module.exports = {
         object: require('./cliObjects.js'),
         state: require('./cliStates.js'),
         process: require('./cliProcess.js'),
-        message: require('./cliMessage.js')
+        message: require('./cliMessage.js'),
+        logs: require('./cliLogs.js')
     }
 };

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -38,6 +38,7 @@ function initYargs() {
                 tools.appName + ' restart\n' +
                 tools.appName + ' restart <adapter>\n' +
                 tools.appName + ' info\n' +
+                tools.appName + ' logs\n' +
                 tools.appName + ' add <adapter> [desiredNumber] [--enabled] [--host <host>] [--port <port>]\n' +
                 tools.appName + ' install <adapter>\n' +
                 tools.appName + ' url <url> [<name>]\n' +
@@ -620,6 +621,12 @@ function processCommand(command, args, params, callback) {
         case 'message': {
             const messageCommand = new cli.command.message(commandOptions);
             messageCommand.execute(args);
+            break;
+        }
+
+        case 'logs': {
+            const logsCommand = new cli.command.logs(commandOptions);
+            logsCommand.execute(args);
             break;
         }
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "bluebird": "^3.5.1",
+    "chokidar": "^2.0.4",
     "daemonize2": "^0.4.2",
     "iobroker.admin": ">=2.0.9",
     "iobroker.objects-redis": "^0.2.4",
@@ -42,6 +43,7 @@
     "yargs": "^12.0.1"
   },
   "devDependencies": {
+    "@types/chokidar": "^1.7.5",
     "@types/mocha": "^5.2.5",
     "@types/node": "^6.0.109",
     "@types/yargs": "^12.0.1",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "bluebird": "^3.5.1",
     "chokidar": "^2.0.4",
     "daemonize2": "^0.4.2",
+    "event-stream": "^4.0.1",
     "iobroker.admin": ">=2.0.9",
     "iobroker.objects-redis": "^0.2.4",
     "jsonwebtoken": "^8.3.0",
@@ -44,6 +45,7 @@
   },
   "devDependencies": {
     "@types/chokidar": "^1.7.5",
+    "@types/event-stream": "^3.3.34",
     "@types/mocha": "^5.2.5",
     "@types/node": "^6.0.109",
     "@types/yargs": "^12.0.1",


### PR DESCRIPTION
Fixes #275 

`iobroker logs` starts a realtime-streaming of the current iobroker logfile to the console, just like `tail -n 0 -f` does:
![unbenannt](https://user-images.githubusercontent.com/17641229/50721875-fa467000-10c6-11e9-9fa3-b28037d846f7.PNG)

`iobroker logs --all` first shows the entire today's logfile, like `cat filename && tail -n 0 -f filename`

`iobroker logs adaptername [--all]` allows filtering by the adapter/instance name:
![unbenannt](https://user-images.githubusercontent.com/17641229/50722181-7642b700-10cb-11e9-8401-efab417e2bbf.PNG)
