### PR TITLE
CLI "iobroker cert create"

### DIFF
--- a/lib/cli/cliCert.js
+++ b/lib/cli/cliCert.js
@@ -1,0 +1,139 @@
+'use strict';
+const CLICommand = require('./cliCommand.js');
+const CLIObjects = require('./cliObjects.js');
+const messages = require('./messages.js');
+const tools = require('../tools.js');
+const forge = require('node-forge');
+const os = require('os');
+
+/** Command ioBroker cert ... */
+module.exports = class CLICert extends CLICommand {
+
+    /** @param {import('./cliCommand.js').CLICommandOptions} options */
+    constructor(options) {
+        super(options);
+    }
+
+    /**
+     * Executes a command
+     * @param {any[]} args
+     */
+    execute(args) {
+        const { callback, showHelp } = this.options;
+        const command = args[0];
+
+        switch (command) {
+            case 'renew':
+            case 'create':
+                return this.create(args);
+            default:
+                messages.error.unknownCommand('cert', command);
+                showHelp();
+                return void callback(3);
+        }
+    }
+
+    /**
+     * create new private certificate
+     * @param {any[]} args
+     */
+    create(args) {
+
+        // If at any time you wish to disable the use of native code, where available, for particular forge features
+        // like its secure random number generator, you may set the forge.options.usePureJavaScript flag to true. It
+        // is not recommended that you set this flag as native code is typically more performant and may have stronger
+        // security properties. It may be useful to set this flag to test certain features that you plan to run in
+        // environments that are different from your testing environment.
+        forge.options.usePureJavaScript = false;
+
+        const { callback, dbConnect } = this.options;
+        const id = "system.certificates";
+        const certPropPath = "native.certificates";
+
+        // https://github.com/digitalbazaar/forge
+        const pki = forge.pki;
+
+        const keys = pki.rsa.generateKeyPair({bits: 2048, e: 0x10001});
+        let cert = pki.createCertificate();
+
+        cert.publicKey = keys.publicKey;
+        cert.serialNumber = '01';
+        cert.validity.notBefore = new Date();
+        cert.validity.notAfter = new Date();
+        cert.validity.notAfter.setFullYear(cert.validity.notBefore.getFullYear() + 5);
+
+        const subAttrs = [
+            {name:'commonName',value: tools.getHostName()},
+            {name:'organizationName',value:'ioBroker GmbH'},
+            {shortName:'OU',value:'iobroker'}
+        ];
+
+        const issAttrs = [
+            {name:'commonName',value: 'iobroker'},
+            {name:'organizationName',value:'ioBroker GmbH'},
+            {shortName:'OU',value:'iobroker'}
+        ];
+
+        cert.setSubject(subAttrs);
+        cert.setIssuer(issAttrs);
+
+        cert.setExtensions([{
+            name: 'basicConstraints',
+            critical: true,
+            cA: false
+            },
+            {
+                name: 'keyUsage',
+                critical: true,
+                digitalSignature: true,
+                contentCommitment: true,
+                keyEncipherment: true,
+                dataEncipherment: true,
+                keyAgreement: true,
+                keyCertSign: true,
+                cRLSign: true,
+                encipherOnly: true,
+                decipherOnly: true
+            },
+            {
+                name: 'subjectAltName',
+                altNames: [{
+                    type: 2,
+                    value: os.hostname()
+                }]
+            },
+            {
+                name: 'subjectKeyIdentifier'
+            },
+            {
+                name: 'extKeyUsage',
+                serverAuth: true,
+                clientAuth: true,
+                codeSigning: false,
+                emailProtection: false,
+                timeStamping: false
+            },
+            {
+                name: 'authorityKeyIdentifier'
+            }
+        ]);
+
+        cert.sign(keys.privateKey);
+
+        const pem_pkey = pki.privateKeyToPem(keys.privateKey);
+        const pem_cert = pki.certificateToPem(cert);
+
+        console.log(pem_pkey);
+        console.log(pem_cert);
+
+        const certificates = {
+            defaultPrivate: pem_pkey,
+            defaultPublic: pem_cert
+        };
+
+        const command = ["set", id, certPropPath + "=" + JSON.stringify(certificates)];
+
+        const objectsCommand = new CLIObjects(this.options);
+        objectsCommand.execute(command);
+    }
+};

