### PR TITLE
Validate arguments to `iobroker del ...` CLI command

### DIFF
--- a/lib/cli/cliTools.js
+++ b/lib/cli/cliTools.js
@@ -37,7 +37,7 @@ function normalizeAdapterName(name) {
  * @param {string} name The name which is supposed to be an adapter identifier
  */
 function validateAdapterIdentifier(name) {
-    return /^[a-z0-9\-]+$/.test(name);
+    return /^[a-z0-9\-_]+$/.test(name);
 }
 
 /**
@@ -46,7 +46,7 @@ function validateAdapterIdentifier(name) {
  * @param {string} name
  */
 function validateAdapterOrInstanceIdentifier(name) {
-    return /^[a-z0-9\-]+(\.\d+)?$/.test(name);
+    return /^[a-z0-9\-_]+(\.\d+)?$/.test(name);
 }
 
 /**

--- a/lib/cli/cliTools.js
+++ b/lib/cli/cliTools.js
@@ -33,6 +33,23 @@ function normalizeAdapterName(name) {
 }
 
 /**
+ * Ensures that the given string is a valid adapter identifier (<adaptername>) WITHOUT instance number
+ * @param {string} name The name which is supposed to be an adapter identifier
+ */
+function validateAdapterIdentifier(name) {
+    return /^[a-z0-9\-]+$/.test(name);
+}
+
+/**
+ * Ensures that the given string contains a valid identifier for 
+ * an adapter (without instance number) or instance (with instance number)
+ * @param {string} name
+ */
+function validateAdapterOrInstanceIdentifier(name) {
+    return /^[a-z0-9\-]+(\.\d+)?$/.test(name);
+}
+
+/**
  * Extracts the instance name from an object ID
  * @param {string} instanceObjID The ID of the instance object
  */
@@ -83,6 +100,8 @@ module.exports = {
     formatValue,
     getObjectFrom,
     normalizeAdapterName,
+    validateAdapterIdentifier,
+    validateAdapterOrInstanceIdentifier,
     getInstanceName,
     enumInstances,
     enumHosts,

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -502,18 +502,38 @@ function processCommand(command, args, params, callback) {
             let adapter  = args[0];
             let instance = args[1];
 
+            // The adapter argument is required
             if (!adapter) {
                 showHelp();
                 return void callback(2);
-            } else {
-                // If user accidentally wrote tools.appName.adapter => remove adapter
-                adapter = cli.tools.normalizeAdapterName(adapter);
             }
+            // If the user accidentally wrote <tools.appName>.adapter,
+            // remove <tools.appName> from the adapter name
+            adapter = cli.tools.normalizeAdapterName(adapter);
 
-            if (adapter && adapter.indexOf('.') !== -1) {
-                const parts = adapter.split('.');
-                adapter      = parts[0];
-                instance  = parts[1];
+            // Avoid deleting stuff we don't want to delete
+            // e.g. `system.adapter.*`
+            if (!instance) {
+                // Ensure that adapter contains a valid adapter (without instance nr)
+                // or instance (with instance nr) identifier
+                if (!cli.tools.validateAdapterOrInstanceIdentifier(adapter)) {
+                    showHelp();
+                    return void callback(2);
+                }
+                // split the adapter into adapter + instance if necessary
+                if (adapter.indexOf('.') > -1) {
+                    ([adapter, instance] = adapter.split('.', 2));
+                }
+            } else {
+                // ensure that adapter contains a valid adapter identifier
+                // and the instance is a number
+                if (
+                    !cli.tools.validateAdapterIdentifier(adapter)
+                    || !/^\d+$/.test(instance)
+                ) {
+                    showHelp();
+                    return void callback(2);
+                }
             }
 
             if (instance || instance === 0) {


### PR DESCRIPTION
With this PR, we check that the arguments to `iobroker del adaptername [instance]` are valid. The following combinations are assumed valid:
* `adaptername` contains only these chars: `a-z`, `0-9`, `-`, `_`
  `instance` is not given
* `adaptername` contains only these chars: `a-z`, `0-9`, `-`, `_`, followed by a dot, followed by a number
  `instance` is not given, but will be extracted from the adaptername
* `adaptername` contains only these chars: `a-z`, `0-9`, `-`, `_`
  `instance` is a number

fixes: #675 