### PR TITLE
fixing issues in backup validation + add some missing commands to cli help

### DIFF
--- a/lib/setup.js
+++ b/lib/setup.js
@@ -737,7 +737,7 @@ function processCommand(command, args, params, callback) {
                     console.log('Backup OK');
                     processExit(0);
                 }).catch(e => {
-                    console.log('Backup check failed: ' + e);
+                    console.log(`Backup check failed: ${e}`);
                     processExit(1);
                 });
             });

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -101,6 +101,7 @@ function initYargs() {
                 tools.appName + ' clean\n' +
                 tools.appName + ' backup\n' +
                 tools.appName + ' restore <backup name or path>\n' +
+                tools.appName + ' validate <backup name or path>\n' +
                 tools.appName + ' <command> --timeout 5000\n' +
                 tools.appName + ' status [all]\n' +
                 tools.appName + ' repo [name]\n' +
@@ -109,6 +110,7 @@ function initYargs() {
                 tools.appName + ' repo del <name>\n' +
                 tools.appName + ' uuid\n' +
                 tools.appName + ' unsetup\n' +
+                tools.appName + ' fix\n' +
                 tools.appName + ' multihost <enable|disable> [--secure true|false]\n' +
                 tools.appName + ' multihost browse\n' +
                 tools.appName + ' multihost connect\n' +

--- a/lib/setup/setupBackup.js
+++ b/lib/setup/setupBackup.js
@@ -649,7 +649,7 @@ class BackupRestore {
     validateBackup(name) {
         return new Promise(resolve => {
             let backups;
-            if (name === undefined || (!name && name !== 0)) {
+            if (!name && name !== 0) {
                 backups = this.listBackups();
                 backups.sort((a, b) => b > a);
                 if (backups.length) {
@@ -767,7 +767,7 @@ class BackupRestore {
 
     restoreBackup(name, callback) {
         let backups;
-        if (name === undefined || (!name && name !== 0)) {
+        if (!name && name !== 0) {
             // List all available backups
             console.log('Please specify one of the backup names:');
             backups = this.listBackups();
@@ -779,7 +779,7 @@ class BackupRestore {
             } else {
                 console.warn('No backups found');
             }
-            this.processExit(10);
+            return this.processExit(10);
         }
 
         if (!this.cleanDatabase) throw 'Invalid arguments: cleanDatabase is missing';

--- a/lib/setup/setupBackup.js
+++ b/lib/setup/setupBackup.js
@@ -709,30 +709,30 @@ class BackupRestore {
                     this.processExit(9);
                 }
                 if (!fs.existsSync(`${tmpDir}/backup/backup.json`)) {
-                    console.error(`host.${hostname} Cannot find extracted file from file "${tmpDir}/backup/backup.json"`);
-                    this.processExit(9);
+                    console.error(`host.${hostname} Validation failed. Cannot find extracted file from file "${tmpDir}/backup/backup.json"`);
+                    return this.processExit(9);
                 }
 
-                console.log('Starting validation ...');
+                console.log(`host.${hostname} Starting validation ...`);
                 let backupJSON;
                 try {
                     backupJSON = require(`${tmpDir}/backup/backup.json`);
                 } catch (e) {
-                    console.error(`Backup ${name} does not contain a valid backup.json file: ${e}`);
-                    this._removeFolderRecursive(`${tmpDir}/backup/`).then(this.processExit(26));
+                    console.error(`host.${hostname} Backup corrupted. Backup ${name} does not contain a valid backup.json file: ${e}`);
+                    return this._removeFolderRecursive(`${tmpDir}/backup/`).then(this.processExit(26));
                 }
 
                 if (!backupJSON || !backupJSON.objects || !backupJSON.objects.length) {
-                    console.error('Backup does not contain valid objects');
-                    this._removeFolderRecursive(`${tmpDir}/backup/`).then(this.processExit(26));
+                    console.error(`host.${hostname} Backup corrupted. Backup does not contain valid objects`);
+                    return this._removeFolderRecursive(`${tmpDir}/backup/`).then(this.processExit(26));
                 } // endIf
 
-                console.log('backup.json OK');
+                console.log(`host.${hostname} backup.json OK`);
 
                 this._checkDirectory(`${tmpDir}/backup/files`, true).then(() => this._removeFolderRecursive(`${tmpDir}/backup/`))
                     .then(resolve).catch(e => {
-                        console.error(e);
-                        this.processExit(26);
+                        console.error(`host.${hostname} Backup corrupted: ${e}`);
+                        return this.processExit(26);
                     });
             });
         });
@@ -745,17 +745,17 @@ class BackupRestore {
                 const files = fs.readdirSync(path);
                 if (!files.length) resolve();
                 for (const file of files) {
-                    const filePath = path + '/' + file;
+                    const filePath = `${path}/${file}`;
                     if(fs.existsSync(filePath) && fs.statSync(filePath).isDirectory()) {
                     // if directory then check it
                         promises.push(this._checkDirectory(filePath, verbose));
                     } else if (file.endsWith('.json')) {
                         try {
                             require(filePath);
-                            if (verbose) console.log(file + ' OK');
+                            if (verbose) console.log(`host.${hostname} ${file} OK`);
                             resolve();
                         } catch (e) {
-                            reject(filePath + ' is not a valid json file');
+                            reject(`host.${hostname} ${filePath} is not a valid json file`);
                         }
                     }
                 }

--- a/lib/setup/setupBackup.js
+++ b/lib/setup/setupBackup.js
@@ -632,12 +632,12 @@ class BackupRestore {
 
     validateBackupAfterCreation() {
         return new Promise((resolve, reject) => {
-            const backupJSON = require(tmpDir + '/backup/backup.json');
+            const backupJSON = require(`${tmpDir}/backup/backup.json`);
             if (!backupJSON.objects || !backupJSON.objects.length) {
                 reject('Backup does not contain valid objects');
             }
 
-            this._checkDirectory(tmpDir + '/backup/files')
+            this._checkDirectory(`${tmpDir}/backup/files`)
                 .then(() => {
                     resolve();
                 }).catch(e => {
@@ -650,18 +650,18 @@ class BackupRestore {
         return new Promise(resolve => {
             let backups;
             if (!name && name !== 0) {
-                // List all available backups
-                console.log('Please specify one of the backup names:');
                 backups = this.listBackups();
                 backups.sort((a, b) => b > a);
                 if (backups.length) {
+                    // List all available backups
+                    console.log('Please specify one of the backup names:');
                     for (const t in backups) {
-                        console.log(backups[t] + ' or ' + backups[t].replace('_backup' + tools.appName + '.tar.gz', '') + ' or ' + t);
+                        console.log(`${backups[t]} or ${backups[t].replace('_backup' + tools.appName + '.tar.gz', '')} or ${t}`);
                     }
                 } else {
-                    console.warn('No backups found');
+                    console.warn(`No backups found. Create a backup, using "${tools.appName} backup" first`);
                 }
-                this.processExit(10);
+                return this.processExit(10);
             }
             // If number
             if (parseInt(name, 10).toString() === name.toString()) {
@@ -673,28 +673,31 @@ class BackupRestore {
                     if (backups.length) {
                         console.log('Please specify one of the backup names:');
                         for (const t in backups) {
-                            console.log(backups[t] + ' or ' + backups[t].replace('_backup' + tools.appName + '.tar.gz', '') + ' or ' + t);
+                            console.log(`${backups[t]} or ${backups[t].replace('_backup' + tools.appName + '.tar.gz', '')} or ${t}`);
                         }
-                    } // endIf
+                    } else {
+                        console.log(`No existing backups. Create a backup, using "${tools.appName} backup" first`);
+                    }
+                    return this.processExit(10);
                 } else {
-                    console.log('host.' + hostname + ' Using backup file ' + name);
+                    console.log(`host.${hostname} Using backup file ${name}`);
                 }
             }
 
             name = (name || '').toString().replace(/\\/g, '/');
             if (name.indexOf('/') === -1) {
                 name = this.getBackupDir() + name;
-                const regEx = new RegExp('_backup' + tools.appName, 'i');
-                if (!regEx.test(name)) name += '_backup' + tools.appName;
+                const regEx = new RegExp(`_backup${tools.appName}`, 'i');
+                if (!regEx.test(name)) name += `_backup${tools.appName}`;
                 if (!name.match(/\.tar\.gz$/i)) name += '.tar.gz';
             }
             if (!fs.existsSync(name)) {
-                console.error('host.' + hostname + ' Cannot find ' + name);
+                console.error(`host.${hostname} Cannot find ${name}`);
                 this.processExit(11);
             }
             const tar = require('tar');
-            if (fs.existsSync(tmpDir + '/backup/backup.json')) {
-                fs.unlinkSync(tmpDir + '/backup/backup.json');
+            if (fs.existsSync(`${tmpDir}/backup/backup.json`)) {
+                fs.unlinkSync(`${tmpDir}/backup/backup.json`);
             }
 
             tar.extract({
@@ -702,31 +705,31 @@ class BackupRestore {
                 cwd: tmpDir
             }, err => {
                 if (err) {
-                    console.error('host.' + hostname + ' Cannot extract from file "' + name + '"');
+                    console.error(`host.${hostname} Cannot extract from file "${name}"`);
                     this.processExit(9);
                 }
-                if (!fs.existsSync(tmpDir + '/backup/backup.json')) {
-                    console.error('host.' + hostname + ' Cannot find extracted file from file "' + tmpDir + '/backup/backup.json"');
+                if (!fs.existsSync(`${tmpDir}/backup/backup.json`)) {
+                    console.error(`host.${hostname} Cannot find extracted file from file "${tmpDir}/backup/backup.json"`);
                     this.processExit(9);
                 }
 
                 console.log('Starting validation ...');
                 let backupJSON;
                 try {
-                    backupJSON = require(tmpDir + '/backup/backup.json');
+                    backupJSON = require(`${tmpDir}/backup/backup.json`);
                 } catch (e) {
-                    console.error('Backup ' + name + ' does not contain a valid backup.json file: ' + e);
-                    this._removeFolderRecursive(tmpDir + '/backup/').then(this.processExit(26));
+                    console.error(`Backup ${name} does not contain a valid backup.json file: ${e}`);
+                    this._removeFolderRecursive(`${tmpDir}/backup/`).then(this.processExit(26));
                 }
 
                 if (!backupJSON || !backupJSON.objects || !backupJSON.objects.length) {
                     console.error('Backup does not contain valid objects');
-                    this._removeFolderRecursive(tmpDir + '/backup/').then(this.processExit(26));
+                    this._removeFolderRecursive(`${tmpDir}/backup/`).then(this.processExit(26));
                 } // endIf
 
                 console.log('backup.json OK');
 
-                this._checkDirectory(tmpDir + '/backup/files', true).then(() => this._removeFolderRecursive(tmpDir + '/backup/'))
+                this._checkDirectory(`${tmpDir}/backup/files`, true).then(() => this._removeFolderRecursive(`${tmpDir}/backup/`))
                     .then(resolve).catch(e => {
                         console.error(e);
                         this.processExit(26);

--- a/lib/setup/setupBackup.js
+++ b/lib/setup/setupBackup.js
@@ -347,14 +347,14 @@ class BackupRestore {
                             }
                         }));
 
-                        console.log('host.' + hostname + ' ' + result.objects.length + ' objects saved');
+                        console.log(`host.${hostname} ${result.objects.length} objects saved`);
 
                         fs.writeFileSync(tmpDir + '/backup/backup.json', JSON.stringify(result, null, 2));
 
                         Promise.all(promises).then(() => this.validateBackupAfterCreation())
                             .then(() => this.packBackup(name, callback))
                             .catch(e => {
-                                console.error(e);
+                                console.error(`host.${hostname} Backup not created: ${e}`);
                                 this._removeFolderRecursive(tmpDir + /backup/).then(() => this.processExit(26));
                             });
                     });


### PR DESCRIPTION
- added commands `fix` and `validate` to help
- fix some issues in backup validation due to the fact, that this.processExit won't stop execution immediately because its calling a callback, thus we have to return to avoid strange errors in stdout
- made some logging in backup validation more meaningful