### PR TITLE
do not allow access to adapter.states and adapter.objects anymore

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -39,6 +39,8 @@ const ALIAS_STARTS_WITH = 'alias.';
 let schedule;
 let restartScheduleJob;
 let initializeTimeout;
+let adapterStates;
+let adapterObjects;
 
 const supportedFeatures = [
     'ALIAS', // Alias Feature supported
@@ -132,6 +134,9 @@ function Adapter(options) {
 
     this.logList = [];
     this.aliases = {};
+
+    // TODO: Remove this backward compatibility shim in the future
+    this.objects = {};
 
     this.eventLoopLags = [];
     this.overwriteLogLevel = false;
@@ -265,13 +270,13 @@ function Adapter(options) {
             logger.warn(text);
         }
         setTimeout(() => { // give last states some time to get handled
-            if (this.states) {
-                this.states.destroy();
-                this.states = null;
+            if (adapterStates) {
+                adapterStates.destroy();
+                adapterStates = null;
             }
-            if (this.objects) {
-                this.objects.destroy();
-                this.objects = null;
+            if (adapterObjects) {
+                adapterObjects.destroy();
+                adapterObjects = null;
             }
             if (this.startedInCompactMode) {
                 this.emit('exit', exitCode, reason);
@@ -1023,9 +1028,9 @@ function Adapter(options) {
         if (state !== undefined) {
             delete task.state;
         }
-        this.objects.extendObject(task._id, task, () =>
+        adapterObjects.extendObject(task._id, task, () =>
             state ?
-                this.states.setState(task._id, state, () => setImmediate(extendObjects, tasks, callback)) :
+                adapterStates.setState(task._id, state, () => setImmediate(extendObjects, tasks, callback)) :
                 setImmediate(extendObjects, tasks, callback));
     };
 
@@ -1306,9 +1311,9 @@ function Adapter(options) {
     };
 
     const autoSubscribeOn = (cb) => {
-        if (!this.autoSubscribe && this.objects) {
+        if (!this.autoSubscribe && adapterObjects) {
             // collect all
-            this.objects.getObjectView('system', 'instance', {startkey: 'system.adapter.', endkey: 'system.adapter.\u9999'}, options, (err, res) => {
+            adapterObjects.getObjectView('system', 'instance', {startkey: 'system.adapter.', endkey: 'system.adapter.\u9999'}, options, (err, res) => {
                 if (res && res.rows) {
                     this.autoSubscribe = [];
                     for (let c = res.rows.length - 1; c >= 0; c--) {
@@ -1324,7 +1329,7 @@ function Adapter(options) {
                 if (typeof cb === 'function') cb();
             });
             // because of autoSubscribe
-            this.objects.subscribe('system.adapter.*');
+            adapterObjects.subscribe('system.adapter.*');
         } else if (typeof cb === 'function') {
             cb();
         }
@@ -1346,7 +1351,7 @@ function Adapter(options) {
             connection: config.objects,
             logger:     logger,
             connected: (objectsInstance) => {
-                this.objects = objectsInstance;
+                adapterObjects = objectsInstance;
                 this.connected = true;
                 if (initializeTimeout) {
                     clearTimeout(initializeTimeout);
@@ -1556,11 +1561,11 @@ function Adapter(options) {
                 callback = options;
                 options = undefined;
             }
-            if (!this.objects) { // if objects is no longer existing, we do not need to unsubscribe
+            if (!adapterObjects) { // if objects is no longer existing, we do not need to unsubscribe
                 callback && callback('Objects database not connected');
                 return;
             }
-            this.objects.setObject(id, obj, options, (err, result) => {
+            adapterObjects.setObject(id, obj, options, (err, result) => {
                 if (!err && obj.common && obj.common.def !== undefined) {
                     this.setState(id, obj.common.def, true, null, () =>
                         typeof callback === 'function' && callback(err, result));
@@ -1684,26 +1689,26 @@ function Adapter(options) {
         this.getAdapterObjects = (callback) => {
             const objects = {};
 
-            if (!this.objects) { // if objects is no longer existing, we do not need to unsubscribe
+            if (!adapterObjects) { // if objects is no longer existing, we do not need to unsubscribe
                 callback && callback(objects);
                 return;
             }
 
-            this.objects.getObjectView('system', 'state', {startkey: this.namespace + '.', endkey: this.namespace + '.\u9999', include_docs: true}, (err, _states) => {
+            adapterObjects.getObjectView('system', 'state', {startkey: this.namespace + '.', endkey: this.namespace + '.\u9999', include_docs: true}, (err, _states) => {
 
-                if (!this.objects) { // if objects is no longer existing, we do not need to unsubscribe
+                if (!adapterObjects) { // if objects is no longer existing, we do not need to unsubscribe
                     callback && callback(objects);
                     return;
                 }
 
-                this.objects.getObjectView('system', 'channel', {startkey: this.namespace + '.', endkey: this.namespace + '.\u9999', include_docs: true}, (err, _channels) => {
+                adapterObjects.getObjectView('system', 'channel', {startkey: this.namespace + '.', endkey: this.namespace + '.\u9999', include_docs: true}, (err, _channels) => {
 
-                    if (!this.objects) { // if objects is no longer existing, we do not need to unsubscribe
+                    if (!adapterObjects) { // if objects is no longer existing, we do not need to unsubscribe
                         callback && callback(objects);
                         return;
                     }
 
-                    this.objects.getObjectView('system', 'device', {startkey: this.namespace + '.', endkey: this.namespace + '.\u9999', include_docs: true}, (err, _devices) => {
+                    adapterObjects.getObjectView('system', 'device', {startkey: this.namespace + '.', endkey: this.namespace + '.\u9999', include_docs: true}, (err, _devices) => {
                         if (_channels) {
                             for (let c = _channels.rows.length - 1; c >= 0; c--) {
                                 objects[_channels.rows[c].id] = _channels.rows[c].value;
@@ -1799,7 +1804,7 @@ function Adapter(options) {
                 options = null;
             }
 
-            if (!this.objects) { // if objects is no longer existing, we do not need to unsubscribe
+            if (!adapterObjects) { // if objects is no longer existing, we do not need to unsubscribe
                 return callback && callback('Objects database not connected');
             }
 
@@ -1827,7 +1832,7 @@ function Adapter(options) {
                 (obj.native && obj.native.devices))
             ) {
                 // Read whole object
-                this.objects.getObject(id, options, (err, oldObj) => {
+                adapterObjects.getObject(id, options, (err, oldObj) => {
                     if (err) {
                         return typeof callback === 'function' && callback(err);
                     }
@@ -1853,14 +1858,14 @@ function Adapter(options) {
                     obj.user = obj.user || (options ? options.user : '') || 'system.user.admin';
                     obj.ts   = obj.ts   || Date.now();
 
-                    this.objects.setObject(id, obj, options, callback);
+                    adapterObjects.setObject(id, obj, options, callback);
                 });
             } else {
                 obj.from = obj.from || ('system.adapter.' + this.namespace);
                 obj.user = obj.user || (options ? options.user : '') || 'system.user.admin';
                 obj.ts   = obj.ts   || Date.now();
 
-                this.objects.extendObject(id, obj, options, callback);
+                adapterObjects.extendObject(id, obj, options, callback);
             }
         };
         /**
@@ -1943,7 +1948,7 @@ function Adapter(options) {
                 callback = options;
                 options = null;
             }
-            if (!this.objects) { // if objects is no longer existing, we do not need to unsubscribe
+            if (!adapterObjects) { // if objects is no longer existing, we do not need to unsubscribe
                 callback && callback('Objects database not connected');
                 return;
             }
@@ -1964,7 +1969,7 @@ function Adapter(options) {
                 (obj.common && obj.common.members)
             ) {
                 // Read whole object
-                this.objects.getObject(id, options, (err, oldObj) => {
+                adapterObjects.getObject(id, options, (err, oldObj) => {
                     if (err) {
                         return typeof callback === 'function' && callback(err);
                     }
@@ -1990,14 +1995,14 @@ function Adapter(options) {
                     obj.user = obj.user || (options ? options.user : '') || 'system.user.admin';
                     obj.ts   = obj.ts || Date.now();
 
-                    this.objects.setObject(id, obj, callback);
+                    adapterObjects.setObject(id, obj, callback);
                 });
             } else {
                 obj.from = obj.from || ('system.adapter.' + this.namespace);
                 obj.user = obj.user || (options ? options.user : '') || 'system.user.admin';
                 obj.ts   = obj.ts || Date.now();
 
-                this.objects.extendObject(id, obj, options, callback);
+                adapterObjects.extendObject(id, obj, options, callback);
             }
         };
         /**
@@ -2026,12 +2031,12 @@ function Adapter(options) {
                 callback = options;
                 options = null;
             }
-            if (!this.objects) { // if objects is no longer existing, we do not need to unsubscribe
+            if (!adapterObjects) { // if objects is no longer existing, we do not need to unsubscribe
                 callback && callback('Objects database not connected');
                 return;
             }
 
-            this.objects.getObject(this._fixId(id), options, callback);
+            adapterObjects.getObject(this._fixId(id), options, callback);
         };
         /**
          * Promise-version of Adapter.getObject
@@ -2071,17 +2076,24 @@ function Adapter(options) {
                 callback = options;
                 options = undefined;
             }
-            if (!this.objects) { // if objects is no longer existing, we do not need to unsubscribe
+            if (!adapterObjects) { // if objects is no longer existing, we do not need to unsubscribe
                 callback && callback('Objects database not connected');
                 return;
             }
 
-            return this.objects.getObjectView(design, search, params, options, callback);
+            return adapterObjects.getObjectView(design, search, params, options, callback);
         };
         /**
          * Promise-version of Adapter.getObjectView
          */
         this.getObjectViewAsync = tools.promisify(this.getObjectView, this);
+
+        // TODO: remove this backward compatibility shim in the future
+        this.objects.getObjectView = (design, search, params, options, callback) => {
+            // for now log it only on debug
+            this.log.debug('adapter.objects.getObjectView is deprecated, and will be removed in the future. Please use adapter.getObjectView/Async. Report this to Developer!');
+            return this.getObjectView(design, search, params, options, callback);
+        };
 
         /**
          * Read object list from DB.
@@ -2116,17 +2128,24 @@ function Adapter(options) {
                 options = null;
             }
 
-            if (!this.objects) { // if objects is no longer existing, we do not need to unsubscribe
+            if (!adapterObjects) { // if objects is no longer existing, we do not need to unsubscribe
                 callback && callback('Objects database not connected');
                 return;
             }
 
-            this.objects.getObjectList(params, options, callback);
+            adapterObjects.getObjectList(params, options, callback);
         };
         /**
          * Promise-version of Adapter.getObjectList
          */
         this.getObjectListAsync = tools.promisify(this.getObjectList, this);
+
+        // TODO: remove this backward compatibility shim in the future
+        this.objects.getObjectList = (params, options, callback) => {
+            // for now log it only on debug
+            this.log.debug('adapter.objects.getObjectList is deprecated, and will be removed in the future. Please use adapter.getObjectList/Async. Report this to Developer!');
+            adapterObjects.getObjectList(params, options, callback);
+        };
 
         /**
          * Get the enum tree.
@@ -2168,7 +2187,7 @@ function Adapter(options) {
                 callback = options;
                 options = null;
             }
-            if (!this.objects) { // if objects is no longer existing, we do not need to unsubscribe
+            if (!adapterObjects) { // if objects is no longer existing, we do not need to unsubscribe
                 callback && callback('Objects database not connected');
                 return;
             }
@@ -2176,7 +2195,7 @@ function Adapter(options) {
             if (!_enum.match('^enum.')) _enum = 'enum.' + _enum;
             const result = {};
 
-            this.objects.getObjectView('system', 'enum', {startkey: _enum + '.', endkey: _enum + '.\u9999'}, options, (err, res) => {
+            adapterObjects.getObjectView('system', 'enum', {startkey: _enum + '.', endkey: _enum + '.\u9999'}, options, (err, res) => {
                 if (err) {
                     return typeof callback === 'function' && callback(err);
                 }
@@ -2244,7 +2263,7 @@ function Adapter(options) {
                 callback = options;
                 options  = null;
             }
-            if (!this.objects) { // if objects is no longer existing, we do not need to unsubscribe
+            if (!adapterObjects) { // if objects is no longer existing, we do not need to unsubscribe
                 callback && callback('Objects database not connected');
                 return;
             }
@@ -2262,7 +2281,7 @@ function Adapter(options) {
                 }
             } else {
                 // Read all enums
-                this.objects.getObjectView('system', 'enum', {startkey: 'enum.', endkey: 'enum.\u9999'}, options, (err, res) => {
+                adapterObjects.getObjectView('system', 'enum', {startkey: 'enum.', endkey: 'enum.\u9999'}, options, (err, res) => {
                     // be aware, that res.rows[x].id is the name of enum!
                     if (err) {
                         callback(err);
@@ -2359,12 +2378,12 @@ function Adapter(options) {
                 options = enums;
                 enums = null;
             }
-            if (!this.objects) { // if objects is no longer existing, we do not need to unsubscribe
+            if (!adapterObjects) { // if objects is no longer existing, we do not need to unsubscribe
                 callback && callback('Objects database not connected');
                 return;
             }
 
-            this.objects.getObjectView('system', type || 'state', params, options, (err, res) => {
+            adapterObjects.getObjectView('system', type || 'state', params, options, (err, res) => {
                 if (err) {
                     callback(err);
                     return;
@@ -2440,12 +2459,12 @@ function Adapter(options) {
                 callback = type;
                 type = null;
             }
-            if (!this.objects) { // if objects is no longer existing, we do not need to unsubscribe
+            if (!adapterObjects) { // if objects is no longer existing, we do not need to unsubscribe
                 callback && callback('Objects database not connected');
                 return;
             }
 
-            this.objects.findObject(id, type, options, callback);
+            adapterObjects.findObject(id, type, options, callback);
         };
         /**
          * Promise-version of Adapter.findForeignObject
@@ -2473,12 +2492,12 @@ function Adapter(options) {
                 callback = options;
                 options = null;
             }
-            if (!this.objects) { // if objects is no longer existing, we do not need to unsubscribe
+            if (!adapterObjects) { // if objects is no longer existing, we do not need to unsubscribe
                 callback && callback('Objects database not connected');
                 return;
             }
 
-            this.objects.getObject(id, options, (err, obj) => {
+            adapterObjects.getObject(id, options, (err, obj) => {
                 const adapterName = this.namespace.split('.')[0];
                 // remove protectedNative if not admin or own adapter
                 if(obj && obj._id && obj._id.startsWith('system.adapter.') && adapterName !== 'admin' &&
@@ -2529,7 +2548,7 @@ function Adapter(options) {
                 cb && cb();
             } else {
                 const task = tasks.shift();
-                this.objects.delObject(task.id, options, err => {
+                adapterObjects.delObject(task.id, options, err => {
                     if (err) {
                         cb && cb(err);
                     } else if (!task.state) {
@@ -2545,7 +2564,7 @@ function Adapter(options) {
                     }
                 });
             }
-        }
+        };
         /**
          * Delete any object.
          *
@@ -2567,7 +2586,7 @@ function Adapter(options) {
                 callback = options;
                 options = null;
             }
-            if (!this.objects) { // if objects is no longer existing, we do not need to unsubscribe
+            if (!adapterObjects) { // if objects is no longer existing, we do not need to unsubscribe
                 callback && callback('Objects database not connected');
                 return;
             }
@@ -2575,17 +2594,17 @@ function Adapter(options) {
             // If recursive deletion of all underlying objects, including id
             if (options && options.recursive) {
                 // read object itself
-                this.objects.getObject(id, options, (err, obj) => {
+                adapterObjects.getObject(id, options, (err, obj) => {
                     const tasks = obj ? [{id, state: obj.type === 'state'}] : [];
                     const selector = {startkey: id + '.', endkey: id + '.\u9999'};
                     // read all underlying states
-                    this.objects.getObjectView('system', 'state', selector, options, (err, res) => {
+                    adapterObjects.getObjectView('system', 'state', selector, options, (err, res) => {
                         res && res.rows && res.rows.forEach(item => !tasks.find(task => task.id === item.id) && tasks.push({id: item.id, state: true}));
                         // read all underlying channels
-                        this.objects.getObjectView('system', 'channel', selector, options, (err, res) => {
+                        adapterObjects.getObjectView('system', 'channel', selector, options, (err, res) => {
                             res && res.rows && res.rows.forEach(item => !tasks.find(task => task.id === item.id) && tasks.push({id: item.id}));
                             // read all underlying devices
-                            this.objects.getObjectView('system', 'device', selector, options, (err, res) => {
+                            adapterObjects.getObjectView('system', 'device', selector, options, (err, res) => {
                                 res && res.rows && res.rows.forEach(item => !tasks.find(task => task.id === item.id) && tasks.push({id: item.id}));
                                 _deleteObjects(tasks, options, callback);
                             });
@@ -2593,11 +2612,11 @@ function Adapter(options) {
                     });
                 });
             } else {
-                this.objects.getObject(id, options, (err, obj) => {
+                adapterObjects.getObject(id, options, (err, obj) => {
                     if (err || !obj) {
                         return (typeof callback === 'function') && callback(err || tools.ERRORS.ERROR_NOT_FOUND);
                     } else {
-                        this.objects.delObject(obj._id, options, err => {
+                        adapterObjects.delObject(obj._id, options, err => {
                             if (err || obj.type !== 'state') {
                                 return (typeof callback === 'function') && callback(err);
                             } else {
@@ -2632,16 +2651,16 @@ function Adapter(options) {
                 callback = options;
                 options = undefined;
             }
-            if (!this.objects) { // if objects is no longer existing, we do not need to unsubscribe
+            if (!adapterObjects) { // if objects is no longer existing, we do not need to unsubscribe
                 callback && callback('Objects database not connected');
                 return;
             }
 
             if (pattern === '*') {
-                this.objects.subscribeUser(this.namespace + '.*', options, callback);
+                adapterObjects.subscribeUser(this.namespace + '.*', options, callback);
             } else {
                 pattern = this._fixId(pattern, true);
-                this.objects.subscribeUser(pattern, options, callback);
+                adapterObjects.subscribeUser(pattern, options, callback);
             }
         };
         /**
@@ -2668,16 +2687,16 @@ function Adapter(options) {
                 callback = options;
                 options = undefined;
             }
-            if (!this.objects) { // if objects is no longer existing, we do not need to unsubscribe
+            if (!adapterObjects) { // if objects is no longer existing, we do not need to unsubscribe
                 callback && callback('Objects database not connected');
                 return;
             }
 
             if (pattern === '*') {
-                this.objects.unsubscribeUser(this.namespace + '.*', options, callback);
+                adapterObjects.unsubscribeUser(this.namespace + '.*', options, callback);
             } else {
                 pattern = this._fixId(pattern, true);
-                this.objects.unsubscribeUser(pattern, options, callback);
+                adapterObjects.unsubscribeUser(pattern, options, callback);
             }
         };
         /**
@@ -2704,12 +2723,12 @@ function Adapter(options) {
                 callback = options;
                 options = undefined;
             }
-            if (!this.objects) { // if objects is no longer existing, we do not need to unsubscribe
+            if (!adapterObjects) { // if objects is no longer existing, we do not need to unsubscribe
                 callback && callback('Objects database not connected');
                 return;
             }
 
-            this.objects.subscribeUser(pattern, options, callback);
+            adapterObjects.subscribeUser(pattern, options, callback);
         };
         /**
          * Promise-version of Adapter.subscribeForeignObjects
@@ -2736,12 +2755,12 @@ function Adapter(options) {
                 options = undefined;
             }
             if (!pattern) pattern = '*';
-            if (!this.objects) { // if objects is no longer existing, we do not need to unsubscribe
+            if (!adapterObjects) { // if objects is no longer existing, we do not need to unsubscribe
                 callback && callback('Objects database not connected');
                 return;
             }
 
-            this.objects && this.objects.unsubscribeUser(pattern, options, callback);
+            adapterObjects && adapterObjects.unsubscribeUser(pattern, options, callback);
         };
         /**
          * Promise-version of Adapter.unsubscribeForeignObjects
@@ -2772,7 +2791,7 @@ function Adapter(options) {
                 callback = options;
                 options = null;
             }
-            if (!this.objects) { // if objects is no longer existing, we do not need to unsubscribe
+            if (!adapterObjects) { // if objects is no longer existing, we do not need to unsubscribe
                 callback && callback('Objects database not connected');
                 return;
             }
@@ -2784,7 +2803,7 @@ function Adapter(options) {
                 logger.warn(this.namespaceLog + ' Do not use parent or children for ' + id);
             }
 
-            this.objects.getObject(id, options, (err, _obj) => {
+            adapterObjects.getObject(id, options, (err, _obj) => {
                 if (!_obj) {
                     if (!obj.from) obj.from = 'system.adapter.' + this.namespace;
                     if (!obj.user) obj.user = (options ? options.user : '') || 'system.user.admin';
@@ -2825,12 +2844,12 @@ function Adapter(options) {
                 callback = options;
                 options = null;
             }
-            if (!this.objects) { // if objects is no longer existing, we do not need to unsubscribe
+            if (!adapterObjects) { // if objects is no longer existing, we do not need to unsubscribe
                 callback && callback('Objects database not connected');
                 return;
             }
 
-            this.objects.getObject(id, options, (err, _obj) => {
+            adapterObjects.getObject(id, options, (err, _obj) => {
                 if (!_obj) {
                     if (!obj.from) obj.from = 'system.adapter.' + this.namespace;
                     if (!obj.user) obj.user = (options ? options.user : '') || 'system.user.admin';
@@ -3090,7 +3109,7 @@ function Adapter(options) {
                 callback = options;
                 options = null;
             }
-            if (!this.objects) { // if objects is no longer existing, we do not need to unsubscribe
+            if (!adapterObjects) { // if objects is no longer existing, we do not need to unsubscribe
                 callback && callback('Objects database not connected');
                 return;
             }
@@ -3098,7 +3117,7 @@ function Adapter(options) {
             deviceName = deviceName.replace(FORBIDDEN_CHARS, '_').replace(/\./g, '_');
             if (!this._namespaceRegExp.test(deviceName)) deviceName = this.namespace + '.' + deviceName;
 
-            this.objects.getObjectView('system', 'device', {startkey: deviceName, endkey: deviceName}, options, (err, res) => {
+            adapterObjects.getObjectView('system', 'device', {startkey: deviceName, endkey: deviceName}, options, (err, res) => {
                 if (err || !res || !res.rows) {
                     typeof callback === 'function' && callback(err);
                     callback = null;
@@ -3122,7 +3141,7 @@ function Adapter(options) {
                             let _cnt = 0;
                             _cnt++;
                             // read channels of device
-                            this.objects.getObjectView('system', 'channel', {startkey: deviceName + '.', endkey: deviceName + '.\u9999'}, options, (err, res) => {
+                            adapterObjects.getObjectView('system', 'channel', {startkey: deviceName + '.', endkey: deviceName + '.\u9999'}, options, (err, res) => {
                                 _cnt--;
                                 if (err) {
                                     typeof callback === 'function' && callback(err);
@@ -3150,7 +3169,7 @@ function Adapter(options) {
                             });
                             // read states of the device...
                             _cnt++;
-                            this.objects.getObjectView('system', 'state', {startkey: deviceName + '.', endkey: deviceName + '.\u9999'}, options, (err, res) => {
+                            adapterObjects.getObjectView('system', 'state', {startkey: deviceName + '.', endkey: deviceName + '.\u9999'}, options, (err, res) => {
                                 _cnt--;
                                 if (err) {
                                     typeof callback === 'function' && callback(err);
@@ -3195,7 +3214,7 @@ function Adapter(options) {
                 callback = options;
                 options = null;
             }
-            if (!this.objects) { // if objects is no longer existing, we do not need to unsubscribe
+            if (!adapterObjects) { // if objects is no longer existing, we do not need to unsubscribe
                 callback && callback('Objects database not connected');
                 return;
             }
@@ -3218,7 +3237,7 @@ function Adapter(options) {
             const objId = this.namespace + '.' + this._DCS2ID(parentDevice, channelName);
 
             if (addTo.match(/^enum\./)) {
-                this.objects.getObject(addTo, options, (err, obj) => {
+                adapterObjects.getObject(addTo, options, (err, obj) => {
                     if (err) {
                         typeof callback === 'function' && callback(err);
                     } else if (obj) {
@@ -3229,14 +3248,14 @@ function Adapter(options) {
                             obj.user = (options ? options.user : '') || 'system.user.admin';
                             obj.ts = Date.now();
 
-                            this.objects.setObject(obj._id, obj, options, callback);
+                            adapterObjects.setObject(obj._id, obj, options, callback);
                         }
                     }
                 });
             } else {
                 if (enumName.match(/^enum\./)) enumName = enumName.substring(5);
 
-                this.objects.getObject('enum.' + enumName + '.' + addTo, options, (err, obj) => {
+                adapterObjects.getObject('enum.' + enumName + '.' + addTo, options, (err, obj) => {
                     if (err) {
                         return typeof callback === 'function' && callback(err);
                     }
@@ -3250,13 +3269,13 @@ function Adapter(options) {
                             obj.user = (options ? options.user : '') || 'system.user.admin';
                             obj.ts = Date.now();
 
-                            this.objects.setObject(obj._id, obj, options, callback);
+                            adapterObjects.setObject(obj._id, obj, options, callback);
                         } else {
                             if (callback) callback();
                         }
                     } else {
                         // Create enum
-                        this.objects.setObject('enum.' + enumName + '.' + addTo, {
+                        adapterObjects.setObject('enum.' + enumName + '.' + addTo, {
                             common: {
                                 name: addTo,
                                 members: [objId]
@@ -3279,7 +3298,7 @@ function Adapter(options) {
                 callback = options;
                 options = null;
             }
-            if (!this.objects) { // if objects is no longer existing, we do not need to unsubscribe
+            if (!adapterObjects) { // if objects is no longer existing, we do not need to unsubscribe
                 callback && callback('Objects database not connected');
                 return;
             }
@@ -3308,7 +3327,7 @@ function Adapter(options) {
                 enumName = 'enum.';
             }
 
-            this.objects.getObjectView('system', 'enum', {startkey: enumName, endkey: enumName + '\u9999'}, options, (err, res) => {
+            adapterObjects.getObjectView('system', 'enum', {startkey: enumName, endkey: enumName + '\u9999'}, options, (err, res) => {
                 if (err) {
                     return typeof callback === 'function' && callback(err);
                 }
@@ -3316,7 +3335,7 @@ function Adapter(options) {
                     let count = 0;
                     for (let i = 0; i < res.rows.length; i++) {
                         count++;
-                        this.objects.getObject(res.rows[i].id, options, (err, obj) => {
+                        adapterObjects.getObject(res.rows[i].id, options, (err, obj) => {
                             if (err) {
                                 typeof callback === 'function' && callback(err);
                                 callback = null;
@@ -3330,7 +3349,7 @@ function Adapter(options) {
                                     obj.user = (options ? options.user : '') || 'system.user.admin';
                                     obj.ts = Date.now();
 
-                                    this.objects.setObject(obj._id, obj, options, err => {
+                                    adapterObjects.setObject(obj._id, obj, options, err => {
                                         if (!--count && callback) {
                                             callback(err);
                                         } else {
@@ -3373,7 +3392,7 @@ function Adapter(options) {
                 channelName  = parentDevice;
                 parentDevice = '';
             }
-            if (!this.objects) { // if objects is no longer existing, we do not need to unsubscribe
+            if (!adapterObjects) { // if objects is no longer existing, we do not need to unsubscribe
                 callback && callback('Objects database not connected');
                 return;
             }
@@ -3403,7 +3422,7 @@ function Adapter(options) {
 
             logger.info(this.namespaceLog + ' Delete channel ' + channelName);
 
-            this.objects.getObjectView('system', 'channel', {startkey: channelName, endkey: channelName}, options, (err, res) => {
+            adapterObjects.getObjectView('system', 'channel', {startkey: channelName, endkey: channelName}, options, (err, res) => {
                 if (err || !res || !res.rows) {
                     typeof callback === 'function' && callback(err);
                     callback = null;
@@ -3421,7 +3440,7 @@ function Adapter(options) {
                             return;
                         }
                         if (!--cnt) {
-                            this.objects.getObjectView('system', 'state', {startkey: channelName + '.', endkey: channelName + '.\u9999'}, options, (err, res) => {
+                            adapterObjects.getObjectView('system', 'state', {startkey: channelName + '.', endkey: channelName + '.\u9999'}, options, (err, res) => {
                                 if (err || !res || !res.rows) {
                                     typeof callback === 'function' && callback(err);
                                     callback = null;
@@ -3541,12 +3560,12 @@ function Adapter(options) {
                 callback = options;
                 options = null;
             }
-            if (!this.objects) { // if objects is no longer existing, we do not need to unsubscribe
+            if (!adapterObjects) { // if objects is no longer existing, we do not need to unsubscribe
                 callback && callback('Objects database not connected');
                 return;
             }
 
-            this.objects.getObjectView('system', 'device', {startkey: this.namespace + '.', endkey: this.namespace + '.\u9999'}, options, (err, obj) => {
+            adapterObjects.getObjectView('system', 'device', {startkey: this.namespace + '.', endkey: this.namespace + '.\u9999'}, options, (err, obj) => {
                 if (callback) {
                     if (obj.rows.length) {
                         const res = [];
@@ -3574,7 +3593,7 @@ function Adapter(options) {
                 callback = parentDevice;
                 parentDevice = null;
             }
-            if (!this.objects) { // if objects is no longer existing, we do not need to unsubscribe
+            if (!adapterObjects) { // if objects is no longer existing, we do not need to unsubscribe
                 callback && callback('Objects database not connected');
                 return;
             }
@@ -3587,7 +3606,7 @@ function Adapter(options) {
 
             parentDevice  = parentDevice.replace(FORBIDDEN_CHARS, '_').replace(/\./g, '_');
             parentDevice = this.namespace + (parentDevice ? ('.' + parentDevice) : '');
-            this.objects.getObjectView('system', 'channel', {startkey: parentDevice + '.', endkey: parentDevice + '.\u9999'}, options, (err, obj) => {
+            adapterObjects.getObjectView('system', 'channel', {startkey: parentDevice + '.', endkey: parentDevice + '.\u9999'}, options, (err, obj) => {
                 if (callback) {
                     if (obj.rows.length) {
                         const res = [];
@@ -3622,7 +3641,7 @@ function Adapter(options) {
                 callback = parentChannel;
                 parentChannel = null;
             }
-            if (!this.objects) { // if objects is no longer existing, we do not need to unsubscribe
+            if (!adapterObjects) { // if objects is no longer existing, we do not need to unsubscribe
                 callback && callback('Objects database not connected');
                 return;
             }
@@ -3651,14 +3670,14 @@ function Adapter(options) {
 
             const id = this.namespace + '.' + this._DCS2ID(parentDevice, parentChannel, true);
 
-            this.objects.getObjectView('system', 'state', {startkey: id, endkey: id + '\u9999'}, options, (err, obj) => {
+            adapterObjects.getObjectView('system', 'state', {startkey: id, endkey: id + '\u9999'}, options, (err, obj) => {
                 if (callback) {
                     const res = [];
                     if (obj.rows.length) {
                         let read = 0;
                         for (let i = 0; i < obj.rows.length; i++) {
                             read++;
-                            this.objects.getObject(obj.rows[i].id, (err, subObj) => {
+                            adapterObjects.getObject(obj.rows[i].id, (err, subObj) => {
                                 if (subObj) res.push(subObj);
 
                                 if (!--read) callback(null, res);
@@ -3680,7 +3699,7 @@ function Adapter(options) {
                 callback = options;
                 options = null;
             }
-            if (!this.objects) { // if objects is no longer existing, we do not need to unsubscribe
+            if (!adapterObjects) { // if objects is no longer existing, we do not need to unsubscribe
                 callback && callback('Objects database not connected');
                 return;
             }
@@ -3718,7 +3737,7 @@ function Adapter(options) {
             const objId = this._fixId({device: parentDevice, channel: parentChannel, state: stateName});
 
             if (addTo.match(/^enum\./)) {
-                this.objects.getObject(addTo, options, (err, obj) => {
+                adapterObjects.getObject(addTo, options, (err, obj) => {
                     if (!err && obj) {
                         const pos = obj.common.members.indexOf(objId);
                         if (pos === -1) {
@@ -3726,7 +3745,7 @@ function Adapter(options) {
                             obj.from = 'system.adapter.' + this.namespace;
                             obj.user = (options ? options.user : '') || 'system.user.admin';
                             obj.ts = Date.now();
-                            this.objects.setObject(obj._id, obj, options, callback);
+                            adapterObjects.setObject(obj._id, obj, options, callback);
                         } else if (callback) {
                             callback();
                         }
@@ -3737,7 +3756,7 @@ function Adapter(options) {
             } else {
                 if (enumName.match(/^enum\./)) enumName = enumName.substring(5);
 
-                this.objects.getObject('enum.' + enumName + '.' + addTo, options, (err, obj) => {
+                adapterObjects.getObject('enum.' + enumName + '.' + addTo, options, (err, obj) => {
                     if (!err && obj) {
                         const pos = obj.common.members.indexOf(objId);
                         if (pos === -1) {
@@ -3745,7 +3764,7 @@ function Adapter(options) {
                             obj.from = 'system.adapter.' + this.namespace;
                             obj.user = (options ? options.user : '') || 'system.user.admin';
                             obj.ts = Date.now();
-                            this.objects.setObject(obj._id, obj, callback);
+                            adapterObjects.setObject(obj._id, obj, callback);
                         } else if (callback) {
                             callback();
                         }
@@ -3755,7 +3774,7 @@ function Adapter(options) {
                         }
 
                         // Create enum
-                        this.objects.setObject('enum.' + enumName + '.' + addTo, {
+                        adapterObjects.setObject('enum.' + enumName + '.' + addTo, {
                             common: {
                                 name: addTo,
                                 members: [objId]
@@ -3778,7 +3797,7 @@ function Adapter(options) {
                 callback = options;
                 options = null;
             }
-            if (!this.objects) { // if objects is no longer existing, we do not need to unsubscribe
+            if (!adapterObjects) { // if objects is no longer existing, we do not need to unsubscribe
                 callback && callback('Objects database not connected');
                 return;
             }
@@ -3821,12 +3840,12 @@ function Adapter(options) {
                 enumName = 'enum.';
             }
 
-            this.objects.getObjectView('system', 'enum', {startkey: enumName, endkey: enumName + '\u9999'}, options,  (err, res) => {
+            adapterObjects.getObjectView('system', 'enum', {startkey: enumName, endkey: enumName + '\u9999'}, options,  (err, res) => {
                 if (!err && res) {
                     let count = 0;
                     for (let i = 0; i < res.rows.length; i++) {
                         count++;
-                        this.objects.getObject(res.rows[i].id, options, (err, obj) => {
+                        adapterObjects.getObject(res.rows[i].id, options, (err, obj) => {
                             if (err) {
                                 if (callback) {
                                     callback(err);
@@ -3841,7 +3860,7 @@ function Adapter(options) {
                                     obj.from = 'system.adapter.' + this.namespace;
                                     obj.user = (options ? options.user : '') || 'system.user.admin';
                                     obj.ts = Date.now();
-                                    this.objects.setObject(obj._id, obj, err => {
+                                    adapterObjects.setObject(obj._id, obj, err => {
                                         if (!--count && callback) {
                                             callback(err);
                                             callback = null;
@@ -3877,12 +3896,12 @@ function Adapter(options) {
                 callback = options;
                 options = null;
             }
-            if (!this.objects) { // if objects is no longer existing, we do not need to unsubscribe
+            if (!adapterObjects) { // if objects is no longer existing, we do not need to unsubscribe
                 callback && callback('Objects database not connected');
                 return;
             }
 
-            this.objects.chmodFile(_adapter, path, options, callback);
+            adapterObjects.chmodFile(_adapter, path, options, callback);
         };
         /**
          * Promise-version of Adapter.chmodFile
@@ -3933,12 +3952,12 @@ function Adapter(options) {
                 callback = options;
                 options = null;
             }
-            if (!this.objects) { // if objects is no longer existing, we do not need to unsubscribe
+            if (!adapterObjects) { // if objects is no longer existing, we do not need to unsubscribe
                 callback && callback('Objects database not connected');
                 return;
             }
 
-            this.objects.readDir(_adapter, path, options, callback);
+            adapterObjects.readDir(_adapter, path, options, callback);
         };
         /**
          * Promise-version of Adapter.readDir
@@ -3952,12 +3971,12 @@ function Adapter(options) {
                 callback = options;
                 options = null;
             }
-            if (!this.objects) { // if objects is no longer existing, we do not need to unsubscribe
+            if (!adapterObjects) { // if objects is no longer existing, we do not need to unsubscribe
                 callback && callback('Objects database not connected');
                 return;
             }
 
-            this.objects.unlink(_adapter, name, options, callback);
+            adapterObjects.unlink(_adapter, name, options, callback);
         };
         /**
          * Promise-version of Adapter.unlink
@@ -3973,12 +3992,12 @@ function Adapter(options) {
                 callback = options;
                 options = null;
             }
-            if (!this.objects) { // if objects is no longer existing, we do not need to unsubscribe
+            if (!adapterObjects) { // if objects is no longer existing, we do not need to unsubscribe
                 callback && callback('Objects database not connected');
                 return;
             }
 
-            this.objects.rename(_adapter, oldName, newName, options, callback);
+            adapterObjects.rename(_adapter, oldName, newName, options, callback);
         };
         /**
          * Promise-version of Adapter.rename
@@ -3991,12 +4010,12 @@ function Adapter(options) {
                 callback = options;
                 options = null;
             }
-            if (!this.objects) { // if objects is no longer existing, we do not need to unsubscribe
+            if (!adapterObjects) { // if objects is no longer existing, we do not need to unsubscribe
                 callback && callback('Objects database not connected');
                 return;
             }
 
-            this.objects.mkdir(_adapter, dirname, options, callback);
+            adapterObjects.mkdir(_adapter, dirname, options, callback);
         };
         /**
          * Promise-version of Adapter.mkdir
@@ -4034,12 +4053,12 @@ function Adapter(options) {
                 callback = options;
                 options = null;
             }
-            if (!this.objects) { // if objects is no longer existing, we do not need to unsubscribe
+            if (!adapterObjects) { // if objects is no longer existing, we do not need to unsubscribe
                 callback && callback('Objects database not connected');
                 return;
             }
 
-            this.objects.readFile(_adapter, filename, options, callback);
+            adapterObjects.readFile(_adapter, filename, options, callback);
         };
         /**
          * Promise-version of Adapter.readFile
@@ -4078,12 +4097,12 @@ function Adapter(options) {
                 callback = options;
                 options = null;
             }
-            if (!this.objects) { // if objects is no longer existing, we do not need to unsubscribe
+            if (!adapterObjects) { // if objects is no longer existing, we do not need to unsubscribe
                 callback && callback('Objects database not connected');
                 return;
             }
 
-            this.objects.writeFile(_adapter, filename, data, options, callback);
+            adapterObjects.writeFile(_adapter, filename, data, options, callback);
         };
         /**
          * Promise-version of Adapter.writeFile
@@ -4512,7 +4531,7 @@ function Adapter(options) {
 
             options.checked = true;
 
-            this.objects.getObject(ids, options, (err, obj) => {
+            adapterObjects.getObject(ids, options, (err, obj) => {
                 if (originalChecked !== undefined) {
                     options.checked = originalChecked;
                 } else {
@@ -4545,7 +4564,7 @@ function Adapter(options) {
                 // if no default history set
                 if (!this.defaultHistory) {
                     // read all adapters
-                    this.objects.getObjectView('system', 'instance', {startkey: '', endkey: '\u9999'}, (err, _obj) => {
+                    adapterObjects.getObjectView('system', 'instance', {startkey: '', endkey: '\u9999'}, (err, _obj) => {
                         if (_obj) {
                             for (let i = 0; i < _obj.rows.length; i++) {
                                 if (_obj.rows[i].value.common && _obj.rows[i].value.common.type === 'storage') {
@@ -4568,13 +4587,13 @@ function Adapter(options) {
     };
 
     const _setStateChangedHelper = (id, state, callback) => {
-        if (!this.objects) { // if objects is no longer existing, we do not need to unsubscribe
+        if (!adapterObjects) { // if objects is no longer existing, we do not need to unsubscribe
             callback && callback('Objects database not connected');
             return;
         }
 
         if (id.startsWith(ALIAS_STARTS_WITH)) {
-            this.objects.getObject(id, (err, obj) => {
+            adapterObjects.getObject(id, (err, obj) => {
                 if (obj && obj.common && obj.common.alias && obj.common.alias.id) {
                     _setStateChangedHelper(obj.common.alias.id, state, callback);
                 } else {
@@ -4619,7 +4638,7 @@ function Adapter(options) {
 
                     if (differ) {
                         this.outputCount++;
-                        this.states.setState(id, state, (/* err */) =>
+                        adapterStates.setState(id, state, (/* err */) =>
                             typeof callback === 'function' && callback(null, id, false));
                     } else {
                         typeof callback === 'function' && callback(null, id, true);
@@ -4650,7 +4669,7 @@ function Adapter(options) {
             namespace:  this.namespaceLog,
             connection: config.states,
             connected: (statesInstance) => {
-                this.states = statesInstance;
+                adapterStates = statesInstance;
                 logger.debug(this.namespaceLog + ' statesDB connected');
                 this.statesConnectedTime = Date.now();
 
@@ -4661,14 +4680,14 @@ function Adapter(options) {
 
                 if (!config.isInstall) {
                     // Subscribe for process exit signal
-                    this.states.subscribe('system.adapter.' + this.namespace + '.sigKill');
+                    adapterStates.subscribe('system.adapter.' + this.namespace + '.sigKill');
 
                     // Subscribe for loglevel
-                    this.states.subscribe('system.adapter.' + this.namespace + '.logLevel');
+                    adapterStates.subscribe('system.adapter.' + this.namespace + '.logLevel');
                 }
                 if (options.subscribable) {
-                    this.states.subscribe('system.adapter.' + this.namespace + '.subscribes');
-                    this.states.getState('system.adapter.' + this.namespace + '.subscribes', (err, state) => {
+                    adapterStates.subscribe('system.adapter.' + this.namespace + '.subscribes');
+                    adapterStates.getState('system.adapter.' + this.namespace + '.subscribes', (err, state) => {
                         if (!state || !state.val) {
                             this.patterns = {};
                         } else {
@@ -4729,7 +4748,7 @@ function Adapter(options) {
                         } else if (state.val && state.val !== currentLevel) {
                             logger.info(this.namespaceLog + ' Got invalid loglevel "' + state.val + '", ignoring');
                         }
-                        this.states && this.states.setState('system.adapter.' + this.namespace + '.logLevel', {
+                        adapterStates && adapterStates.setState('system.adapter.' + this.namespace + '.logLevel', {
                             val: currentLevel,
                             ack: true,
                             from: 'system.adapter.' + this.namespace
@@ -4903,7 +4922,7 @@ function Adapter(options) {
 
             if (!instanceName.match(/^system\.adapter\./)) instanceName = 'system.adapter.' + instanceName;
 
-            if (!this.states) { // if states is no longer existing, we do not need to unsubscribe
+            if (!adapterStates) { // if states is no longer existing, we do not need to unsubscribe
                 callback && callback('States database not connected');
                 return;
             }
@@ -4916,16 +4935,16 @@ function Adapter(options) {
 
             // If not specific instance
             if (!instanceName.match(/\.[0-9]+$/)) {
-                if (!this.objects) { // if objects is no longer existing, we do not need to unsubscribe
+                if (!adapterObjects) { // if objects is no longer existing, we do not need to unsubscribe
                     callback && callback('Objects database not connected');
                     return;
                 }
 
                 // Send to all instances of adapter
-                this.objects.getObjectView('system', 'instance', {startkey: instanceName + '.', endkey: instanceName + '.\u9999'}, (err, _obj) => {
+                adapterObjects.getObjectView('system', 'instance', {startkey: instanceName + '.', endkey: instanceName + '.\u9999'}, (err, _obj) => {
                     if (_obj) {
                         for (let i = 0; i < _obj.rows.length; i++) {
-                            this.states.pushMessage(_obj.rows[i].id, obj);
+                            adapterStates.pushMessage(_obj.rows[i].id, obj);
                         }
                     }
                 });
@@ -4935,7 +4954,7 @@ function Adapter(options) {
                         // force subscribe even no messagebox enabled
                         if (!this.common.messagebox && !this.mboxSubscribed) {
                             this.mboxSubscribed = true;
-                            this.states.subscribeMessage('system.adapter.' + this.namespace);
+                            adapterStates.subscribeMessage('system.adapter.' + this.namespace);
                         }
 
                         obj.callback = {
@@ -4959,7 +4978,7 @@ function Adapter(options) {
                     }
                 }
 
-                this.states.pushMessage(instanceName, obj);
+                adapterStates.pushMessage(instanceName, obj);
             }
         };
         /**
@@ -4993,7 +5012,7 @@ function Adapter(options) {
             }
             const obj = {command, message, from: 'system.adapter.' + this.namespace};
 
-            if (!this.states) { // if states is no longer existing, we do not need to unsubscribe
+            if (!adapterStates) { // if states is no longer existing, we do not need to unsubscribe
                 callback && callback('States database not connected');
                 return;
             }
@@ -5003,14 +5022,14 @@ function Adapter(options) {
             }
 
             if (!hostName) {
-                if (!this.objects) { // if objects is no longer existing, we do not need to unsubscribe
+                if (!adapterObjects) { // if objects is no longer existing, we do not need to unsubscribe
                     callback && callback('Objects database not connected');
                     return;
                 }
 
                 // Send to all hosts
-                this.objects.getObjectList({startkey: 'system.host.', endkey: 'system.host.' + '\u9999'}, null, (err, res) => {
-                    if (!this.states) { // if states is no longer existing, we do not need to unsubscribe
+                adapterObjects.getObjectList({startkey: 'system.host.', endkey: 'system.host.' + '\u9999'}, null, (err, res) => {
+                    if (!adapterStates) { // if states is no longer existing, we do not need to unsubscribe
                         return;
                     }
                     if (!err && res.rows.length) {
@@ -5018,7 +5037,7 @@ function Adapter(options) {
                             const parts = res.rows[i].id.split('.');
                             // ignore system.host.name.alive and so on
                             if (parts.length === 3) {
-                                this.states.pushMessage(res.rows[i].id, obj);
+                                adapterStates.pushMessage(res.rows[i].id, obj);
                             }
                         }
                     }
@@ -5029,7 +5048,7 @@ function Adapter(options) {
                         // force subscribe even no messagebox enabled
                         if (!this.common.messagebox && !this.mboxSubscribed) {
                             this.mboxSubscribed = true;
-                            this.states.subscribeMessage('system.adapter.' + this.namespace);
+                            adapterStates.subscribeMessage('system.adapter.' + this.namespace);
                         }
 
                         obj.callback = {
@@ -5049,7 +5068,7 @@ function Adapter(options) {
                     }
                 }
 
-                this.states.pushMessage(hostName, obj);
+                adapterStates.pushMessage(hostName, obj);
             }
         };
         /**
@@ -5107,7 +5126,7 @@ function Adapter(options) {
                 ack = undefined;
             }
 
-            if (!this.states) { // if states is no longer existing, we do not need to set
+            if (!adapterStates) { // if states is no longer existing, we do not need to set
                 callback && callback('States database not connected');
                 return;
             }
@@ -5138,7 +5157,7 @@ function Adapter(options) {
                                     } else {
                                         // write target state
                                         this.outputCount++;
-                                        this.states.setState(obj.common.alias.id, tools.formatAliasValue(obj && obj.common, targetObj && targetObj.common, state, logger, this.namespaceLog), callback);
+                                        adapterStates.setState(obj.common.alias.id, tools.formatAliasValue(obj && obj.common, targetObj && targetObj.common, state, logger, this.namespaceLog), callback);
                                     }
                                 });
                             } else {
@@ -5147,26 +5166,26 @@ function Adapter(options) {
                             }
                         } else {
                             this.outputCount++;
-                            this.states.setState(id, state, callback);
+                            adapterStates.setState(id, state, callback);
                         }
                     }
                 });
             } else {
                 if (id.startsWith(ALIAS_STARTS_WITH)) {
-                    if (!this.objects) { // if objects is no longer existing, we do not need to unsubscribe
+                    if (!adapterObjects) { // if objects is no longer existing, we do not need to unsubscribe
                         callback && callback('Objects database not connected');
                         return;
                     }
 
                     // write alias
                     // read alias id
-                    this.objects.getObject(id, options, (err, obj) => {
+                    adapterObjects.getObject(id, options, (err, obj) => {
                         if (obj && obj.common && obj.common.alias && obj.common.alias.id) {
                             // read object for formatting
-                            this.objects.getObject(obj.common.alias.id, options, (err, targetObj) => {
+                            adapterObjects.getObject(obj.common.alias.id, options, (err, targetObj) => {
                                 // write target state
                                 this.outputCount++;
-                                this.states.setState(obj.common.alias.id, tools.formatAliasValue(obj && obj.common, targetObj && targetObj.common, state, logger, this.namespaceLog), callback);
+                                adapterStates.setState(obj.common.alias.id, tools.formatAliasValue(obj && obj.common, targetObj && targetObj.common, state, logger, this.namespaceLog), callback);
                             });
                         } else {
                             logger.warn(this.namespaceLog + ' ' + (err || `Alias ${id} has no target 3`));
@@ -5175,7 +5194,7 @@ function Adapter(options) {
                     });
                 } else {
                     this.outputCount++;
-                    this.states.setState(id, state, callback);
+                    adapterStates.setState(id, state, callback);
                 }
             }
         };
@@ -5223,7 +5242,7 @@ function Adapter(options) {
                 ack = undefined;
             }
 
-            if (!this.states) { // if states is no longer existing, we do not need to unsubscribe
+            if (!adapterStates) { // if states is no longer existing, we do not need to unsubscribe
                 callback && callback('States database not connected');
                 return;
             }
@@ -5302,7 +5321,7 @@ function Adapter(options) {
                 ack = undefined;
             }
 
-            if (!this.states) { // if states is no longer existing, we do not need to unsubscribe
+            if (!adapterStates) { // if states is no longer existing, we do not need to unsubscribe
                 callback && callback('States database not connected');
                 return;
             }
@@ -5344,7 +5363,7 @@ function Adapter(options) {
                                         typeof callback === 'function' && callback(err);
                                     } else {
                                         this.outputCount++;
-                                        this.states.setState(obj.common.alias.id, tools.formatAliasValue(obj && obj.common, targetObj && targetObj.common, state, logger, this.namespaceLog), callback);
+                                        adapterStates.setState(obj.common.alias.id, tools.formatAliasValue(obj && obj.common, targetObj && targetObj.common, state, logger, this.namespaceLog), callback);
                                     }
                                 });
                             } else {
@@ -5353,25 +5372,25 @@ function Adapter(options) {
                             }
                         } else {
                             this.outputCount++;
-                            this.states.setState(id, state, callback);
+                            adapterStates.setState(id, state, callback);
                         }
                     }
                 });
             } else {
                 // write alias
                 if (id.startsWith(ALIAS_STARTS_WITH)) {
-                    if (!this.objects) { // if objects is no longer existing, we do not need to unsubscribe
+                    if (!adapterObjects) { // if objects is no longer existing, we do not need to unsubscribe
                         callback && callback('Objects database not connected');
                         return;
                     }
 
                     // read alias id
-                    this.objects.getObject(id, options, (err, obj) => {
+                    adapterObjects.getObject(id, options, (err, obj) => {
                         if (obj && obj.common && obj.common.alias && obj.common.alias.id) {
                             // read object for formatting
-                            this.objects.getObject(obj.common.alias.id, options, (err, targetObj) => {
+                            adapterObjects.getObject(obj.common.alias.id, options, (err, targetObj) => {
                                 this.outputCount++;
-                                this.states.setState(obj.common.alias.id, tools.formatAliasValue(obj && obj.common, targetObj && targetObj.common, state, logger, this.namespaceLog), callback);
+                                adapterStates.setState(obj.common.alias.id, tools.formatAliasValue(obj && obj.common, targetObj && targetObj.common, state, logger, this.namespaceLog), callback);
                             });
                         } else {
                             logger.warn(this.namespaceLog + ' ' + (err || `Alias ${id} has no target 5`));
@@ -5380,7 +5399,7 @@ function Adapter(options) {
                     });
                 } else {
                     this.outputCount++;
-                    this.states.setState(id, state, callback);
+                    adapterStates.setState(id, state, callback);
                 }
             }
         };
@@ -5437,7 +5456,7 @@ function Adapter(options) {
                 ack = undefined;
             }
 
-            if (!this.states) { // if states is no longer existing, we do not need to unsubscribe
+            if (!adapterStates) { // if states is no longer existing, we do not need to unsubscribe
                 callback && callback('States database not connected');
                 return;
             }
@@ -5505,11 +5524,11 @@ function Adapter(options) {
                 return;
             }
 
-            if (!this.states) { // if states is no longer existing, we do not need to unsubscribe
+            if (!adapterStates) { // if states is no longer existing, we do not need to unsubscribe
                 callback && callback('States database not connected');
                 return;
             }
-            if (!this.objects) { // if objects is no longer existing, we do not need to unsubscribe
+            if (!adapterObjects) { // if objects is no longer existing, we do not need to unsubscribe
                 callback && callback('Objects database not connected');
                 return;
             }
@@ -5522,16 +5541,16 @@ function Adapter(options) {
                         callback(err);
                     } else {
                         if (id.startsWith(ALIAS_STARTS_WITH)) {
-                            this.objects.getObject(id, options, (err, obj) => {
+                            adapterObjects.getObject(id, options, (err, obj) => {
                                 if (obj && obj.common && obj.common.alias && (obj.common.alias.id || obj.common.alias.val !== undefined)) {
                                     if (this.oStates && this.oStates[obj.common.alias.id]) {
-                                        this.objects.getObject(obj.common.alias.id, (err, sourceObj) => {
+                                        adapterObjects.getObject(obj.common.alias.id, (err, sourceObj) => {
                                             const state = JSON.parse(JSON.stringify(this.oStates[obj.common.alias.id]));
                                             callback(err, tools.formatAliasValue(sourceObj && sourceObj.common, obj.common, state, logger, this.namespaceLog));
                                         });
                                     } else {
-                                        this.objects.getObject(obj.common.alias.id, (err, sourceObj) => {
-                                            this.states.getState(obj.common.alias.id, (err, state) =>
+                                        adapterObjects.getObject(obj.common.alias.id, (err, sourceObj) => {
+                                            adapterStates.getState(obj.common.alias.id, (err, state) =>
                                                 callback(err, tools.formatAliasValue(sourceObj && sourceObj.common, obj.common, state, logger, this.namespaceLog)));
                                         });
                                     }
@@ -5544,21 +5563,21 @@ function Adapter(options) {
                             if (this.oStates && this.oStates[id]) {
                                 callback(null, this.oStates[id]);
                             } else {
-                                this.states.getState(id, callback);
+                                adapterStates.getState(id, callback);
                             }
                         }
                     }
                 });
             } else {
                 if (id.startsWith(ALIAS_STARTS_WITH)) {
-                    this.objects.getObject(id, options, (err, obj) => {
+                    adapterObjects.getObject(id, options, (err, obj) => {
                         if (obj && obj.common && obj.common.alias && (obj.common.alias.id || obj.common.alias.val !== undefined)) {
-                            this.objects.getObject(obj.common.alias.id, options, (err, sourceObj) => {
+                            adapterObjects.getObject(obj.common.alias.id, options, (err, sourceObj) => {
                                 if (this.oStates && this.oStates[obj.common.alias.id]) {
                                     const state = JSON.parse(JSON.stringify(this.oStates[obj.common.alias.id]));
                                     callback(err, tools.formatAliasValue(sourceObj && sourceObj.common, obj.common, state, logger, this.namespaceLog));
                                 } else {
-                                    this.states.getState(obj.common.alias.id, (err, state) =>
+                                    adapterStates.getState(obj.common.alias.id, (err, state) =>
                                         callback(err, tools.formatAliasValue(sourceObj && sourceObj.common, obj.common, state, logger, this.namespaceLog)));
                                 }
                             });
@@ -5571,7 +5590,7 @@ function Adapter(options) {
                     if (this.oStates && this.oStates[id]) {
                         callback(null, this.oStates[id]);
                     } else {
-                        this.states.getState(id, callback);
+                        adapterStates.getState(id, callback);
                     }
                 }
             }
@@ -5609,11 +5628,11 @@ function Adapter(options) {
                 return;
             }
 
-            if (!this.states) { // if states is no longer existing, we do not need to unsubscribe
+            if (!adapterStates) { // if states is no longer existing, we do not need to unsubscribe
                 callback && callback('States database not connected');
                 return;
             }
-            if (!this.objects) { // if objects is no longer existing, we do not need to unsubscribe
+            if (!adapterObjects) { // if objects is no longer existing, we do not need to unsubscribe
                 callback && callback('Objects database not connected');
                 return;
             }
@@ -5641,7 +5660,7 @@ function Adapter(options) {
                                                 callback(err);
                                             } else {
                                                 this.inputCount++;
-                                                this.states.getState(obj.common.alias.id, (err, state) =>
+                                                adapterStates.getState(obj.common.alias.id, (err, state) =>
                                                     callback(err, tools.formatAliasValue(sourceObj && sourceObj.common, obj.common, state, logger, this.namespaceLog)));
                                             }
                                         });
@@ -5654,16 +5673,16 @@ function Adapter(options) {
                             if (this.oStates && this.oStates[id]) {
                                 callback(null, this.oStates[id]);
                             } else {
-                                this.states.getState(id, callback);
+                                adapterStates.getState(id, callback);
                             }
                         }
                     }
                 });
             } else {
                 if (id.startsWith(ALIAS_STARTS_WITH)) {
-                    this.objects.getObject(id, (err, obj) => {
+                    adapterObjects.getObject(id, (err, obj) => {
                         if (obj && obj.common && obj.common.alias && (obj.common.alias.id || obj.common.alias.val !== undefined)) {
-                            this.objects.getObject(obj.common.alias.id, (err, sourceObj) => {
+                            adapterObjects.getObject(obj.common.alias.id, (err, sourceObj) => {
                                 if (err) {
                                     return callback(err);
                                 }
@@ -5672,7 +5691,7 @@ function Adapter(options) {
                                     callback(err, tools.formatAliasValue(sourceObj && sourceObj.common, obj.common, state, logger, this.namespaceLog));
                                 } else {
                                     this.inputCount++;
-                                    this.states.getState(obj.common.alias.id, (err, state) =>
+                                    adapterStates.getState(obj.common.alias.id, (err, state) =>
                                         callback(err, tools.formatAliasValue(sourceObj && sourceObj.common, obj.common, state, logger, this.namespaceLog)));
                                 }
                             });
@@ -5686,7 +5705,7 @@ function Adapter(options) {
                         callback(null, this.oStates[id]);
                     } else {
                         this.inputCount++;
-                        this.states.getState(id, callback);
+                        adapterStates.getState(id, callback);
                     }
                 }
             }
@@ -5832,7 +5851,7 @@ function Adapter(options) {
                 options = null;
             }
 
-            if (!this.states) { // if states is no longer existing, we do not need to unsubscribe
+            if (!adapterStates) { // if states is no longer existing, we do not need to unsubscribe
                 callback && callback('States database not connected');
                 return;
             }
@@ -5842,11 +5861,11 @@ function Adapter(options) {
                     if (err) {
                         typeof callback === 'function' && callback(err);
                     } else {
-                        this.states.delState(id, callback);
+                        adapterStates.delState(id, callback);
                     }
                 });
             } else {
-                this.states.delState(id, callback);
+                adapterStates.delState(id, callback);
             }
         };
         /**
@@ -5886,7 +5905,7 @@ function Adapter(options) {
         this.getStatesAsync = tools.promisify(this.getStates, this);
 
         this._processStatesSecondary = function (keys, targetObjs, srcObjs, callback) {
-            this.states.getStates(keys, (err, arr) => {
+            adapterStates.getStates(keys, (err, arr) => {
                 if (err) {
                     return callback(err);
                 }
@@ -5988,11 +6007,11 @@ function Adapter(options) {
                 return logger.error(this.namespaceLog + ' getForeignStates invalid callback for ' + pattern);
             }
 
-            if (!this.states) { // if states is no longer existing, we do not need to unsubscribe
+            if (!adapterStates) { // if states is no longer existing, we do not need to unsubscribe
                 return callback && callback('States database not connected');
             }
 
-            if (!this.objects) { // if states is no longer existing, we do not need to unsubscribe
+            if (!adapterObjects) { // if states is no longer existing, we do not need to unsubscribe
                 return callback && callback('Objects database not connected');
             }
 
@@ -6029,7 +6048,7 @@ function Adapter(options) {
                 }
                 options.checked = true;
 
-                this.objects.getObjectView('system', 'state', params, options, (err, res) => {
+                adapterObjects.getObjectView('system', 'state', params, options, (err, res) => {
                     if (originalChecked !== undefined) {
                         options.checked = originalChecked;
                     } else {
@@ -6081,8 +6100,8 @@ function Adapter(options) {
                 this.aliases[sourceId].targets.push(targetEntry);
 
                 if (!this.aliases[sourceId].source) {
-                    this.states.subscribe(sourceId, () =>
-                        this.objects.getObject(sourceId, options, (err, sourceObj) => {
+                    adapterStates.subscribe(sourceId, () =>
+                        adapterObjects.getObject(sourceId, options, (err, sourceObj) => {
                             if (sourceObj && sourceObj.common) {
                                 this.aliases[sourceObj._id].source = {};
                                 this.aliases[sourceObj._id].source.min = sourceObj.common.min;
@@ -6119,7 +6138,7 @@ function Adapter(options) {
                 // unsubscribe if no more aliases exists
                 if (!this.aliases[sourceId].targets.length) {
                     delete this.aliases[sourceId];
-                    return this.states.unsubscribe(sourceId, callback);
+                    return adapterStates.unsubscribe(sourceId, callback);
                 }
             }
             return callback && setImmediate(() => callback());
@@ -6146,18 +6165,18 @@ function Adapter(options) {
                 options = null;
             }
 
-            if (!this.states) { // if states is no longer existing, we do not need to unsubscribe
+            if (!adapterStates) { // if states is no longer existing, we do not need to unsubscribe
                 callback && callback('States database not connected');
                 return;
             }
 
             // Todo check rights for options
             autoSubscribeOn(() => {
-                if (!this.states) { // if states is no longer existing, we do not need to unsubscribe
+                if (!adapterStates) { // if states is no longer existing, we do not need to unsubscribe
                     callback && callback('States database not connected');
                     return;
                 }
-                if (!this.objects) { // if objects is no longer existing, we do not need to unsubscribe
+                if (!adapterObjects) { // if objects is no longer existing, we do not need to unsubscribe
                     callback && callback('Objects database not connected');
                     return;
                 }
@@ -6166,7 +6185,7 @@ function Adapter(options) {
                 for (let s = 0; s < this.autoSubscribe.length; s++) {
                     if (pattern === '*' || pattern.substring(0, this.autoSubscribe[s].length + 1) === this.autoSubscribe[s] + '.') {
                         // put this pattern into adapter list
-                        this.states.getState('system.adapter.' + this.autoSubscribe[s] + '.subscribes', (err, state) => {
+                        adapterStates.getState('system.adapter.' + this.autoSubscribe[s] + '.subscribes', (err, state) => {
                             state = {};
                             state.val = state.val || '{}';
                             let subs;
@@ -6179,7 +6198,7 @@ function Adapter(options) {
                             subs[pattern][this.namespace] = subs[pattern][this.namespace] || 0;
                             subs[pattern][this.namespace]++;
                             this.outputCount++;
-                            this.states.setState('system.adapter.' + this.autoSubscribe[s] + '.subscribes', subs);
+                            adapterStates.setState('system.adapter.' + this.autoSubscribe[s] + '.subscribes', subs);
                         });
                     }
                 }
@@ -6205,7 +6224,7 @@ function Adapter(options) {
                     if (aliasesIds.length) {
                         if (!this._aliasObjectsSubscribed) {
                             this._aliasObjectsSubscribed = true;
-                            this.objects.subscribe(ALIAS_STARTS_WITH + '*');
+                            adapterObjects.subscribe(ALIAS_STARTS_WITH + '*');
                         }
 
                         this._getObjectsByArray(aliasesIds, null, options, (errors, aliasObjs) =>
@@ -6216,7 +6235,7 @@ function Adapter(options) {
 
                     if (nonAliasesIds.length) {
                         nonAliasesIds.forEach(id => {
-                            this.states.subscribeUser(id, () =>
+                            adapterStates.subscribeUser(id, () =>
                                 !--count && typeof callback === 'function' && callback());
                         });
                     }
@@ -6224,7 +6243,7 @@ function Adapter(options) {
                     if (typeof pattern === 'string' && (pattern === '*' || pattern.startsWith(ALIAS_STARTS_WITH)) || pattern instanceof RegExp) {
                         if (!this._aliasObjectsSubscribed) {
                             this._aliasObjectsSubscribed = true;
-                            this.objects.subscribe(ALIAS_STARTS_WITH + '*');
+                            adapterObjects.subscribe(ALIAS_STARTS_WITH + '*');
                         }
 
                         // read all aliases
@@ -6241,7 +6260,7 @@ function Adapter(options) {
                                     this._addAliasSubscribe(aliasObj, aliasPattern, () => {
                                         if (!--count) {
                                             if (pattern === '*') {
-                                                this.states.subscribeUser(pattern, callback);
+                                                adapterStates.subscribeUser(pattern, callback);
                                             } else {
                                                 callback && callback();
                                             }
@@ -6252,16 +6271,16 @@ function Adapter(options) {
 
                             // no alias objects found
                             if (!count) {
-                                this.states.subscribeUser(pattern, callback);
+                                adapterStates.subscribeUser(pattern, callback);
                             }
                         });
                     } else {
-                        this.states.subscribeUser(pattern, callback);
+                        adapterStates.subscribeUser(pattern, callback);
                     }
                 } else if (typeof pattern === 'string' && pattern.startsWith(ALIAS_STARTS_WITH)) {
                     if (!this._aliasObjectsSubscribed) {
                         this._aliasObjectsSubscribed = true;
-                        this.objects.subscribe(ALIAS_STARTS_WITH + '*');
+                        adapterObjects.subscribe(ALIAS_STARTS_WITH + '*');
                     }
 
                     // aliases['sourceId'] = {
@@ -6280,12 +6299,12 @@ function Adapter(options) {
 
 
                     // just read one alias Object
-                    this.objects.getObject(pattern, options, (err, aliasObj) => {
+                    adapterObjects.getObject(pattern, options, (err, aliasObj) => {
                         err && logger.warn(`${this.namespaceLog} cannot read ${pattern}: ${err}`);
                         aliasObj && this._addAliasSubscribe(aliasObj, pattern, callback);
                     });
                 } else {
-                    this.states.subscribeUser(pattern, callback);
+                    adapterStates.subscribeUser(pattern, callback);
                 }
             });
         };
@@ -6314,7 +6333,7 @@ function Adapter(options) {
         this.unsubscribeForeignStates = (pattern, options, callback) => {
             pattern = pattern || '*';
 
-            if (!this.states) { // if states is no longer existing, we do not need to unsubscribe
+            if (!adapterStates) { // if states is no longer existing, we do not need to unsubscribe
                 return typeof callback === 'function' && callback('States database not connected');
             }
 
@@ -6328,7 +6347,7 @@ function Adapter(options) {
                 for (let s = 0; s < this.autoSubscribe.length; s++) {
                     if (pattern === '*' || pattern.substring(0, this.autoSubscribe[s].length + 1) === this.autoSubscribe[s] + '.') {
                         // remove this pattern from adapter list
-                        this.states.getState('system.adapter.' + this.autoSubscribe[s] + '.subscribes', (err, state) => {
+                        adapterStates.getState('system.adapter.' + this.autoSubscribe[s] + '.subscribes', (err, state) => {
                             if (!state || !state.val) return;
                             let subs;
                             try {
@@ -6351,7 +6370,7 @@ function Adapter(options) {
                             }
                             if (!found) delete subs[pattern];
                             this.outputCount++;
-                            this.states.setState('system.adapter.' + this.autoSubscribe[s] + '.subscribes', subs);
+                            adapterStates.setState('system.adapter.' + this.autoSubscribe[s] + '.subscribes', subs);
                         });
                     }
                 }
@@ -6370,7 +6389,7 @@ function Adapter(options) {
                 aliasPattern = JSON.stringify(pattern); // check all aliases
 
                 count++;
-                this.states.unsubscribeUser(pattern, () =>
+                adapterStates.unsubscribeUser(pattern, () =>
                     !--count && typeof callback === 'function' && callback());
 
             } else if (typeof pattern === 'string' && (pattern.includes('*') || pattern.startsWith(ALIAS_STARTS_WITH))) {
@@ -6378,17 +6397,17 @@ function Adapter(options) {
                     aliasPattern = pattern; // check all aliases
                     if (pattern === '*') {
                         count++;
-                        this.states.unsubscribeUser(pattern, () =>
+                        adapterStates.unsubscribeUser(pattern, () =>
                             !--count && typeof callback === 'function' && callback());
                     }
                 } else {
                     count++;
-                    this.states.unsubscribeUser(pattern, () =>
+                    adapterStates.unsubscribeUser(pattern, () =>
                         !--count && typeof callback === 'function' && callback());
                 }
             } else {
                 count++;
-                this.states.unsubscribeUser(pattern, () =>
+                adapterStates.unsubscribeUser(pattern, () =>
                     !--count && typeof callback === 'function' && callback());
             }
 
@@ -6403,7 +6422,7 @@ function Adapter(options) {
                                     if (!Object.keys(this.aliases).length) {
                                         if (this._aliasObjectsSubscribed) {
                                             this._aliasObjectsSubscribed = false;
-                                            this.objects.unsubscribe(ALIAS_STARTS_WITH + '*');
+                                            adapterObjects.unsubscribe(ALIAS_STARTS_WITH + '*');
                                         }
                                     }
                                     typeof callback === 'function' && callback();
@@ -6442,17 +6461,17 @@ function Adapter(options) {
                 options = null;
             }
 
-            if (!this.states) { // if states is no longer existing, we do not need to unsubscribe
+            if (!adapterStates) { // if states is no longer existing, we do not need to unsubscribe
                 callback && callback('States database not connected');
                 return;
             }
 
             // Exception. Threat the '*' case automatically
             if (!pattern || pattern === '*') {
-                this.states.subscribeUser(this.namespace + '.*', callback);
+                adapterStates.subscribeUser(this.namespace + '.*', callback);
             } else {
                 pattern = this._fixId(pattern, true);
-                this.states.subscribeUser(pattern, callback);
+                adapterStates.subscribeUser(pattern, callback);
             }
         };
         /**
@@ -6478,7 +6497,7 @@ function Adapter(options) {
          * @param {function} callback return result function (err) {}
          */
         this.unsubscribeStates = (pattern, options, callback) => {
-            if (!this.states) { // if states is no longer existing, we do not need to unsubscribe
+            if (!adapterStates) { // if states is no longer existing, we do not need to unsubscribe
                 callback && callback('States database not connected');
                 return;
             }
@@ -6489,10 +6508,10 @@ function Adapter(options) {
             }
 
             if (!pattern || pattern === '*') {
-                this.states.unsubscribeUser(this.namespace + '.*', callback);
+                adapterStates.unsubscribeUser(this.namespace + '.*', callback);
             } else {
                 pattern = this._fixId(pattern, true);
-                this.states.unsubscribeUser(pattern, callback);
+                adapterStates.unsubscribeUser(pattern, callback);
             }
         };
         /**
@@ -6501,84 +6520,84 @@ function Adapter(options) {
         this.unsubscribeStatesAsync = tools.promisify(this.unsubscribeStates, this);
 
         this.pushFifo = (id, state, callback) => {
-            if (!this.states) { // if states is no longer existing, we do not need to unsubscribe
+            if (!adapterStates) { // if states is no longer existing, we do not need to unsubscribe
                 callback && callback('States database not connected');
                 return;
             }
 
-            this.states.pushFifo(id, state, callback);
+            adapterStates.pushFifo(id, state, callback);
         };
 
         this.trimFifo = (id, start, end, callback) => {
-            if (!this.states) { // if states is no longer existing, we do not need to unsubscribe
+            if (!adapterStates) { // if states is no longer existing, we do not need to unsubscribe
                 callback && callback('States database not connected');
                 return;
             }
 
-            this.states.trimFifo(id, start, end, callback);
+            adapterStates.trimFifo(id, start, end, callback);
         };
 
         this.getFifoRange = (id, start, end, callback) => {
-            if (!this.states) { // if states is no longer existing, we do not need to unsubscribe
+            if (!adapterStates) { // if states is no longer existing, we do not need to unsubscribe
                 callback && callback('States database not connected');
                 return;
             }
 
-            this.states.getFifoRange(id, start, end, callback);
+            adapterStates.getFifoRange(id, start, end, callback);
         };
 
         this.getFifo = (id, callback) => {
-            if (!this.states) { // if states is no longer existing, we do not need to unsubscribe
+            if (!adapterStates) { // if states is no longer existing, we do not need to unsubscribe
                 callback && callback('States database not connected');
                 return;
             }
 
-            this.states.getFifo(id, callback);
+            adapterStates.getFifo(id, callback);
         };
 
         this.lenFifo = (id, callback) => {
-            if (!this.states) { // if states is no longer existing, we do not need to unsubscribe
+            if (!adapterStates) { // if states is no longer existing, we do not need to unsubscribe
                 callback && callback('States database not connected');
                 return;
             }
 
-            this.states.lenFifo(id, callback);
+            adapterStates.lenFifo(id, callback);
         };
 
         this.subscribeFifo = (pattern) => {
-            if (!this.states) { // if states is no longer existing, we do not need to unsubscribe
+            if (!adapterStates) { // if states is no longer existing, we do not need to unsubscribe
                 callback && callback('States database not connected');
                 return;
             }
 
-            this.states.subscribeFifo(pattern);
+            adapterStates.subscribeFifo(pattern);
         };
 
         this.getSession = (id, callback) => {
-            if (!this.states) { // if states is no longer existing, we do not need to unsubscribe
+            if (!adapterStates) { // if states is no longer existing, we do not need to unsubscribe
                 callback && callback('States database not connected');
                 return;
             }
 
-            this.states.getSession(id, callback);
+            adapterStates.getSession(id, callback);
         };
 
         this.setSession = (id, ttl, data, callback) => {
-            if (!this.states) { // if states is no longer existing, we do not need to unsubscribe
+            if (!adapterStates) { // if states is no longer existing, we do not need to unsubscribe
                 callback && callback('States database not connected');
                 return;
             }
 
-            this.states.setSession(id, ttl, data, callback);
+            adapterStates.setSession(id, ttl, data, callback);
         };
 
         this.destroySession = (id, callback) => {
-            if (!this.states) { // if states is no longer existing, we do not need to unsubscribe
+            if (!adapterStates) { // if states is no longer existing, we do not need to unsubscribe
                 callback && callback('States database not connected');
                 return;
             }
 
-            this.states.destroySession(id, callback);
+            adapterStates.destroySession(id, callback);
         };
 
         /**
@@ -6599,7 +6618,7 @@ function Adapter(options) {
                 options = {};
             }
 
-            if (!this.states) { // if states is no longer existing, we do not need to unsubscribe
+            if (!adapterStates) { // if states is no longer existing, we do not need to unsubscribe
                 callback && callback('States database not connected');
                 return;
             }
@@ -6609,11 +6628,11 @@ function Adapter(options) {
                     if (err) {
                         typeof callback === 'function' && callback(err);
                     } else {
-                        this.states.setBinaryState(id, binary, callback);
+                        adapterStates.setBinaryState(id, binary, callback);
                     }
                 });
             } else {
-                this.states.setBinaryState(id, binary, callback);
+                adapterStates.setBinaryState(id, binary, callback);
             }
         };
         /**
@@ -6636,7 +6655,7 @@ function Adapter(options) {
                 options = {};
             }
 
-            if (!this.states) { // if states is no longer existing, we do not need to unsubscribe
+            if (!adapterStates) { // if states is no longer existing, we do not need to unsubscribe
                 callback && callback('States database not connected');
                 return;
             }
@@ -6646,11 +6665,11 @@ function Adapter(options) {
                     if (err) {
                         typeof callback === 'function' && callback(err);
                     } else {
-                        this.states.getBinaryState(id, callback);
+                        adapterStates.getBinaryState(id, callback);
                     }
                 });
             } else {
-                this.states.getBinaryState(id, callback);
+                adapterStates.getBinaryState(id, callback);
             }
         };
         /**
@@ -6679,7 +6698,7 @@ function Adapter(options) {
                 options = {};
             }
 
-            if (!this.states) { // if states is no longer existing, we do not need to unsubscribe
+            if (!adapterStates) { // if states is no longer existing, we do not need to unsubscribe
                 callback && callback('States database not connected');
                 return;
             }
@@ -6689,11 +6708,11 @@ function Adapter(options) {
                     if (err) {
                         typeof callback === 'function' && callback(err);
                     } else {
-                        this.states.delBinaryState(id, callback);
+                        adapterStates.delBinaryState(id, callback);
                     }
                 });
             } else {
-                this.states.delBinaryState(id, callback);
+                adapterStates.delBinaryState(id, callback);
             }
         };
 
@@ -6721,13 +6740,13 @@ function Adapter(options) {
 
     // read all logs prepared for this adapter at start
     const readLogs = (callback) => {
-        if (!this.states) { // if states is no longer existing, we do not need to unsubscribe
+        if (!adapterStates) { // if states is no longer existing, we do not need to unsubscribe
             callback && callback('States database not connected');
             return;
         }
 
         // read all stored messages
-        this.states.getLog('system.adapter.' + this.namespace, (err, msg) => {
+        adapterStates.getLog('system.adapter.' + this.namespace, (err, msg) => {
             if (msg) {
                 this.emit('log', msg);
                 setImmediate(() => readLogs(callback));
@@ -6744,9 +6763,9 @@ function Adapter(options) {
         logs.push('Actual Loglist - ' + JSON.stringify(this.logList));
 
         // Read current state of all log subscribers
-        this.states.getKeys('*.logging', (err, keys) => {
+        adapterStates.getKeys('*.logging', (err, keys) => {
             if (keys && keys.length) {
-                this.states.getStates(keys, (err, obj) => {
+                adapterStates.getStates(keys, (err, obj) => {
                     if (obj) {
                         for (let i = 0; i < keys.length; i++) {
                             // We can JSON.parse, but index is 16x faster
@@ -6780,9 +6799,9 @@ function Adapter(options) {
         // temporary log buffer
         let messages = [];
         // Read current state of all log subscriber
-        this.states.getKeys('*.logging', (err, keys) => {
+        adapterStates.getKeys('*.logging', (err, keys) => {
             if (keys && keys.length) {
-                this.states.getStates(keys, (err, obj) => {
+                adapterStates.getStates(keys, (err, obj) => {
                     if (obj) {
                         for (let i = 0; i < keys.length; i++) {
                             // We can JSON.parse, but index is 16x faster
@@ -6794,10 +6813,10 @@ function Adapter(options) {
                                 this.logRedirect(true, id);
                             }
                         }
-                        if (this.logList.length && messages && messages.length && this.states && this.states.pushLog) {
+                        if (this.logList.length && messages && messages.length && adapterStates && adapterStates.pushLog) {
                             for (let m = 0; m < messages.length; m++) {
                                 for (let k = 0; k < this.logList.length; k++) {
-                                    this.states.pushLog(this.logList[k], messages[m]);
+                                    adapterStates.pushLog(this.logList[k], messages[m]);
                                 }
                             }
                         }
@@ -6850,10 +6869,10 @@ function Adapter(options) {
                         messages.splice(0, messages.length - config.states.maxQueue);
                     }
                 }
-            } else if (this.states && this.states.pushLog) {
+            } else if (adapterStates && adapterStates.pushLog) {
                 // Send to all adapter, that required logs
                 for (let i = 0; i < this.logList.length; i++) {
-                    this.states.pushLog(this.logList[i], info);
+                    adapterStates.pushLog(this.logList[i], info);
                 }
             }
         });
@@ -6862,7 +6881,7 @@ function Adapter(options) {
 
         if (options.logTransporter) {
             this.requireLog = (isActive) => {
-                if (this.states) {
+                if (adapterStates) {
                     if (this.logRequired !== isActive) {
                         this.logRequired = isActive; // remember state
                         if (!isActive) {
@@ -6874,7 +6893,7 @@ function Adapter(options) {
                                 this.logOffTimer = null;
                                 logger.debug(this.namespaceLog + ' Change log subscriber state: FALSE');
                                 this.outputCount++;
-                                this.states.setState('system.adapter.' + this.namespace + '.logging', {val: false, ack: true, from: 'system.adapter.' + this.namespace});
+                                adapterStates.setState('system.adapter.' + this.namespace + '.logging', {val: false, ack: true, from: 'system.adapter.' + this.namespace});
                             }, 10000);
                         } else {
                             if (this.logOffTimer) {
@@ -6883,7 +6902,7 @@ function Adapter(options) {
                             } else {
                                 logger.debug(this.namespaceLog + ' Change log subscriber state: true');
                                 this.outputCount++;
-                                this.states.setState('system.adapter.' + this.namespace + '.logging', {val: true, ack: true, from: 'system.adapter.' + this.namespace});
+                                adapterStates.setState('system.adapter.' + this.namespace + '.logging', {val: true, ack: true, from: 'system.adapter.' + this.namespace});
                             }
                         }
                     }
@@ -6894,12 +6913,12 @@ function Adapter(options) {
                 msg && this.emit('log', msg);
 
                 // BF (2019_10_09): this is not required anyMore
-                this.states && this.states.delLog && this.states.delLog('system.adapter.' + this.namespace, msg._id);
+                adapterStates && adapterStates.delLog && adapterStates.delLog('system.adapter.' + this.namespace, msg._id);
             };
 
             readLogs();
 
-            this.states.subscribeLog('system.adapter.' + this.namespace);
+            adapterStates.subscribeLog('system.adapter.' + this.namespace);
         } else {
             this.requireLog = (_isActive) => {
                 logger.warn(this.namespaceLog + ' requireLog is not supported by this adapter! Please set common.logTransporter to true');
@@ -6920,9 +6939,9 @@ function Adapter(options) {
                     if (!config.isInstall && (!process.argv || !config.forceIfDisabled)) {
                         const id = 'system.adapter.' + this.namespace;
                         this.outputCount += 2;
-                        this.states.setState(id + '.alive', {val: true, ack: true, expire: 30, from: id});
+                        adapterStates.setState(id + '.alive', {val: true, ack: true, expire: 30, from: id});
                         let done = false;
-                        this.states.setState(id + '.connected', {val: true, ack: true, expire: 30, from: id}, () => {
+                        adapterStates.setState(id + '.connected', {val: true, ack: true, expire: 30, from: id}, () => {
                             if (!done) {
                                 done = true;
                                 this.terminate(EXIT_CODES.NO_ADAPTER_CONFIG_FOUND);
@@ -6994,13 +7013,13 @@ function Adapter(options) {
                 }
 
                 // Monitor logging state
-                this.states.subscribe('*.logging');
+                adapterStates.subscribe('*.logging');
 
                 if (typeof options.message === 'function' && !adapterConfig.common.messagebox) {
                     logger.error(this.namespaceLog + ' : message handler implemented, but messagebox not enabled. Define common.messagebox in io-package.json for adapter or delete message handler.');
                 } else if (/*typeof options.message === 'function' && */adapterConfig.common.messagebox) {
                     this.mboxSubscribed = true;
-                    this.states.subscribeMessage('system.adapter.' + this.namespace);
+                    adapterStates.subscribeMessage('system.adapter.' + this.namespace);
                 }
             } else {
                 this.name = adapterConfig.name || options.name;
@@ -7052,7 +7071,7 @@ function Adapter(options) {
             this.log = new Log(this, config.log.level);
 
             // set current loglevel
-            this.states.setState('system.adapter.' + this.namespace + '.logLevel', {val: config.log.level, ack: true, from: 'system.adapter.' + this.namespace});
+            adapterStates.setState('system.adapter.' + this.namespace + '.logLevel', {val: config.log.level, ack: true, from: 'system.adapter.' + this.namespace});
 
             if (options.instance === undefined) {
                 this.version = (this.pack && this.pack.version) ? this.pack.version : ((this.ioPack && this.ioPack.common) ? this.ioPack.common.version : 'unknown');
@@ -7064,15 +7083,15 @@ function Adapter(options) {
                     reportInterval = setInterval(reportStatus, config.system.statisticsInterval);
                     reportStatus();
                     const id = 'system.adapter.' + this.namespace;
-                    this.states.setState(id + '.compactMode', {ack: true, from: id, val: !!this.startedInCompactMode});
+                    adapterStates.setState(id + '.compactMode', {ack: true, from: id, val: !!this.startedInCompactMode});
                     this.outputCount++;
                     if (this.startedInCompactMode) {
-                        this.states.setState(id + '.cpu', {ack: true, from: id, val: 0});
-                        this.states.setState(id + '.cputime', {ack: true, from: id, val: 0});
-                        this.states.setState(id + '.memRss', {val: 0, ack: true, from: id});
-                        this.states.setState(id + '.memHeapTotal', {val: 0, ack: true, from: id});
-                        this.states.setState(id + '.memHeapUsed', {val: 0, ack: true, from: id});
-                        this.states.setState(id + '.eventLoopLag', {val: 0, ack: true, from: id});
+                        adapterStates.setState(id + '.cpu', {ack: true, from: id, val: 0});
+                        adapterStates.setState(id + '.cputime', {ack: true, from: id, val: 0});
+                        adapterStates.setState(id + '.memRss', {val: 0, ack: true, from: id});
+                        adapterStates.setState(id + '.memHeapTotal', {val: 0, ack: true, from: id});
+                        adapterStates.setState(id + '.memHeapUsed', {val: 0, ack: true, from: id});
+                        adapterStates.setState(id + '.eventLoopLag', {val: 0, ack: true, from: id});
                         this.outputCount += 6;
                     } else {
                         tools.measureEventLoopLag(1000, lag => this.eventLoopLags.push(lag));
@@ -7116,17 +7135,17 @@ function Adapter(options) {
                 this.adapterReady = true;
 
                 // todo remove it later, when the error is fixed
-                this.states.subscribe(this.namespace + '.checkLogging');
+                adapterStates.subscribe(this.namespace + '.checkLogging');
             }
         });
     };
 
     const reportStatus = () => {
         const id = 'system.adapter.' + this.namespace;
-        this.states.setState(id + '.alive', {val: true, ack: true, expire: Math.floor(config.system.statisticsInterval / 1000) + 10, from: id});
+        adapterStates.setState(id + '.alive', {val: true, ack: true, expire: Math.floor(config.system.statisticsInterval / 1000) + 10, from: id});
         this.outputCount++;
         if (this.connected) {
-            this.states.setState(id + '.connected', {val: true, ack: true, expire: 30, from: id});
+            adapterStates.setState(id + '.connected', {val: true, ack: true, expire: 30, from: id});
             this.outputCount++;
         }
         if (!this.startedInCompactMode) {
@@ -7142,25 +7161,25 @@ function Adapter(options) {
             // }
             pidUsage(process.pid, (err, stats) => {
                 // sometimes adapter is stopped, but this is still running
-                if (!err && this && this.states && this.states.setState && stats) {
-                    this.states.setState(id + '.cpu', {ack: true, from: id, val: Math.round(100 * parseFloat(stats.cpu)) / 100});
-                    this.states.setState(id + '.cputime', {ack: true, from: id, val: stats.ctime / 1000});
+                if (!err && this && adapterStates && adapterStates.setState && stats) {
+                    adapterStates.setState(id + '.cpu', {ack: true, from: id, val: Math.round(100 * parseFloat(stats.cpu)) / 100});
+                    adapterStates.setState(id + '.cputime', {ack: true, from: id, val: stats.ctime / 1000});
                     this.outputCount += 2;
                 }
             });
             //RSS is the resident set size, the portion of the process's memory held in RAM (as opposed to the swap space or the part held in the filesystem).
             const mem = process.memoryUsage();
-            this.states.setState(id + '.memRss', {
+            adapterStates.setState(id + '.memRss', {
                 val: parseFloat((mem.rss / 1048576/* 1MB */).toFixed(2)),
                 ack: true,
                 from: id
             });
-            this.states.setState(id + '.memHeapTotal', {
+            adapterStates.setState(id + '.memHeapTotal', {
                 val: parseFloat((mem.heapTotal / 1048576/* 1MB */).toFixed(2)),
                 ack: true,
                 from: id
             });
-            this.states.setState(id + '.memHeapUsed', {
+            adapterStates.setState(id + '.memHeapUsed', {
                 val: parseFloat((mem.heapUsed / 1048576/* 1MB */).toFixed(2)),
                 ack: true,
                 from: id
@@ -7168,15 +7187,15 @@ function Adapter(options) {
             this.outputCount += 3;
             if (this.eventLoopLags.length) {
                 const eventLoopLag = Math.ceil(this.eventLoopLags.reduce((a, b) => (a + b)) / this.eventLoopLags.length);
-                this.states.setState(id + '.eventLoopLag', {val: eventLoopLag, ack: true, from: id}); // average of measured values
+                adapterStates.setState(id + '.eventLoopLag', {val: eventLoopLag, ack: true, from: id}); // average of measured values
                 this.eventLoopLags = [];
                 this.outputCount++;
             }
         }
         this.outputCount += 3;
-        this.states.setState(id + '.uptime', {val: parseInt(process.uptime().toFixed(), 10), ack: true, from: id});
-        this.states.setState(id + '.inputCount', {val: this.inputCount, ack: true, from: id});
-        this.states.setState(id + '.outputCount', {val: this.outputCount, ack: true, from: id});
+        adapterStates.setState(id + '.uptime', {val: parseInt(process.uptime().toFixed(), 10), ack: true, from: id});
+        adapterStates.setState(id + '.inputCount', {val: this.inputCount, ack: true, from: id});
+        adapterStates.setState(id + '.outputCount', {val: this.outputCount, ack: true, from: id});
         this.inputCount  = 0;
         this.outputCount = 0;
     };
@@ -7193,9 +7212,9 @@ function Adapter(options) {
             const finishUnload = () => {
                 if (this.terminated) return;
 
-                if (this.states && updateAliveState) {
+                if (adapterStates && updateAliveState) {
                     this.outputCount++;
-                    this.states.setState(id + '.alive', {val: false, ack: true, from: id}, () => {
+                    adapterStates.setState(id + '.alive', {val: false, ack: true, from: id}, () => {
                         if (!isPause && logger) logger.info(this.namespaceLog + ' terminating');
                         this.terminate(exitCode);
                     });
@@ -7227,7 +7246,7 @@ function Adapter(options) {
             // Even if the developer forgets to call the unload callback, we need to stop the process
             // Therefore wait a short while and then force the unload
             setTimeout(() => {
-                if (this.states) {
+                if (adapterStates) {
                     finishUnload();
 
                     // Give 1 seconds to write the value

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -2090,8 +2090,7 @@ function Adapter(options) {
 
         // TODO: remove this backward compatibility shim in the future
         this.objects.getObjectView = (design, search, params, options, callback) => {
-            // for now log it only on debug
-            this.log.debug('adapter.objects.getObjectView is deprecated, and will be removed in the future. Please use adapter.getObjectView/Async. Report this to Developer!');
+            this.log.warn('adapter.objects.getObjectView is deprecated, and will be removed in the future. Please use adapter.getObjectView/Async. Report this to Developer!');
             return this.getObjectView(design, search, params, options, callback);
         };
 
@@ -2142,8 +2141,7 @@ function Adapter(options) {
 
         // TODO: remove this backward compatibility shim in the future
         this.objects.getObjectList = (params, options, callback) => {
-            // for now log it only on debug
-            this.log.debug('adapter.objects.getObjectList is deprecated, and will be removed in the future. Please use adapter.getObjectList/Async. Report this to Developer!');
+            this.log.warn('adapter.objects.getObjectList is deprecated, and will be removed in the future. Please use adapter.getObjectList/Async. Report this to Developer!');
             adapterObjects.getObjectList(params, options, callback);
         };
 

--- a/test/lib/testAdapter.js
+++ b/test/lib/testAdapter.js
@@ -223,7 +223,7 @@ function testAdapter(options) {
             expect(context.adapter.namespace).to.be.equal(context.adapterShortName + '.0');
             expect(context.adapter.name).to.be.equal(context.adapterShortName);
             expect(context.adapter.instance).to.be.equal(0);
-            expect(context.adapter.states).to.be.ok;
+            expect(context.adapter.states).to.be.undefined;
             expect(context.adapter.objects).to.be.ok;
             expect(context.adapter.log).to.be.ok;
             expect(context.adapter.log.info).to.be.a('function');

--- a/test/lib/testMessages.js
+++ b/test/lib/testMessages.js
@@ -8,13 +8,13 @@ function register(it, expect, context) {
     const testName = context.name + ' ' + context.adapterShortName + ' adapter: ';
     const gid = 'system.adapter.' + context.adapterShortName + '.0';
     it(testName + 'check pushMessage', function (done) {
-        context.adapter.states.subscribeMessage(gid, function (err) {
+        context.states.subscribeMessage(gid, function (err) {
             expect(err).to.be.not.ok;
 
             context.onAdapterMessage = function (obj) {
                 expect(typeof obj).to.equal('object');
                 expect(obj.test).to.equal(1);
-                context.adapter.states.unsubscribeMessage(gid, () => done());
+                context.states.unsubscribeMessage(gid, () => done());
                 context.onAdapterMessage = null;
             };
 
@@ -25,14 +25,14 @@ function register(it, expect, context) {
         });
     });
     it(testName + 'check pushMessage Buffer', function (done) {
-        context.adapter.states.subscribeMessage(gid, function (err) {
+        context.states.subscribeMessage(gid, function (err) {
             expect(err).to.be.not.ok;
 
             context.onAdapterMessage = function (obj) {
                 expect(typeof obj).to.equal('object');
                 expect(Buffer.isBuffer(obj.test)).to.be.true;
                 expect(obj.test.toString('utf8')).to.equal('ABCDEFG');
-                context.adapter.states.unsubscribeMessage(gid, () => done());
+                context.states.unsubscribeMessage(gid, () => done());
                 context.onAdapterMessage = null;
             };
 
@@ -50,7 +50,7 @@ function register(it, expect, context) {
     });
 
     it(testName + 'check pushLog', function (done) {
-        context.adapter.states.subscribeLog(gid, function (err) {
+        context.states.subscribeLog(gid, function (err) {
             expect(err).to.be.not.ok;
             context.states.pushLog(gid, {test: 1}, function (err, id) {
                 expect(err).to.be.null;


### PR DESCRIPTION
- provide backward shim for the two used methods `getObjectList` and `getObjectView`