### PR TITLE
Remember installation location

### DIFF
--- a/lib/setup.js
+++ b/lib/setup.js
@@ -286,36 +286,6 @@ function processCommand(command, args, params, callback) {
             if (url[0] === '"' && url[url.length - 1] === '"') {
                 url = url.substring(1, url.length - 1);
             }
-            // try to fix URL
-            if (url.match(/^https:\/\/github\.com\//)) {
-                url = url.replace(/\.git$/, '');
-                if (!url.match(/\.zip$/) && !url.match(/\.gz$/) && !url.match(/\/tarball\/[^/]+$/)) {
-                    url += '/tarball/master';
-                }
-            }
-            console.log('install ' + url);
-
-            // Try to extract name from URL
-            if (!name) {
-                if (url.match(/\.tgz$|\.zip/)) {
-                    const parts = url.split('/');
-                    const last = parts.pop();
-                    const mm = last.match(/\.([-_\w\d]+)-[.\d]+/);
-                    if (mm) {
-                        name = mm[1];
-                    }
-                } else {
-                    const reG = new RegExp(tools.appName + '\\.([-_\\w\\d]+)\\/');
-                    let m = reG.exec(url);
-                    if (m) {
-                        name = m[1];
-                    } else {
-                        const reg = new RegExp(tools.appName.toLowerCase() + '\\.([-_\\w\\d]+)\\/');
-                        m = reg.exec(url);
-                        if (m) name = m[1];
-                    }
-                }
-            }
 
             dbConnect(params, () => {
                 const Install = require('./setup/setupInstall.js');
@@ -328,43 +298,7 @@ function processCommand(command, args, params, callback) {
                     params:        params
                 });
 
-                const options = {
-                    packetName: name
-                };
-                install.npmInstallWithCheck(url, options, false, (_url, installDir) => {
-                    const Upload = require('./setup/setupUpload.js');
-                    const upload = new Upload({
-                        states:      states,
-                        objects:     objects
-                    });
-
-                    if (name) {
-                        upload.uploadAdapter(name, true, true, () =>
-                            upload.uploadAdapter(name, false, true, callback));
-                    } else {
-                        // Try to find io-package.json with newest date
-                        const dirs = fs.readdirSync(installDir);
-                        let date = null;
-                        let dir  = null;
-                        for (let i = 0; i < dirs.length; i++) {
-                            if (fs.existsSync(installDir + '/' + dirs[i] + '/io-package.json')) {
-                                const stat = fs.statSync(installDir + '/' + dirs[i] + '/io-package.json');
-                                if (!date || stat.mtime.getTime() > date.getTime()) {
-                                    dir  = dirs[i];
-                                    date = stat.mtime;
-                                }
-                            }
-                        }
-                        // if modify time is not older than one hour
-                        if (dir && (new Date()).getTime() - date.getTime() < 3600000) {
-                            name = dir.substring(tools.appName.length + 1);
-                            upload.uploadAdapter(name, true, true, () =>
-                                upload.uploadAdapter(name, false, true, callback));
-                        } else {
-                            return void callback();
-                        }
-                    }
-                });
+                install.installAdapterFromUrl(url, name, callback);
             });
             break;
         }

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -89,7 +89,7 @@ function initYargs() {
                 tools.appName + ' host this\n' +
                 tools.appName + ' host <hostname>\n' +
                 tools.appName + ' host set <hostname>\n' +
-                tools.appName + ' host remove <hostname>\n' +		
+                tools.appName + ' host remove <hostname>\n' +
                 tools.appName + ' set <adapter>.<instance> [--port port] [--ip address] [--ssl true|false]\n' +
                 tools.appName + ' license <license.file or license.text>\n' +
                 tools.appName + ' cert create\n' +
@@ -295,6 +295,28 @@ function processCommand(command, args, params, callback) {
             }
             console.log('install ' + url);
 
+            // Try to extract name from URL
+            if (!name) {
+                if (url.match(/\.tgz$|\.zip/)) {
+                    const parts = url.split('/');
+                    const last = parts.pop();
+                    const mm = last.match(/\.([-_\w\d]+)-[.\d]+/);
+                    if (mm) {
+                        name = mm[1];
+                    }
+                } else {
+                    const reG = new RegExp(tools.appName + '\\.([-_\\w\\d]+)\\/');
+                    let m = reG.exec(url);
+                    if (m) {
+                        name = m[1];
+                    } else {
+                        const reg = new RegExp(tools.appName.toLowerCase() + '\\.([-_\\w\\d]+)\\/');
+                        m = reg.exec(url);
+                        if (m) name = m[1];
+                    }
+                }
+            }
+
             dbConnect(params, () => {
                 const Install = require('./setup/setupInstall.js');
                 const install = new Install({
@@ -306,34 +328,15 @@ function processCommand(command, args, params, callback) {
                     params:        params
                 });
 
-                install.npmInstallWithCheck(url, true, false, (_url, installDir) => {
+                const options = {
+                    packetName: name
+                };
+                install.npmInstallWithCheck(url, options, false, (_url, installDir) => {
                     const Upload = require('./setup/setupUpload.js');
                     const upload = new Upload({
                         states:      states,
                         objects:     objects
                     });
-
-                    // Try to extract name from URL
-                    if (!name) {
-                        if (url.match(/\.tgz$|\.zip/)) {
-                            const parts = url.split('/');
-                            const last = parts.pop();
-                            const mm = last.match(/\.([-_\w\d]+)-[.\d]+/);
-                            if (mm) {
-                                name = mm[1];
-                            }
-                        } else {
-                            const reG = new RegExp(tools.appName + '\\.([-_\\w\\d]+)\\/');
-                            let m = reG.exec(url);
-                            if (m) {
-                                name = m[1];
-                            } else {
-                                const reg = new RegExp(tools.appName.toLowerCase() + '\\.([-_\\w\\d]+)\\/');
-                                m = reg.exec(url);
-                                if (m) name = m[1];
-                            }
-                        }
-                    }
 
                     if (name) {
                         upload.uploadAdapter(name, true, true, () =>

--- a/lib/setup/setupInstall.js
+++ b/lib/setup/setupInstall.js
@@ -19,6 +19,8 @@ function Install(options) {
     const path             = require('path');
     const semver           = require('semver');
     const child_process    = require('child_process');
+    const request          = require('request');
+
     // todo solve it somehow
     const unsafePermAlways = [tools.appName.toLowerCase() + '.zwave', tools.appName.toLowerCase() + '.amazon-dash', tools.appName.toLowerCase() + '.xbox'];
     const isRootOnUnix     = typeof process.getuid === 'function' && process.getuid() === 0;
@@ -380,6 +382,7 @@ function Install(options) {
             child.stdout.pipe(process.stdout);
         }
         const packetDirName = options.packetName ? tools.appName.toLowerCase() + '.' + options.packetName : npmUrl;
+
         child.on('exit', (code /* , signal */) => {
             // code 1 is strange error that cannot be explained. Everything is installed but error :(
             if (code && code !== 1) {
@@ -1487,6 +1490,93 @@ function Install(options) {
 
         // TODO delete meta objects - i think a recursive deletion of all child object would be less effort.
     };
+
+    this.installAdapterFromUrl = function(url, name, callback) {
+        // try to fix URL
+        if (url.match(/^https:\/\/github\.com\//)) {
+            url = url.replace(/\.git$/, '');
+            if (!url.match(/\.zip$/) && !url.match(/\.gz$/) && !url.match(/\/tarball\/[^/]+$/)) {
+                if (url.endsWith('/')) {
+                    url = url.substring(0, url.length -1);
+                }
+                const githubParts = url.match(/^https:\/\/github\.com\/([^\/]+\/[^\/]+)\/?.*$/);
+                if (githubParts && githubParts[1]) {
+                    request.get({
+                        url: 'http://api.github.com/repos/' + githubParts[1] + '/commits/master',
+                        json: true,
+                        headers: {'User-Agent': 'ioBroker Adapter install'}
+                    }, (err, res, data) => {
+                        if (err) {
+                            console.log('Info: Can not get current GitHub commit, we remember master branch only: ' + err);
+                            return void that.installAdapterFromUrl(url + '/tarball/master', name, callback)
+                        } else if (res.statusCode !== 200) {
+                            console.log('Info: Can not get current GitHub commit, we remember master branch only. Status:', res.statusCode + (data && data.message ? ' (' + data.message + ')' : ''));
+                            return void that.installAdapterFromUrl(url + '/tarball/master', name, callback)
+                        } else if (!data.sha) {
+                            console.log('Info: Can not get current GitHub commit, we remember master branch only. No SHA available');
+                            return void that.installAdapterFromUrl(url + '/tarball/master', name, callback)
+                        }
+                        return void that.installAdapterFromUrl(url + '/tarball/' + data.sha, name, callback)
+                    });
+                    return;
+                }
+                url += '/tarball/master';
+            }
+        }
+        console.log('install ' + url);
+
+        // Try to extract name from URL
+        if (!name) {
+            if (url.match(/\.tgz$|\.zip/)) {
+                const parts = url.split('/');
+                const last = parts.pop();
+                const mm = last.match(/\.([-_\w\d]+)-[.\d]+/);
+                if (mm) {
+                    name = mm[1];
+                }
+            } else {
+                const reG = new RegExp(tools.appName + '\\.([-_\\w\\d]+)\\/', 'i');
+                let m = reG.exec(url);
+                if (m) {
+                    name = m[1];
+                }
+            }
+        }
+
+        const options = {
+            packetName: name
+        };
+        that.npmInstallWithCheck(url, options, false, (_url, installDir) => {
+            if (name) {
+                upload.uploadAdapter(name, true, true, () =>
+                    upload.uploadAdapter(name, false, true, () =>
+                        upload.upgradeAdapterObjects(name, callback)));
+            } else {
+                // Try to find io-package.json with newest date
+                const dirs = fs.readdirSync(installDir);
+                let date = null;
+                let dir  = null;
+                for (let i = 0; i < dirs.length; i++) {
+                    if (fs.existsSync(installDir + '/' + dirs[i] + '/io-package.json')) {
+                        const stat = fs.statSync(installDir + '/' + dirs[i] + '/io-package.json');
+                        if (!date || stat.mtime.getTime() > date.getTime()) {
+                            dir  = dirs[i];
+                            date = stat.mtime;
+                        }
+                    }
+                }
+                // if modify time is not older than one hour
+                if (dir && (new Date()).getTime() - date.getTime() < 3600000) {
+                    name = dir.substring(tools.appName.length + 1);
+                    upload.uploadAdapter(name, true, true, () =>
+                        upload.uploadAdapter(name, false, true, () =>
+                            upload.upgradeAdapterObjects(name, callback)));
+                } else {
+                    return void callback();
+                }
+            }
+        });
+    }
 }
 
 module.exports = Install;

--- a/lib/setup/setupInstall.js
+++ b/lib/setup/setupInstall.js
@@ -143,6 +143,7 @@ function Install(options) {
                 version = '';
             }
         }
+        options.packetName = packetName;
 
         const sources = repoUrl;
         options.unsafePerm = sources[packetName] && sources[packetName].unsafePerm;
@@ -244,6 +245,9 @@ function Install(options) {
                             if (typeof callback === 'function') callback(name, 'Invalid io-package.json!');
                             processExit(EXIT_CODES.INVALID_IO_PACKAGE_JSON);
                         }
+                        packetIo.common = packetIo.common || {};
+                        packetIo.common.installedFrom = url;
+                        fs.writeFileSync(source + '/io-package.json', JSON.stringify(packetIo, null, 2), 'utf8');
 
                         let destination = __dirname + '/../..';
                         if (!packetIo.common.controller) {
@@ -375,15 +379,34 @@ function Install(options) {
         if (debug || params.debug) {
             child.stdout.pipe(process.stdout);
         }
+        const packetDirName = options.packetName ? tools.appName.toLowerCase() + '.' + options.packetName : npmUrl;
         child.on('exit', (code /* , signal */) => {
             // code 1 is strange error that cannot be explained. Everything is installed but error :(
             if (code && code !== 1) {
                 console.error('host.' + hostname + ' Cannot install ' + npmUrl + ': ' + code);
                 processExit(EXIT_CODES.CANNOT_INSTALL_NPM_PACKET);
             }
+            // inject the installedFrom information in io-package
+            if (fs.existsSync(cwd + '/node_modules/' + packetDirName)) {
+                let iopack;
+                try {
+                    iopack = JSON.parse(fs.readFileSync(cwd + '/node_modules/' + packetDirName + '/io-package.json', 'utf8'));
+                } catch (e) {
+                    iopack = null;
+                }
+                if (iopack) {
+                    iopack.common = iopack.common || {};
+                    iopack.common.installedFrom = npmUrl;
+                    try {
+                        fs.writeFileSync(cwd + '/node_modules/' + packetDirName + '/io-package.json', JSON.stringify(iopack, null, 2), 'utf8');
+                    } catch (e) {
+                        // OK
+                    }
+                }
+            }
             // create file that indicates, that npm was called there
-            if (npmUrl.indexOf(':') === -1 && fs.existsSync(cwd + '/node_modules/' + npmUrl)) {
-                fs.writeFileSync(cwd + '/node_modules/' + npmUrl + '/iob_npm.done', ' ');
+            if (fs.existsSync(cwd + '/node_modules/' + packetDirName)) {
+                fs.writeFileSync(cwd + '/node_modules/' + packetDirName + '/iob_npm.done', ' ');
             }
             // command succeeded
             if (callback) callback(npmUrl, cwd + '/node_modules');

--- a/lib/setup/setupUpload.js
+++ b/lib/setup/setupUpload.js
@@ -82,7 +82,7 @@ function Upload(options) {
                 }
             }
             if (onlyAlive) {
-                checkHostsIfAlive(hosts, callback)
+                checkHostsIfAlive(hosts, callback);
             } else {
                 callback(hosts);
             }
@@ -711,7 +711,7 @@ function Upload(options) {
         if (typeof iopack === 'function') {
             callback = iopack;
             iopack = null;
-        } else if (typeof iopack === 'object') {
+        } else if (typeof iopack === 'object' && typeof iopack.warn === 'function' && typeof iopack.error === 'function') {
             callback = logger;
             logger = iopack;
             iopack = null;
@@ -723,40 +723,44 @@ function Upload(options) {
 
         logger = logger || console;
 
-        if (!iopack) {
-            const adapterDir = tools.getAdapterDir(name);
-            try {
-                iopack = JSON.parse(fs.readFileSync(adapterDir + '/io-package.json', 'utf8'));
-            } catch (e) {
-                if (adapterDir) {
-                    logger.error('Cannot find io-package.json in ' + adapterDir);
-                } else {
-                    logger.error(`Cannot find io-package.json for "${name}"`);
-                }
-                iopack = null;
+        const adapterDir = tools.getAdapterDir(name);
+        let iopackFile;
+        try {
+            iopackFile = JSON.parse(fs.readFileSync(adapterDir + '/io-package.json', 'utf8'));
+        } catch (e) {
+            if (adapterDir) {
+                logger.error('Cannot find io-package.json in ' + adapterDir);
+            } else {
+                logger.error(`Cannot find io-package.json for "${name}"`);
             }
+            iopackFile = null;
         }
+        iopack = iopack || iopackFile;
 
         if (!iopack) {
             callback(name);
         } else {
+            // Always update installed From from File on disk if exists and set
+            if (iopackFile && iopackFile.common && iopackFile.common.installedFrom) {
+                iopack.common = iopack.common || {};
+                iopack.common.installedFrom = iopackFile.common.installedFrom;
+            }
             objects.getObject('system.adapter.' + name, (err, obj) => {
                 if (err || !obj) {
-                    logger.error(`system.adapter.${name} does not exist`);
-                    callback(name);
-                } else {
-                    obj.common = iopack.common || {};
-                    obj.native = iopack.native || {};
-
-                    obj.common.installedVersion = iopack.common.version;
-
-                    const hostname = tools.getHostName();
-
-                    obj.from = `system.host.${hostname}.cli`;
-                    obj.ts = Date.now();
-
-                    objects.setObject('system.adapter.' + name, obj, () => this._upgradeAdapterObjectsHelper(name, iopack, hostname, logger, callback));
+                    // Not existing? Why ever ... we recreate
+                    obj = {};
                 }
+                obj.common = iopack.common || {};
+                obj.native = iopack.native || {};
+
+                obj.common.installedVersion = iopack.common.version;
+
+                const hostname = tools.getHostName();
+
+                obj.from = `system.host.${hostname}.cli`;
+                obj.ts = Date.now();
+
+                objects.setObject('system.adapter.' + name, obj, () => this._upgradeAdapterObjectsHelper(name, iopack, hostname, logger, callback));
             });
         }
     };

--- a/main.js
+++ b/main.js
@@ -2367,11 +2367,12 @@ function installAdapters() {
         procs[task.id].downloadRetry++;
         logger.warn(hostLogPrefix + ' startInstance cannot find adapter "' + name + '". Try to install it... ' + procs[task.id].downloadRetry + ' attempt');
 
-        const installArgs = []
+        const installArgs = [];
         if (task.installedFrom) {
             if (task.installedFrom.includes('://')) {
                 installArgs.push('url');
                 installArgs.push(task.installedFrom);
+                installArgs.push(task.id.split('.')[2]);
             }
             else {
                 installArgs.push('install');

--- a/main.js
+++ b/main.js
@@ -2230,7 +2230,7 @@ function initInstances() {
             const adapterDir = tools.getAdapterDir(name);
             if (!fs.existsSync(adapterDir)) {
                 procs[id].downloadRetry = procs[id].downloadRetry || 0;
-                installQueue.push({id: id, disabled: true, version: procs[id].config.common.version, installedFrom: instance.common.installedFrom});
+                installQueue.push({id: id, disabled: true, version: procs[id].config.common.version, installedFrom: procs[id].config.common.installedFrom});
                 // start install queue if not started
                 installQueue.length === 1 && installAdapters();
             }
@@ -2387,7 +2387,7 @@ function installAdapters() {
             installArgs.push(name);
         }
         logger.info(hostLogPrefix + ' ' + tools.appName + ' ' + installArgs.join(' '));
-        installArgs.unshift(__dirname + '/' + tools.appName + '.js');]
+        installArgs.unshift(__dirname + '/' + tools.appName + '.js');
 
         try {
             const child = require('child_process').spawn('node', installArgs, {windowsHide: true});


### PR DESCRIPTION
* rewrite io-package after installation to include common.installedFrom as new property, with this normal upload will make this available in objects
* use "installedFrom" property when available for automatic reinstallations (on host moves or error cases)
* fix one more case where Github installs have not triggered upload
* also remember GitHub commit Hash if possible