### PR TITLE
Fix error introduced by 23f02c1

### DIFF
--- a/lib/setup/setupRepo.js
+++ b/lib/setup/setupRepo.js
@@ -49,7 +49,7 @@ function Repo(options) {
                     if (ioPack && ioPack.common) {
                         result[name] = extend(true, sources[name], ioPack.common);
                     }
-                    setImmediate(downloads, sources, result, sourcesHash, callback);
+                    setImmediate(download, downloads, sources, result, sourcesHash, callback);
                 });
             } else if (sources[name].url) {
                 console.log('Cannot get version of "' + name + '".');
@@ -57,7 +57,7 @@ function Repo(options) {
             } else {
                 console.log('Cannot get any information of "' + name + '". Ignored.');
             }
-            setImmediate(downloads, sources, result, sourcesHash, callback);
+            setImmediate(download, downloads, sources, result, sourcesHash, callback);
         }
     }
 


### PR DESCRIPTION
`setImmediate` expects the target method as the first argument