### PR TITLE
Don't chmod 777 after controller upgrade

### DIFF
--- a/lib/setup/setupUpgrade.js
+++ b/lib/setup/setupUpgrade.js
@@ -295,7 +295,7 @@ function Upgrade(options) {
                         if (err) {
                             processExit(err);
                         } else {
-                            setChmod(() => restartController(callback));
+                            restartController(callback);
                         }
                     });
                 });
@@ -327,7 +327,7 @@ function Upgrade(options) {
                             if (err) {
                                 processExit(err);
                             } else {
-                                setChmod(() => restartController(callback));
+                                restartController(callback);
                             }
                         });
                     });
@@ -336,46 +336,6 @@ function Upgrade(options) {
             });
         }
     };
-
-    // BF (2018.06.04): remove this call later
-    function setChmod(callback) {
-        try {
-            if (configData === null && fs.existsSync(configFile)) {
-                configData = JSON.parse(fs.readFileSync(configFile, 'utf8'));
-            }
-        } catch (e) {
-            console.error(`Cannot read "${configFile}: ${e}`);
-            configData = false;
-        }
-
-        if (configData && configData.system && configData.system.noChmod) {
-            return callback && callback();
-        }
-
-        const platform = require('os').platform();
-        console.log('Host "' + tools.getHostName() + '" (' + platform + ') updated');
-        // Call command chmod +x __dirname if under linux or darwin
-        if (platform === 'linux' || platform === 'darwin') {
-            const exec = require('child_process').exec;
-            let dir;
-            if (__dirname.toLowerCase().replace(/\\/g, '/').indexOf('node_modules/' + tools.appName + '.js-controller') !== -1) {
-                dir = require('path').normalize(__dirname + '/../../../..').replace(/\\/g, '/');
-            } else {
-                dir = require('path').normalize(__dirname + '/../..').replace(/\\/g, '/');
-            }
-
-            const cmd = 'chmod -R 777 ' + dir;
-            console.log('Execute: ' + cmd);
-            const child = exec(cmd);
-            child.stderr.pipe(process.stdout);
-            child.on('exit', () => {
-                console.log('Chmod finished. Restart controller');
-                if (callback) callback();
-            });
-        } else {
-            if (callback) callback();
-        }
-    }
 }
 
 module.exports = Upgrade;

--- a/lib/setup/setupUpgrade.js
+++ b/lib/setup/setupUpgrade.js
@@ -27,9 +27,7 @@ function Upgrade(options) {
     const getRepository     = options.getRepository;
     const params            = options.params;
     let semver;
-    let configData = null;
 
-    const configFile = tools.getConfigFileName();
     const hostname   = tools.getHostName();
     const EXIT_CODES = require('../exitCodes');
 


### PR DESCRIPTION
Avoids messing up the permissions we finally got under control with the installation routine and fixer.

Fixes: #374 

Untested!