### PR TITLE
Bind this context inside Log class

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -5601,6 +5601,16 @@ function Adapter(options) {
                 constructor(adapter, level) {
                     this.adapter = adapter;
                     this.level = level;
+                    // We have to bind the this context here or it is possible that `this` is
+                    // undefined when passing around the logger methods. This happens e.g. when doing this:
+                    //   const log = new Log(...);
+                    //   const test = log.info;
+                    //   test();
+                    this.silly = this.silly.bind(this);
+                    this.debug = this.debug.bind(this);
+                    this.info = this.info.bind(this);
+                    this.error = this.error.bind(this);
+                    this.warn = this.warn.bind(this);
                 }
                 silly(msg) {
                     logger.silly(this.adapter.namespace + ' ' + msg);


### PR DESCRIPTION
This preserves the this context, even when the logger functions are passed around:
```js
const log = new Log(...);
const test = log.info;
test("message");
// ^- this previously failed
```