### PR TITLE
Set TLS-cert validity period to two years because of Apple

### DIFF
--- a/lib/cli/cliCert.js
+++ b/lib/cli/cliCert.js
@@ -59,7 +59,7 @@ module.exports = class CLICert extends CLICommand {
         cert.serialNumber = '0' + makeid(17);
         cert.validity.notBefore = new Date();
         cert.validity.notAfter = new Date();
-        cert.validity.notAfter.setFullYear(cert.validity.notBefore.getFullYear() + 5);
+        cert.validity.notAfter.setFullYear(cert.validity.notBefore.getFullYear() + 2);
 
         const subAttrs = [
             { name: 'commonName', value: tools.getHostName() },


### PR DESCRIPTION
TLS server certificates must have a validity period of 825 days or fewer for new Apple OSes. Set to two years. #515 