### PR TITLE
also respect def values of io-package.json on automatic recreation due

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -1315,7 +1315,9 @@ function Adapter(options) {
                             // default value given - if obj non existing we have to set it
                             try {
                                 const checkObj = await this.getForeignObjectAsync(obj._id);
-                                if (!checkObj) obj.state = obj.common.def;
+                                if (!checkObj) {
+                                    obj.state = obj.common.def;
+                                }
                             } catch (e) {
                                 logger.warn(`${this.namespaceLog} Did not add default (${obj.common.def}) value on creation of ${obj._id}: ${e}`);
                             }

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -1070,10 +1070,26 @@ function Adapter(options) {
         if (state !== undefined) {
             delete task.state;
         }
-        adapterObjects.extendObject(task._id, task, () =>
-            state ?
-                adapterStates.setState(task._id, state, () => setImmediate(extendObjects, tasks, callback)) :
-                setImmediate(extendObjects, tasks, callback));
+        adapterObjects.getObject(task._id, (err, obj) => {
+            if (obj || state !== undefined) {
+                // state will not be newly created, or we have state, thus not set default value
+                adapterObjects.extendObject(task._id, task, () =>
+                    state ?
+                        adapterStates.setState(task._id, {val: task.state, ack: true, from: `system.adapter.${this.namespace}`},
+                            () => setImmediate(extendObjects, tasks, callback)) :
+                        setImmediate(extendObjects, tasks, callback));
+            } else {
+                // set def value after creation if no state explicitly provided
+                adapterObjects.setObject(task._id, task, () => {
+                    if (task.common && task.common.def !== undefined) {
+                        adapterStates.setState(task._id, {val: task.common.def, ack: true, from: `system.adapter.${this.namespace}`},
+                            () => setImmediate(extendObjects, tasks, callback));
+                    } else {
+                        setImmediate(extendObjects, tasks, callback);
+                    }
+                });
+            }
+        });
     };
 
     const createInstancesObjects = (instanceObj, callback) => {

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -1070,26 +1070,10 @@ function Adapter(options) {
         if (state !== undefined) {
             delete task.state;
         }
-        adapterObjects.getObject(task._id, (err, obj) => {
-            if (obj || state !== undefined) {
-                // state will not be newly created, or we have state, thus not set default value
-                adapterObjects.extendObject(task._id, task, () =>
-                    state ?
-                        adapterStates.setState(task._id, {val: task.state, ack: true, from: `system.adapter.${this.namespace}`},
-                            () => setImmediate(extendObjects, tasks, callback)) :
-                        setImmediate(extendObjects, tasks, callback));
-            } else {
-                // set def value after creation if no state explicitly provided
-                adapterObjects.setObject(task._id, task, () => {
-                    if (task.common && task.common.def !== undefined) {
-                        adapterStates.setState(task._id, {val: task.common.def, ack: true, from: `system.adapter.${this.namespace}`},
-                            () => setImmediate(extendObjects, tasks, callback));
-                    } else {
-                        setImmediate(extendObjects, tasks, callback);
-                    }
-                });
-            }
-        });
+        adapterObjects.extendObject(task._id, task, () =>
+            state !== undefined ?
+                adapterStates.setState(task._id, {val: state, from: `system.adapter.${this.namespace}`, ack: true}, () => setImmediate(extendObjects, tasks, callback)) :
+                setImmediate(extendObjects, tasks, callback));
     };
 
     const createInstancesObjects = (instanceObj, callback) => {
@@ -1302,8 +1286,13 @@ function Adapter(options) {
         }
 
         if (this.ioPack.instanceObjects) {
-            this.ioPack.instanceObjects.forEach((obj) => {
-                if (obj && (obj._id || obj._id === '' || obj.type === 'meta')) {
+            this.ioPack.instanceObjects.forEach(async (obj) => {
+                if (!obj._id.startsWith(this.namespace)) {
+                    // instanceObjects are normally defined without namespace prefix
+                    obj._id = (obj._id === '') ? this.namespace : this.namespace + '.' + obj._id;
+                }
+
+                if (obj && (obj._id || obj.type === 'meta')) {
                     if (obj.common) {
                         if (obj.common.name) {
                             // if name has many languages
@@ -1321,11 +1310,18 @@ function Adapter(options) {
                                 obj.common.desc = obj.common.desc.replace('%INSTANCE%', instance);
                             }
                         }
+
+                        if (obj.common.def !== undefined) {
+                            // default value given - if obj non existing we have to set it
+                            try {
+                                const checkObj = await this.getForeignObjectAsync(obj._id);
+                                if (!checkObj) obj.state = obj.common.def;
+                            } catch (e) {
+                                logger.warn(`${this.namespaceLog} Did not add default (${obj.common.def}) value on creation of ${obj._id}: ${e}`);
+                            }
+                        }
                     }
-                    if (!obj._id.startsWith(this.namespace)) {
-                        // instanceObjects are normally defined without namespace prefix
-                        obj._id = (obj._id === '') ? this.namespace : this.namespace + '.' + obj._id;
-                    }
+
                     objs.push(obj);
                 } else {
                     logger.error(this.namespaceLog + ' ' + options.name + '.' + instance + ' invalid instance object: ' + JSON.stringify(obj));

--- a/lib/setup/setupInstall.js
+++ b/lib/setup/setupInstall.js
@@ -1151,7 +1151,9 @@ function Install(options) {
                         function setStates() {
                             if (defStates.length > 0) {
                                 const defState = defStates.pop();
-                                states.setState(defState.id, defState.val, err => {
+                                defState.ack = true;
+                                defState.from = `system.host.${tools.getHostName()}.cli`;
+                                states.setState(defState.id, defState, err => {
                                     if (err) {
                                         console.error(`host.${hostname} error: ${err}`);
                                     } else {


### PR DESCRIPTION
 to instance startage

basically missed one case of https://github.com/ioBroker/ioBroker.js-controller/pull/666 where instanceObjects will be created on adapter restart if non exiting system.adapter.namespace object

and
- some general optimizations for extendObjects function of adapter.js (use from and ack)
- use from and ack on creation of instanceObjects in setupInstall