### PR TITLE
fix npm install specialities

### DIFF
--- a/lib/setup.js
+++ b/lib/setup.js
@@ -2024,11 +2024,13 @@ function installNpm(adapter, callback) {
         });
         child.stderr.pipe(process.stdout);
         child.on('exit', (code, _signal) => {
-            if (code) {
+            // code 1 is strange error that cannot be explained. Everything is installed but error :(
+            if (code && code !== 1) {
                 console.log('Cannot install ' + tools.appName + '.' + adapter + ': ' + code);
                 (callback || processExit)(EXIT_CODES.CANNOT_INSTALL_NPM_PACKET);
             }
             // command succeeded
+            fs.writeFileSync(path + '/iob_npm.done', ' ');
             if (callback) callback(null, adapter);
         });
     } else {


### PR DESCRIPTION
* make sure to also allow weired exit code 1 from npm as success like in all other places too. This should fix cases where upload is missing or such when ioBroker thinks a second npm install is needed

* make sure to create the iob_npm.done file after the additional npm install because it is missing :-)