### PR TITLE
fix async version of getEncryptedConfig

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -980,7 +980,7 @@ function Adapter(options) {
     this.getEncryptedConfig = (attribute, callback) => {
         if (this.config.hasOwnProperty(attribute)) {
             if (typeof callback !== 'function') {
-                return new Promise((reject, resolve) => {
+                return new Promise((resolve, reject) => {
                     this.getEncryptedConfig(attribute, (err, encrypted) => {
                         if (err) {
                             reject(err);


### PR DESCRIPTION
- fix async version of `adapter.getEncryptedConfig`
- currently the promise will never return if successful