--- a/lib/cli/cliCert.js
+++ b/lib/cli/cliCert.js
@@ -130,9 +130,9 @@ module.exports = class CLICert extends CLICommand {
             defaultPublic: pem_cert
         };
 
-        const command = ['set', id, certPropPath + '=' + JSON.stringify(certificates)];
-
+        // use the command `iobroker object set ...` to update the certificate
+        const objectsCommandArgs = ['set', id, certPropPath + '=' + JSON.stringify(certificates)];
         const objectsCommand = new CLIObjects(this.options);
-        objectsCommand.execute(command);
+        objectsCommand.execute(objectsCommandArgs);
     }
 };

--- a/lib/cli/cliCert.js
+++ b/lib/cli/cliCert.js
@@ -35,7 +35,7 @@ module.exports = class CLICert extends CLICommand {
 
     /**
      * create new private certificate
-     * @param {any[]} _args
+     * @param {any[]} [_args]
      */
     create(_args) {
 

--- a/lib/cli/cliCert.js
+++ b/lib/cli/cliCert.js
@@ -35,9 +35,9 @@ module.exports = class CLICert extends CLICommand {
 
     /**
      * create new private certificate
-     * @param {any[]} args
+     * @param {any[]} _args
      */
-    create(args) {
+    create(_args) {
 
         // If at any time you wish to disable the use of native code, where available, for particular forge features
         // like its secure random number generator, you may set the forge.options.usePureJavaScript flag to true. It
@@ -46,15 +46,14 @@ module.exports = class CLICert extends CLICommand {
         // environments that are different from your testing environment.
         forge.options.usePureJavaScript = false;
 
-        const { callback, dbConnect } = this.options;
-        const id = "system.certificates";
-        const certPropPath = "native.certificates";
+        const id = 'system.certificates';
+        const certPropPath = 'native.certificates';
 
         // https://github.com/digitalbazaar/forge
         const pki = forge.pki;
 
-        const keys = pki.rsa.generateKeyPair({bits: 2048, e: 0x10001});
-        let cert = pki.createCertificate();
+        const keys = pki.rsa.generateKeyPair({ bits: 2048, e: 0x10001 });
+        const cert = pki.createCertificate();
 
         cert.publicKey = keys.publicKey;
         cert.serialNumber = '01';
@@ -63,15 +62,15 @@ module.exports = class CLICert extends CLICommand {
         cert.validity.notAfter.setFullYear(cert.validity.notBefore.getFullYear() + 5);
 
         const subAttrs = [
-            {name:'commonName',value: tools.getHostName()},
-            {name:'organizationName',value:'ioBroker GmbH'},
-            {shortName:'OU',value:'iobroker'}
+            { name: 'commonName', value: tools.getHostName() },
+            { name: 'organizationName', value: 'ioBroker GmbH' },
+            { shortName: 'OU', value: 'iobroker' }
         ];
 
         const issAttrs = [
-            {name:'commonName',value: 'iobroker'},
-            {name:'organizationName',value:'ioBroker GmbH'},
-            {shortName:'OU',value:'iobroker'}
+            { name: 'commonName', value: 'iobroker' },
+            { name: 'organizationName', value: 'ioBroker GmbH' },
+            { shortName: 'OU', value: 'iobroker' }
         ];
 
         cert.setSubject(subAttrs);
@@ -81,41 +80,41 @@ module.exports = class CLICert extends CLICommand {
             name: 'basicConstraints',
             critical: true,
             cA: false
-            },
-            {
-                name: 'keyUsage',
-                critical: true,
-                digitalSignature: true,
-                contentCommitment: true,
-                keyEncipherment: true,
-                dataEncipherment: true,
-                keyAgreement: true,
-                keyCertSign: true,
-                cRLSign: true,
-                encipherOnly: true,
-                decipherOnly: true
-            },
-            {
-                name: 'subjectAltName',
-                altNames: [{
-                    type: 2,
-                    value: os.hostname()
-                }]
-            },
-            {
-                name: 'subjectKeyIdentifier'
-            },
-            {
-                name: 'extKeyUsage',
-                serverAuth: true,
-                clientAuth: true,
-                codeSigning: false,
-                emailProtection: false,
-                timeStamping: false
-            },
-            {
-                name: 'authorityKeyIdentifier'
-            }
+        },
+        {
+            name: 'keyUsage',
+            critical: true,
+            digitalSignature: true,
+            contentCommitment: true,
+            keyEncipherment: true,
+            dataEncipherment: true,
+            keyAgreement: true,
+            keyCertSign: true,
+            cRLSign: true,
+            encipherOnly: true,
+            decipherOnly: true
+        },
+        {
+            name: 'subjectAltName',
+            altNames: [{
+                type: 2,
+                value: os.hostname()
+            }]
+        },
+        {
+            name: 'subjectKeyIdentifier'
+        },
+        {
+            name: 'extKeyUsage',
+            serverAuth: true,
+            clientAuth: true,
+            codeSigning: false,
+            emailProtection: false,
+            timeStamping: false
+        },
+        {
+            name: 'authorityKeyIdentifier'
+        }
         ]);
 
         cert.sign(keys.privateKey);
@@ -131,7 +130,7 @@ module.exports = class CLICert extends CLICommand {
             defaultPublic: pem_cert
         };
 
-        const command = ["set", id, certPropPath + "=" + JSON.stringify(certificates)];
+        const command = ['set', id, certPropPath + '=' + JSON.stringify(certificates)];
 
         const objectsCommand = new CLIObjects(this.options);
         objectsCommand.execute(command);

--- a/lib/cli/cliCommand.js
+++ b/lib/cli/cliCommand.js
@@ -27,6 +27,7 @@
  * @property {any} [host]
  * @property {any} [enabled]
  * @property {any} [port]
+ * @property {any} [cert]
  */
 /** @typedef {CLICommandContext & CLICommandParams} CLICommandOptions */
 

--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -12,6 +12,7 @@ module.exports = {
         process: require('./cliProcess.js'),
         message: require('./cliMessage.js'),
         logs: require('./cliLogs.js'),
-        host: require('./cliHost.js')
+        host: require('./cliHost.js'),
+        cert: require('./cliCert.js')
     }
 };

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-inner-declarations */
 /**
  *
  *  ioBroker Command Line Interface (CLI)
@@ -223,25 +224,6 @@ function processCommand(command, args, params, callback) {
                 setup.setup((isFirst, _isRedis) => {
                     if (isFirst) {
 
-                        const initialInstances = ['admin', 'discovery', 'info'];
-
-                        function createInstances() {
-                            if (! initialInstances.length) {
-                                callback();
-                                return;
-                            }
-                            const toInstall = initialInstances.shift();
-                            try {
-                                const path = require.resolve(tools.appName + '.' + toInstall);
-                                if (path) {
-                                    install.createInstance(toInstall, {enabled: true, ignoreIfExists: true}, () => createInstances());
-                                }
-                            } catch (e) {
-                                // not found
-                                createInstances();
-                            }
-                        }
-
                         const Install = require('./setup/setupInstall.js');
                         const install = new Install({
                             objects:       objects,
@@ -251,9 +233,25 @@ function processCommand(command, args, params, callback) {
                             processExit:   callback,
                             params:        params
                         });
+                        const createInstanceAsync = tools.promisifyNoError(install.createInstance, install);
+
+                        // Creates all instances that are needed on a fresh installation
+                        const createInitialInstances = tools.poorMansAsync(function* () {
+                            const initialInstances = ['admin', 'discovery', 'info'];
+                            for (const instance of initialInstances) {
+                                try {
+                                    const path = require.resolve(tools.appName + '.' + instance);
+                                    if (path) {
+                                        yield createInstanceAsync(instance, {enabled: true, ignoreIfExists: true});
+                                    }
+                                } catch (e) {
+                                    // not found, just continue
+                                }
+                            }
+                        });
 
                         //install initial adapter instances
-                        createInstances();
+                        return void createInitialInstances().then(() => callback());
                     } else {
                         return void callback();
                     }

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -91,6 +91,7 @@ function initYargs() {
                 tools.appName + ' host remove <hostname>\n' +		
                 tools.appName + ' set <adapter>.<instance> [--port port] [--ip address] [--ssl true|false]\n' +
                 tools.appName + ' license <license.file or license.text>\n' +
+                tools.appName + ' cert create\n' +
                 tools.appName + ' clean\n' +
                 tools.appName + ' backup\n' +
                 tools.appName + ' restore <backup name or path>\n' +
@@ -221,6 +222,7 @@ function processCommand(command, args, params, callback) {
 
                 setup.setup((isFirst, _isRedis) => {
                     if (isFirst) {
+
                         const initialInstances = ['admin', 'discovery', 'info'];
 
                         function createInstances() {
@@ -1870,6 +1872,12 @@ function processCommand(command, args, params, callback) {
             break;
         }
 
+        case 'cert': {
+            const certCommand = new cli.command.cert(commandOptions);
+            certCommand.execute(args);
+            break;
+        }
+
         case 'license': {
             const file = args[0];
             if (!file) {
@@ -2137,6 +2145,14 @@ function resetDbConnect(_callback) {
         delete require.cache[require.resolve(__dirname + '/states')];
         States = null;
     }
+}
+
+function createCertificate(params, callback) {
+
+    params._ = ['cert','create'];
+    let args = ['create'];
+
+    processCommand('cert', args, params, callback);
 }
 
 // function showConfig(config, root) {

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -224,20 +224,23 @@ function processCommand(command, args, params, callback) {
                 setup.setup((isFirst, _isRedis) => {
                     if (isFirst) {
 
-                        const Install = require('./setup/setupInstall.js');
-                        const install = new Install({
-                            objects:       objects,
-                            states:        states,
-                            installNpm:    installNpm,
-                            getRepository: getRepository,
-                            processExit:   callback,
-                            params:        params
-                        });
-                        const createInstanceAsync = tools.promisifyNoError(install.createInstance, install);
-
                         // Creates all instances that are needed on a fresh installation
                         const createInitialInstances = tools.poorMansAsync(function* () {
+                            const Install = require('./setup/setupInstall.js');
+                            const install = new Install({
+                                objects:       objects,
+                                states:        states,
+                                installNpm:    installNpm,
+                                getRepository: getRepository,
+                                processExit:   callback,
+                                params:        params
+                            });
+                            // In order to loop the instance creation, we need a promisified version of the method
+                            const createInstanceAsync = tools.promisifyNoError(install.createInstance, install);
+
+                            // Define the necessary instances
                             const initialInstances = ['admin', 'discovery', 'info'];
+                            // And try to install each of them
                             for (const instance of initialInstances) {
                                 try {
                                     const path = require.resolve(tools.appName + '.' + instance);
@@ -250,11 +253,27 @@ function processCommand(command, args, params, callback) {
                             }
                         });
 
-                        //install initial adapter instances
-                        return void createInitialInstances().then(() => callback());
+                        // Creates a fresh certificate
+                        function createCertificate() {
+                            return new Promise(resolve => {
+                                const Cert = require('./cli/cliCert');
+                                // Create a new instance of the cert command,
+                                // but use the resolve method as a callback
+                                const cert = new Cert(Object.assign({}, commandOptions, {
+                                    callback: resolve
+                                }));
+                                cert.create();
+                            });
+                        }
+
+                        createInitialInstances()
+                            .then(createCertificate)
+                            .then(() => callback());
+                        return;
                     } else {
                         return void callback();
                     }
+
                 }, isFirst, isRedis);
             }
             break;

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -2164,14 +2164,6 @@ function resetDbConnect(_callback) {
     }
 }
 
-function createCertificate(params, callback) {
-
-    params._ = ['cert','create'];
-    let args = ['create'];
-
-    processCommand('cert', args, params, callback);
-}
-
 // function showConfig(config, root) {
 //     root = root || [];
 //     const prefix = root.join('/').toUpperCase();

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "mime": "^2.4.0",
     "mkdirp": "^0.5.1",
     "ncp": "^2.0.0",
+    "node-forge": "^0.8.5",
     "node-schedule": "^1.3.1",
     "node.extend": "^2.0.2",
     "pidusage": "^2.0.17",


### PR DESCRIPTION
CLI "iobroker cert create" - generates private SSL-certificate that is 5 years valid, issuer "iobroker GmbH".
Helper function "createCertificate(...)" in setup.js is tested but not integrated.

toDo:  Integrate in "iobroker setup first"-function
I can't do this. Please advise.