### PR TITLE
Correctly handle git commits and branches as custom install sources

### DIFF
--- a/lib/setup/setupInstall.js
+++ b/lib/setup/setupInstall.js
@@ -372,7 +372,10 @@ function Install(options) {
             options.unsafePerm = true;
         }
 
-        const cmd = 'npm install ' + npmUrl + (options.unsafePerm ? ' --unsafe-perm' : '') + ' --loglevel error --production --save --prefix "' + cwd + '"';
+        // We don't need --production and --save here.
+        // --production doesn't do anything when installing a specific package (which we do here)
+        // --save is the default since npm 3
+        const cmd = 'npm install ' + npmUrl + (options.unsafePerm ? ' --unsafe-perm' : '') + ' --loglevel error --prefix "' + cwd + '"';
 
         console.log(cmd + ' (System call)');
         // Install node modules as system call
@@ -385,7 +388,25 @@ function Install(options) {
         if (debug || params.debug) {
             child.stdout.pipe(process.stdout);
         }
-        const packetDirName = options.packetName ? tools.appName.toLowerCase() + '.' + options.packetName : npmUrl;
+
+        // Determine where the packet would be installed if npm succeeds
+        /** @type {string} */
+        let packetDirName;
+        if (options.packetName) {
+            packetDirName = tools.appName.toLowerCase() + '.' + options.packetName;
+        } else {
+            packetDirName = npmUrl.toLowerCase();
+            // If the user installed a git commit-ish, the url contains stuff that doesn't belong in a folder name
+            // e.g. iobroker/iobroker.javascript#branch-name
+            if (packetDirName.indexOf('#') > -1) {
+                packetDirName = packetDirName.substr(0, packetDirName.indexOf('#'));
+            }
+            if (packetDirName.indexOf('/') > -1 && !packetDirName.startsWith('@')) {
+                // only scoped packages (e.g. @types/node ) may have a slash in their path
+                packetDirName = packetDirName.substr(packetDirName.lastIndexOf('/') + 1);
+            }
+        }
+        const installDir = path.join(cwd, 'node_modules', packetDirName);
 
         child.on('exit', (code /* , signal */) => {
             // code 1 is strange error that cannot be explained. Everything is installed but error :(
@@ -395,10 +416,11 @@ function Install(options) {
                 return;
             }
             // inject the installedFrom information in io-package
-            if (fs.existsSync(cwd + '/node_modules/' + packetDirName)) {
+            if (fs.existsSync(installDir)) {
+                const ioPackPath = path.join(installDir, 'io-package.json');
                 let iopack;
                 try {
-                    iopack = JSON.parse(fs.readFileSync(cwd + '/node_modules/' + packetDirName + '/io-package.json', 'utf8'));
+                    iopack = JSON.parse(fs.readFileSync(ioPackPath, 'utf8'));
                 } catch (e) {
                     iopack = null;
                 }
@@ -406,21 +428,18 @@ function Install(options) {
                     iopack.common = iopack.common || {};
                     iopack.common.installedFrom = npmUrl;
                     try {
-                        fs.writeFileSync(cwd + '/node_modules/' + packetDirName + '/io-package.json', JSON.stringify(iopack, null, 2), 'utf8');
+                        fs.writeFileSync(ioPackPath, JSON.stringify(iopack, null, 2), 'utf8');
                     } catch (e) {
                         // OK
                     }
                 }
-            }
-            else {
+            } else {
                 console.error('host.' + hostname + ' Cannot install ' + npmUrl + ': ' + code);
                 processExit(EXIT_CODES.CANNOT_INSTALL_NPM_PACKET);
                 return;
             }
             // create file that indicates, that npm was called there
-            if (fs.existsSync(cwd + '/node_modules/' + packetDirName)) {
-                fs.writeFileSync(cwd + '/node_modules/' + packetDirName + '/iob_npm.done', ' ');
-            }
+            fs.writeFileSync(path.join(installDir, 'iob_npm.done'), ' ');
             // command succeeded
             if (callback) callback(npmUrl, cwd + '/node_modules');
         });


### PR DESCRIPTION
npm accepts commits and branches as an install source, e.g. `ioBroker/ioBroker.javascript#my-feature-branch`. ioBroker would use the full string as a file path, so it would look for `/opt/iobroker/node_modules/ioBroker/ioBroker.javascript#my-feature-branch` to determine if `npm install` succeeded.

With this PR, we now sanitize that string, so it can be used as a file path. In detail:
* leading path segments (`ioBroker/`) are removed if the segment does not start with `@` (scoped package)
* trailing hashes (`#my-feature-branch`) are removed
* repo names are converted to lowercase