### PR TITLE
Use vm2 for compact mode

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -3946,8 +3946,7 @@ function Adapter(options) {
                 if (id === 'system.adapter.' + this.namespace + '.sigKill') {
                     if (this.startedInCompactMode) {
                         logger.info('Got terminate signal.');
-                    }
-                    else {
+                    } else {
                         logger.warn('Got terminate signal. Desired PID: ' + state.val + ' <> own PID ' + process.pid);
                     }
                     if (state && state.val !== process.pid && !config.forceIfDisabled) {

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -3944,7 +3944,12 @@ function Adapter(options) {
                 }
 
                 if (id === 'system.adapter.' + this.namespace + '.sigKill') {
-                    logger.warn('Got terminate signal. Desired PID: ' + state.val + ' <> own PID ' + process.pid);
+                    if (this.startedInCompactMode) {
+                        logger.info('Got terminate signal.');
+                    }
+                    else {
+                        logger.warn('Got terminate signal. Desired PID: ' + state.val + ' <> own PID ' + process.pid);
+                    }
                     if (state && state.val !== process.pid && !config.forceIfDisabled) {
                         stop();
                         setTimeout(() => this.terminate(EXIT_CODES.NO_ERROR), 4000);

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -197,6 +197,7 @@ function Adapter(options) {
             exitCode === EXIT_CODES.ADAPTER_REQUESTED_TERMINATION
             || exitCode === EXIT_CODES.START_IMMEDIATELY_AFTER_STOP
             || exitCode === EXIT_CODES.START_IMMEDIATELY_AFTER_STOP_HEX
+            || exitCode === EXIT_CODES.NO_ERROR
         ;
 
         const text = `Terminated (${getErrorText(exitCode)}): ${reason ? reason : 'Without reason'}`;

--- a/main.js
+++ b/main.js
@@ -2585,10 +2585,15 @@ function stopInstance(id, callback) {
     if (!instance || !instance.common || !instance.common.mode) {
         if (procs[id].process) {
             procs[id].stopping = true;
-            try {
-                procs[id].process.kill();  // call stop directly in adapter.js or call kill of process
-            } catch (e) {
-                logger.error(`host.${hostname} Cannot stop ${id}: ${JSON.stringify(e)}`);
+            if (!procs[id].startedInCompactMode) {
+                try {
+                    procs[id].process.kill();  // call stop directly in adapter.js or call kill of process
+                } catch (e) {
+                    logger.error(`host.${hostname} Cannot stop ${id}: ${JSON.stringify(e)}`);
+                }
+            }
+            else {
+                states.setState(id + '.sigKill', {val: -1, ack: false, from: 'system.host.' + hostname});
             }
             delete procs[id].process;
         }
@@ -2639,12 +2644,16 @@ function stopInstance(id, callback) {
                         logger.info('host.' + hostname + ' stopInstance self ' + instance._id + ' killing pid ' + procs[id].process.pid + (result ? ': ' + result : ''));
                         if (procs[id].process) {
                             procs[id].stopping = true;
-                            try {
-                                procs[id].process.kill(); // call stop directly in adapter.js or call kill of process
-                            } catch (e) {
-                                logger.error(`host.${hostname} Cannot stop ${id}: ${JSON.stringify(e)}`);
+                            if (!procs[id].startedInCompactMode) {
+                                try {
+                                    procs[id].process.kill(); // call stop directly in adapter.js or call kill of process
+                                } catch (e) {
+                                    logger.error(`host.${hostname} Cannot stop ${id}: ${JSON.stringify(e)}`);
+                                }
                             }
-
+                            else {
+                                states.setState(id + '.sigKill', {val: -1, ack: false, from: 'system.host.' + hostname});
+                            }
                             delete procs[id].process;
                         }
 
@@ -2661,10 +2670,15 @@ function stopInstance(id, callback) {
                         if (procs[id].process) {
                             logger.info('host.' + hostname + ' stopInstance timeout "' + timeoutDuration + ' ' + instance._id + ' killing pid  ' + procs[id].process.pid);
                             procs[id].stopping = true;
-                            try {
-                                procs[id].process.kill(); // call stop directly in adapter.js or call kill of process
-                            } catch (e) {
-                                logger.error(`host.${hostname} Cannot stop ${id}: ${JSON.stringify(e)}`);
+                            if (!procs[id].startedInCompactMode) {
+                                try {
+                                    procs[id].process.kill(); // call stop directly in adapter.js or call kill of process
+                                } catch (e) {
+                                    logger.error(`host.${hostname} Cannot stop ${id}: ${JSON.stringify(e)}`);
+                                }
+                            }
+                            else {
+                                states.setState(id + '.sigKill', {val: -1, ack: false, from: 'system.host.' + hostname});
                             }
                             delete procs[id].process;
                         }
@@ -2676,10 +2690,15 @@ function stopInstance(id, callback) {
                 } else {
                     logger.info('host.' + hostname + ' stopInstance ' + instance._id + ' killing pid ' + procs[id].process.pid);
                     procs[id].stopping = true;
-                    try {
-                        procs[id].process.kill(); // call stop directly in adapter.js or call kill of process
-                    } catch (e) {
-                        logger.error(`host.${hostname} Cannot stop ${id}: ${JSON.stringify(e)}`);
+                    if (!procs[id].startedInCompactMode) {
+                        try {
+                            procs[id].process.kill(); // call stop directly in adapter.js or call kill of process
+                        } catch (e) {
+                            logger.error(`host.${hostname} Cannot stop ${id}: ${JSON.stringify(e)}`);
+                        }
+                    }
+                    else {
+                        states.setState(id + '.sigKill', {val: -1, ack: false, from: 'system.host.' + hostname});
                     }
                     delete procs[id].process;
                     if (typeof callback === 'function') {
@@ -2728,10 +2747,15 @@ function stopInstance(id, callback) {
             } else {
                 logger.info('host.' + hostname + ' stopInstance ' + instance._id + ' killing pid ' + procs[id].process.pid);
                 procs[id].stopping = true;
-                try {
-                    procs[id].process.kill(); // call stop directly in adapter.js
-                } catch (e) {
-                    logger.error(`host.${hostname} Cannot stop ${id}: ${JSON.stringify(e)}`);
+                if (!procs[id].startedInCompactMode) {
+                    try {
+                        procs[id].process.kill(); // call stop directly in adapter.js
+                    } catch (e) {
+                        logger.error(`host.${hostname} Cannot stop ${id}: ${JSON.stringify(e)}`);
+                    }
+                }
+                else {
+                    states.setState(id + '.sigKill', {val: -1, ack: false, from: 'system.host.' + hostname});
                 }
                 delete procs[id].process;
                 if (typeof callback === 'function') {

--- a/main.js
+++ b/main.js
@@ -19,6 +19,8 @@ const tools      = require('./lib/tools');
 const version    = ioPackage.common.version;
 const pidUsage   = require('pidusage');
 const EXIT_CODES = require('./lib/exitCodes');
+const {NodeVM}   = require('vm2');
+
 let   adapterDir = __dirname.replace(/\\/g, '/');
 let   zipFiles;
 
@@ -2288,55 +2290,8 @@ function startInstance(id, wakeUp) {
             if (procs[id] && !procs[id].process) {
                 allInstancesStopped = false;
                 logger.debug('host.' + hostname + ' startInstance ' + name + '.' + args[0] + ' loglevel=' + args[1]);
-                if (config.system.compact && instance.common.compact) {
-                    if (!adapterModules[name] && fileNameFull) {
-                        try {
-                            adapterModules[name] = require(fileNameFull);
-                        } catch (e) {
-                            logger.error(`host.${hostname} error with ${fileNameFull}: ${JSON.stringify(e)}`);
-                        }
-                    }
-                    if (!adapterModules[name]) {
-                        procs[id].process = cp.fork(fileNameFull, args, {stdio: ['ignore', 'ignore', 'pipe', 'ipc']});
-                    } else {
-                        const _instance = (instance && instance._id && instance.common) ? instance._id.split('.').pop() || 0 : 0;
-                        const logLevel = (instance && instance._id && instance.common) ? instance.common.loglevel || 'info' : 'info';
-                        try {
-                            procs[id].process = adapterModules[name]({logLevel, compactInstance: _instance, compact: true});
-                            procs[id].startedInCompactMode = true;
-                        } catch (e) {
-                            logger.error(`host.${hostname} Cannot start ${name}.${_instance}: ${JSON.stringify(e)}`);
-                        }
-                    }
-                } else {
-                    procs[id].process = cp.fork(fileNameFull, args, {stdio: ['ignore', 'ignore', 'pipe', 'ipc']});
-                }
 
-                if (!procs[id].startedInCompactMode && procs[id].process) {
-                    states.setState(id + '.sigKill', {val: procs[id].process.pid, ack: true, from: 'system.host.' + hostname});
-                }
-
-                // catch error output
-                if (!procs[id].startedInCompactMode && procs[id].process && procs[id].process.stderr) {
-                    procs[id].process.stderr.on('data', data => {
-                        if (!data || !procs[id] || typeof procs[id] !== 'object') return;
-                        const text = data.toString();
-                        // show for debug
-                        console.error(text);
-                        procs[id].errors = procs[id].errors || [];
-                        const now = Date.now();
-                        procs[id].errors.push({ts: now, text: text});
-                        // limit output to 300 messages
-                        if (procs[id].errors > 300) {
-                            procs[id].errors.splice(procs[id].errors.length - 300);
-                        }
-                        cleanErrors(id, now);
-                    });
-                }
-
-                storePids(); // Store all pids to make possible kill them all
-
-                procs[id].process && procs[id].process.on('exit', (code, signal) => {
+                const exitHandler = (code, signal) => {
                     outputCount += 2;
                     states.setState(id + '.alive',     {val: false, ack: true, from: 'system.host.' + hostname});
                     states.setState(id + '.connected', {val: false, ack: true, from: 'system.host.' + hostname});
@@ -2390,7 +2345,13 @@ function startInstance(id, wakeUp) {
                             if (code === EXIT_CODES.START_IMMEDIATELY_AFTER_STOP_HEX /* -100 */ && procs[id].config.common.restartSchedule) {
                                 logger.info('host.' + hostname + ' instance ' + id + ' scheduled normal terminated and will be started anew.');
                             } else {
-                                logger.error('host.' + hostname + ' instance ' + id + ' terminated with code ' + code + ' (' + (getErrorText(code) || '') + ')');
+                                code = parseInt(code, 10);
+                                const text = `host.${hostname} instance ${id} terminated with code ${code} (${getErrorText(code) || ''})`;
+                                if (!code || code === EXIT_CODES.ADAPTER_REQUESTED_TERMINATION || code === EXIT_CODES.NO_ERROR) {
+                                    logger.info(text);
+                                } else {
+                                    logger.error(text);
+                                }
                             }
                         }
                     }
@@ -2429,7 +2390,80 @@ function startInstance(id, wakeUp) {
                         }
                     }
                     storePids(); // Store all pids to make possible kill them all
-                });
+                };
+                if (config.system.compact && instance.common.compact) {
+                    const vm = new NodeVM({
+                        console: 'inherit',
+                        sandbox: {},
+                        require: {
+                            external: true,
+                            builtin: ['*']
+                        },
+                        nesting: true
+                    });
+
+                    if (!adapterModules[name] && fileNameFull) {
+                        try {
+                            //adapterModules[name] = require(fileNameFull);
+                            adapterModules[name] = vm;
+                        } catch (e) {
+                            logger.error(`host.${hostname} error with ${fileNameFull}: ${JSON.stringify(e)}`);
+                        }
+                    }
+                    if (!adapterModules[name]) {
+                        procs[id].process = cp.fork(fileNameFull, args, {stdio: ['ignore', 'ignore', 'pipe', 'ipc']});
+                    } else {
+                        const _instance = (instance && instance._id && instance.common) ? instance._id.split('.').pop() || 0 : 0;
+                        const logLevel = (instance && instance._id && instance.common) ? instance.common.loglevel || 'info' : 'info';
+                        try {
+                            //procs[id].process = adapterModules[name]({logLevel, compactInstance: _instance, compact: true});
+                            const starterScript =
+                                'module.exports = function (callback) {' +
+                                'const adapter = require("' + fileNameFull + '")(' + JSON.stringify({logLevel, compactInstance: _instance, compact: true}) + ');' +
+                                'adapter.on("exit", (code, signal) => {' +
+                                'callback(code, signal);' +
+                                '});' +
+                                'return true' +
+                                '};';
+                            logger.silly(starterScript);
+                            procs[id].process = adapterModules[name].run(starterScript)(exitHandler);
+                            procs[id].startedInCompactMode = true;
+                        } catch (e) {
+                            console.log(e.message);
+                            console.log(e.stackTrace);
+                            logger.error(`host.${hostname} Cannot start ${name}.${_instance}: ${JSON.stringify(e)}`);
+                        }
+                    }
+                } else {
+                    procs[id].process = cp.fork(fileNameFull, args, {stdio: ['ignore', 'ignore', 'pipe', 'ipc']});
+                }
+
+                if (!procs[id].startedInCompactMode && procs[id].process) {
+                    states.setState(id + '.sigKill', {val: procs[id].process.pid, ack: true, from: 'system.host.' + hostname});
+                }
+
+                // catch error output
+                if (!procs[id].startedInCompactMode && procs[id].process && procs[id].process.stderr) {
+                    procs[id].process.stderr.on('data', data => {
+                        if (!data || !procs[id] || typeof procs[id] !== 'object') return;
+                        const text = data.toString();
+                        // show for debug
+                        console.error(text);
+                        procs[id].errors = procs[id].errors || [];
+                        const now = Date.now();
+                        procs[id].errors.push({ts: now, text: text});
+                        // limit output to 300 messages
+                        if (procs[id].errors > 300) {
+                            procs[id].errors.splice(procs[id].errors.length - 300);
+                        }
+                        cleanErrors(id, now);
+                    });
+                }
+
+                storePids(); // Store all pids to make possible kill them all
+
+                !procs[id].startedInCompactMode && procs[id].process && procs[id].process.on('exit', exitHandler);
+
                 if (!wakeUp && procs[id] && procs[id].process && procs[id].config.common && procs[id].config.common.enabled && (!procs[id].config.common.webExtension || !procs[id].config.native.webInstance) && mode !== 'once') {
                     if (procs[id].startedInCompactMode) {
                         logger.info(`host.${hostname} instance ${instance._id} started in COMPACT mode`);
@@ -2481,7 +2515,7 @@ function startInstance(id, wakeUp) {
                         } else {
                             code = parseInt(code, 10);
                             const text = `host.${hostname} instance ${id} terminated with code ${code} (${getErrorText(code) || ''})`;
-                            if (!code || code === EXIT_CODES.ADAPTER_REQUESTED_TERMINATION) {
+                            if (!code || code === EXIT_CODES.ADAPTER_REQUESTED_TERMINATION || code === EXIT_CODES.NO_ERROR) {
                                 logger.info(text);
                             } else {
                                 logger.error(text);
@@ -2516,7 +2550,7 @@ function startInstance(id, wakeUp) {
                     } else {
                         code = parseInt(code, 10);
                         const text = `host.${hostname} instance ${id} terminated with code ${code} (${getErrorText(code) || ''})`;
-                        if (!code || code === EXIT_CODES.ADAPTER_REQUESTED_TERMINATION) {
+                        if (!code || code === EXIT_CODES.ADAPTER_REQUESTED_TERMINATION || code === EXIT_CODES.NO_ERROR) {
                             logger.info(text);
                         } else {
                             logger.error(text);

--- a/main.js
+++ b/main.js
@@ -2434,6 +2434,9 @@ function startInstance(id, wakeUp) {
                             logger.error(`host.${hostname} Cannot start ${name}.${_instance}: ${JSON.stringify(e)}`);
                         }
                     }
+                    if (procs[id].process && !procs[id].process.kill) {
+                        procs[id].process.kill = () => states.setState(id + '.sigKill', {val: -1, ack: false, from: 'system.host.' + hostname});
+                    }
                 } else {
                     procs[id].process = cp.fork(fileNameFull, args, {stdio: ['ignore', 'ignore', 'pipe', 'ipc']});
                 }
@@ -2585,14 +2588,10 @@ function stopInstance(id, callback) {
     if (!instance || !instance.common || !instance.common.mode) {
         if (procs[id].process) {
             procs[id].stopping = true;
-            if (!procs[id].startedInCompactMode) {
-                try {
-                    procs[id].process.kill();  // call stop directly in adapter.js or call kill of process
-                } catch (e) {
-                    logger.error(`host.${hostname} Cannot stop ${id}: ${JSON.stringify(e)}`);
-                }
-            } else {
-                states.setState(id + '.sigKill', {val: -1, ack: false, from: 'system.host.' + hostname});
+            try {
+                procs[id].process.kill();  // call stop directly in adapter.js or call kill of process
+            } catch (e) {
+                logger.error(`host.${hostname} Cannot stop ${id}: ${JSON.stringify(e)}`);
             }
             delete procs[id].process;
         }
@@ -2643,14 +2642,10 @@ function stopInstance(id, callback) {
                         logger.info('host.' + hostname + ' stopInstance self ' + instance._id + ' killing pid ' + procs[id].process.pid + (result ? ': ' + result : ''));
                         if (procs[id].process) {
                             procs[id].stopping = true;
-                            if (!procs[id].startedInCompactMode) {
-                                try {
-                                    procs[id].process.kill(); // call stop directly in adapter.js or call kill of process
-                                } catch (e) {
-                                    logger.error(`host.${hostname} Cannot stop ${id}: ${JSON.stringify(e)}`);
-                                }
-                            } else {
-                                states.setState(id + '.sigKill', {val: -1, ack: false, from: 'system.host.' + hostname});
+                            try {
+                                procs[id].process.kill(); // call stop directly in adapter.js or call kill of process
+                            } catch (e) {
+                                logger.error(`host.${hostname} Cannot stop ${id}: ${JSON.stringify(e)}`);
                             }
                             delete procs[id].process;
                         }
@@ -2668,14 +2663,10 @@ function stopInstance(id, callback) {
                         if (procs[id].process) {
                             logger.info('host.' + hostname + ' stopInstance timeout "' + timeoutDuration + ' ' + instance._id + ' killing pid  ' + procs[id].process.pid);
                             procs[id].stopping = true;
-                            if (!procs[id].startedInCompactMode) {
-                                try {
-                                    procs[id].process.kill(); // call stop directly in adapter.js or call kill of process
-                                } catch (e) {
-                                    logger.error(`host.${hostname} Cannot stop ${id}: ${JSON.stringify(e)}`);
-                                }
-                            } else {
-                                states.setState(id + '.sigKill', {val: -1, ack: false, from: 'system.host.' + hostname});
+                            try {
+                                procs[id].process.kill(); // call stop directly in adapter.js or call kill of process
+                            } catch (e) {
+                                logger.error(`host.${hostname} Cannot stop ${id}: ${JSON.stringify(e)}`);
                             }
                             delete procs[id].process;
                         }
@@ -2687,14 +2678,10 @@ function stopInstance(id, callback) {
                 } else {
                     logger.info('host.' + hostname + ' stopInstance ' + instance._id + ' killing pid ' + procs[id].process.pid);
                     procs[id].stopping = true;
-                    if (!procs[id].startedInCompactMode) {
-                        try {
-                            procs[id].process.kill(); // call stop directly in adapter.js or call kill of process
-                        } catch (e) {
-                            logger.error(`host.${hostname} Cannot stop ${id}: ${JSON.stringify(e)}`);
-                        }
-                    } else {
-                        states.setState(id + '.sigKill', {val: -1, ack: false, from: 'system.host.' + hostname});
+                    try {
+                        procs[id].process.kill(); // call stop directly in adapter.js or call kill of process
+                    } catch (e) {
+                        logger.error(`host.${hostname} Cannot stop ${id}: ${JSON.stringify(e)}`);
                     }
                     delete procs[id].process;
                     if (typeof callback === 'function') {
@@ -2743,14 +2730,10 @@ function stopInstance(id, callback) {
             } else {
                 logger.info('host.' + hostname + ' stopInstance ' + instance._id + ' killing pid ' + procs[id].process.pid);
                 procs[id].stopping = true;
-                if (!procs[id].startedInCompactMode) {
-                    try {
-                        procs[id].process.kill(); // call stop directly in adapter.js
-                    } catch (e) {
-                        logger.error(`host.${hostname} Cannot stop ${id}: ${JSON.stringify(e)}`);
-                    }
-                } else {
-                    states.setState(id + '.sigKill', {val: -1, ack: false, from: 'system.host.' + hostname});
+                try {
+                    procs[id].process.kill(); // call stop directly in adapter.js
+                } catch (e) {
+                    logger.error(`host.${hostname} Cannot stop ${id}: ${JSON.stringify(e)}`);
                 }
                 delete procs[id].process;
                 if (typeof callback === 'function') {

--- a/main.js
+++ b/main.js
@@ -2591,8 +2591,7 @@ function stopInstance(id, callback) {
                 } catch (e) {
                     logger.error(`host.${hostname} Cannot stop ${id}: ${JSON.stringify(e)}`);
                 }
-            }
-            else {
+            } else {
                 states.setState(id + '.sigKill', {val: -1, ack: false, from: 'system.host.' + hostname});
             }
             delete procs[id].process;
@@ -2650,8 +2649,7 @@ function stopInstance(id, callback) {
                                 } catch (e) {
                                     logger.error(`host.${hostname} Cannot stop ${id}: ${JSON.stringify(e)}`);
                                 }
-                            }
-                            else {
+                            } else {
                                 states.setState(id + '.sigKill', {val: -1, ack: false, from: 'system.host.' + hostname});
                             }
                             delete procs[id].process;
@@ -2676,8 +2674,7 @@ function stopInstance(id, callback) {
                                 } catch (e) {
                                     logger.error(`host.${hostname} Cannot stop ${id}: ${JSON.stringify(e)}`);
                                 }
-                            }
-                            else {
+                            } else {
                                 states.setState(id + '.sigKill', {val: -1, ack: false, from: 'system.host.' + hostname});
                             }
                             delete procs[id].process;
@@ -2696,8 +2693,7 @@ function stopInstance(id, callback) {
                         } catch (e) {
                             logger.error(`host.${hostname} Cannot stop ${id}: ${JSON.stringify(e)}`);
                         }
-                    }
-                    else {
+                    } else {
                         states.setState(id + '.sigKill', {val: -1, ack: false, from: 'system.host.' + hostname});
                     }
                     delete procs[id].process;
@@ -2753,8 +2749,7 @@ function stopInstance(id, callback) {
                     } catch (e) {
                         logger.error(`host.${hostname} Cannot stop ${id}: ${JSON.stringify(e)}`);
                     }
-                }
-                else {
+                } else {
                     states.setState(id + '.sigKill', {val: -1, ack: false, from: 'system.host.' + hostname});
                 }
                 delete procs[id].process;

--- a/package.json
+++ b/package.json
@@ -41,8 +41,9 @@
     "socket.io": "2.1.1",
     "socket.io-client": "2.1.1",
     "tar": "^4.4.8",
+    "vm2": "^3.8.1",
     "winston": "^3.2.1",
-    "winston-daily-rotate-file": "^3.7.0",
+    "winston-daily-rotate^-file": "^3.7.0",
     "yargs": "^13.1.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "tar": "^4.4.8",
     "vm2": "^3.8.1",
     "winston": "^3.2.1",
-    "winston-daily-rotate^-file": "^3.7.0",
+    "winston-daily-rotate-file": "^3.7.0",
     "yargs": "^13.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
... to hopefully better encapsulate the Adapter and required Files from the other running compact instances. I have seen no difference in memory usage.
Additionally some Adapter termination logs are being relaxed to be logged as info instead error when exitcode is 0 (NO_ERROR)