### PR TITLE
Fix logic for repo hash comparison

### DIFF
--- a/lib/tools.js
+++ b/lib/tools.js
@@ -780,20 +780,22 @@ function _checkRepositoryFileHash(urlOrPath, additionalInfo, callback) {
                     console.error('Json file is invalid on ' + urlOrPath);
                 }
             }
-            // If new hash was read and old hash is known
-            if (json && json.hash && additionalInfo && additionalInfo.hash && additionalInfo.sources) {
-                // compare hash
-                if (json.hash === additionalInfo.hash) {
-                    console.log('hash not changed, use actual sources');
-                    // hash not changed, use actual sources
+            if (json && json.hash) {
+                // The hash download was successful
+                if (additionalInfo && additionalInfo.sources && json.hash === additionalInfo.hash) {
+                    // The hash is the same as for the cached sources
+                    console.log('hash unchanged, use cached sources');
                     callback(null, additionalInfo.sources, json.hash);
                 } else {
-                    console.log('hash changed => force download of new sources');
-                    // hash changed => force download of new sources
+                    // Either we have no sources cached or the hash changed
+                    // => force download of new sources
+                    console.log('hash changed or no sources cached => force download of new sources');
                     callback(null, null, json.hash);
                 }
             } else {
-                callback(null, additionalInfo.sources, (json && json.hash) || '');
+                // Could not download new sources, use the old ones
+                console.log('failed to download new sources, use cached sources');
+                callback(null, additionalInfo.sources, '');
             }
         }).on('error', _error => {
             //console.log('Cannot download json from ' + urlOrPath + '. Error: ' + error);


### PR DESCRIPTION
the old logic would fail to update the sources when the old hash was missing

fixes: #596 