### PR TITLE
Support Adapter Auto-Rebuild on execution errors

### DIFF
--- a/lib/setup.js
+++ b/lib/setup.js
@@ -461,11 +461,10 @@ function processCommand(command, args, params, callback) {
                 console.log('Please provide the name of the adapter to rebuild');
                 return void callback(1);
             }
-            installNpm(name, true,(err, _adapter) => {
+            installNpm(name, true, (err, _adapter) => {
                 if (err) {
                     processExit(err);
-                }
-                else {
+                } else {
                     console.log();
                     console.log('Rebuild ' + name + ' done');
                     return void callback();

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -461,10 +461,8 @@ function processCommand(command, args, params, callback) {
                 console.log('Please provide the name of the adapter to rebuild');
                 return void callback(1);
             }
-            let rebuildCommand = 'rebuild';
-            if (params && params.install) {
-                rebuildCommand = 'install';
-            }
+
+            const rebuildCommand = (params && params.install) ? 'install' : 'rebuild';
             installNpm(name, rebuildCommand, (err, _adapter) => {
                 if (err) {
                     processExit(err);

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -16,6 +16,7 @@
 // TODO need info about progress of stopping
 
 const fs         = require('fs');
+const pathLib    = require('path');
 const tools      = require('./tools.js');
 const cli        = require('./cli/index.js');
 const EXIT_CODES = require('./exitCodes');
@@ -44,6 +45,7 @@ function initYargs() {
                 tools.appName + ' logs [adapter] [--watch] [--lines=1000]\n' +
                 tools.appName + ' add <adapter> [desiredNumber] [--enabled] [--host <host>] [--port <port>]\n' +
                 tools.appName + ' install <adapter>\n' +
+                tools.appName + ' rebuild <adapter>|self\n' +
                 tools.appName + ' url <url> [<name>]\n' +
                 tools.appName + ' del <adapter>\n' +
                 tools.appName + ' del <adapter>.<instance>\n' +
@@ -440,6 +442,33 @@ function processCommand(command, args, params, callback) {
                         console.log('adapter "' + name + '" already installed. Use "upgrade" to upgrade to a newer version.');
                         return void callback(51);
                     }
+                }
+            });
+            break;
+        }
+
+        case 'rebuild': {
+            let name = args[0];
+
+            // If user accidentally wrote tools.appName.adapter => remove adapter
+            name = cli.tools.normalizeAdapterName(name);
+
+            if (name.indexOf('@') !== -1) {
+                name = name.split('@')[0];
+            }
+
+            if (!name) {
+                console.log('Please provide the name of the adapter to rebuild');
+                return void callback(1);
+            }
+            installNpm(name, true,(err, _adapter) => {
+                if (err) {
+                    processExit(err);
+                }
+                else {
+                    console.log();
+                    console.log('Rebuild ' + name + ' done');
+                    return void callback();
                 }
             });
             break;
@@ -2135,7 +2164,12 @@ function restartController(callback) {
     }
 }
 
-function installNpm(adapter, callback) {
+function installNpm(adapter, executeRebuild, callback) {
+    if (typeof executeRebuild === 'function') {
+        callback = executeRebuild;
+        executeRebuild = false;
+    }
+
     let path = __dirname;
     if (typeof adapter === 'function') {
         callback = adapter;
@@ -2143,12 +2177,18 @@ function installNpm(adapter, callback) {
     }
 
     if (adapter) {
-        path = tools.getAdapterDir(adapter);
+        if (executeRebuild && adapter === 'self') {
+            path = pathLib.join(__dirname, '..');
+        } else {
+            path = tools.getAdapterDir(adapter);
+        }
     }
 
+    const npmCommand = 'install'; // also for rebuild because else dependencies are not updated
+
     // iob_npm.done file was created if "npm i" yet called there
-    if (fs.existsSync(path + '/package.json') && !fs.existsSync(path + '/iob_npm.done')) {
-        const cmd = 'npm install --loglevel error --production';
+    if (fs.existsSync(pathLib.join(path, 'package.json')) && (executeRebuild || !fs.existsSync(pathLib.join(path, 'iob_npm.done')))) {
+        const cmd = 'npm ' + npmCommand +' --loglevel error --production';
         console.log(cmd + ' (System call) in "' + path + '"');
         // Install node modules as system call
 
@@ -2168,7 +2208,7 @@ function installNpm(adapter, callback) {
                 return;
             }
             // command succeeded
-            fs.writeFileSync(path + '/iob_npm.done', ' ');
+            !executeRebuild && fs.writeFileSync(path + '/iob_npm.done', ' ');
             typeof callback === 'function' && callback(null, adapter);
         });
     } else if (typeof callback === 'function') {

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -45,7 +45,7 @@ function initYargs() {
                 tools.appName + ' logs [adapter] [--watch] [--lines=1000]\n' +
                 tools.appName + ' add <adapter> [desiredNumber] [--enabled] [--host <host>] [--port <port>]\n' +
                 tools.appName + ' install <adapter>\n' +
-                tools.appName + ' rebuild <adapter>|self\n' +
+                tools.appName + ' rebuild <adapter>|self [--install]\n' +
                 tools.appName + ' url <url> [<name>]\n' +
                 tools.appName + ' del <adapter>\n' +
                 tools.appName + ' del <adapter>.<instance>\n' +
@@ -461,7 +461,11 @@ function processCommand(command, args, params, callback) {
                 console.log('Please provide the name of the adapter to rebuild');
                 return void callback(1);
             }
-            installNpm(name, true, (err, _adapter) => {
+            let rebuildCommand = 'rebuild';
+            if (params && params.install) {
+                rebuildCommand = 'install';
+            }
+            installNpm(name, rebuildCommand, (err, _adapter) => {
                 if (err) {
                     processExit(err);
                 } else {
@@ -2163,10 +2167,10 @@ function restartController(callback) {
     }
 }
 
-function installNpm(adapter, executeRebuild, callback) {
-    if (typeof executeRebuild === 'function') {
-        callback = executeRebuild;
-        executeRebuild = false;
+function installNpm(adapter, rebuildCommand, callback) {
+    if (typeof rebuildCommand === 'function') {
+        callback = rebuildCommand;
+        rebuildCommand = false;
     }
 
     let path = __dirname;
@@ -2176,18 +2180,21 @@ function installNpm(adapter, executeRebuild, callback) {
     }
 
     if (adapter) {
-        if (executeRebuild && adapter === 'self') {
+        if (rebuildCommand && adapter === 'self') {
             path = pathLib.join(__dirname, '..');
         } else {
             path = tools.getAdapterDir(adapter);
         }
     }
 
-    const npmCommand = 'install'; // also for rebuild because else dependencies are not updated
+    const npmCommand = typeof rebuildCommand === 'string' ? rebuildCommand : 'install';
 
     // iob_npm.done file was created if "npm i" yet called there
-    if (fs.existsSync(pathLib.join(path, 'package.json')) && (executeRebuild || !fs.existsSync(pathLib.join(path, 'iob_npm.done')))) {
-        const cmd = 'npm ' + npmCommand +' --loglevel error --production';
+    if (fs.existsSync(pathLib.join(path, 'package.json')) && (rebuildCommand || !fs.existsSync(pathLib.join(path, 'iob_npm.done')))) {
+        let cmd = 'npm ' + npmCommand +' --loglevel error';
+        if (npmCommand === 'install') {
+            cmd += ' --production';
+        }
         console.log(cmd + ' (System call) in "' + path + '"');
         // Install node modules as system call
 
@@ -2199,6 +2206,7 @@ function installNpm(adapter, executeRebuild, callback) {
             windowsHide: true
         });
         child.stderr.pipe(process.stdout);
+        //child.stdout.pipe(process.stdout);
         child.on('exit', (code, _signal) => {
             // code 1 is strange error that cannot be explained. Everything is installed but error :(
             if (code && code !== 1) {
@@ -2207,7 +2215,9 @@ function installNpm(adapter, executeRebuild, callback) {
                 return;
             }
             // command succeeded
-            !executeRebuild && fs.writeFileSync(path + '/iob_npm.done', ' ');
+            if (!rebuildCommand || rebuildCommand === 'install') {
+                fs.writeFileSync(path + '/iob_npm.done', ' ');
+            }
             typeof callback === 'function' && callback(null, adapter);
         });
     } else if (typeof callback === 'function') {

--- a/main.js
+++ b/main.js
@@ -551,7 +551,7 @@ function createObjects(onConnect) {
                             }
                         });
                     } else if (installQueue.find(obj => obj.id === id)) { // ignore object changes when still in install queue
-                        logger.debug(hostLogPrefix + ' ignore object change because adapter still in installation/rebuild queue');
+                        logger.debug(hostLogPrefix + ' ignore object change because the adapter is still in installation/rebuild queue');
                     } else {
                         const _ipArr = getIPs();
                         if (procs[id].config && checkAndAddInstance(procs[id].config, _ipArr)) {
@@ -2590,7 +2590,7 @@ function installAdapters() {
         procs[task.id].downloadRetry++;
 
         if (task.rebuild) {
-            logger.warn(hostLogPrefix + ' adapter "' + name + '" seems to be installed for an other Node.js version. Try to rebuild it... ' + procs[task.id].downloadRetry + ' attempt');
+            logger.warn(hostLogPrefix + ' adapter "' + name + '" seems to be installed for a different version of Node.js. Trying to rebuild it... ' + procs[task.id].downloadRetry + ' attempt');
         } else {
             logger.warn(hostLogPrefix + ' startInstance cannot find adapter "' + name + '". Try to install it... ' + procs[task.id].downloadRetry + ' attempt');
         }
@@ -2648,7 +2648,7 @@ function installAdapters() {
                     procs[task.id].needsRebuild = false;
                     if (!task.disabled) {
                         if (!procs[task.id].config.common.enabled) {
-                            logger.info(hostLogPrefix + ' startInstance ' + task.id + ': should start instance but disabled, re-enable');
+                            logger.info(hostLogPrefix + ' startInstance ' + task.id + ': instance is disabled but should be started, re-enabling it');
                             states.setState(task.id + '.alive', {val: true, ack: false, from: hostObjectPrefix});
                         }
                         else if (task.rebuild) {
@@ -2659,7 +2659,7 @@ function installAdapters() {
                             startInstance(task.id, task.wakeUp);
                         }
                     } else {
-                        logger.debug(hostLogPrefix + ' ' + tools.appName + ' ' + commandScope + ' successful but instance disabled');
+                        logger.debug(hostLogPrefix + ' ' + tools.appName + ' ' + commandScope + ' successful but the instance is disabled');
                     }
                 }
 

--- a/main.js
+++ b/main.js
@@ -2206,46 +2206,38 @@ function processMessage(msg) {
             break;
 
         case 'updateMultihost':
-            (function () {
-                const result = startMultihost();
-                if (msg.callback) {
-                    sendTo(msg.from, msg.command, {result: result}, msg.callback);
-                }
-            })();
+            const result = startMultihost();
+            if (msg.callback) {
+                sendTo(msg.from, msg.command, {result: result}, msg.callback);
+            }
             break;
 
         case 'getInterfaces':
-            (function () {
-                if (msg.callback) {
-                    sendTo(msg.from, msg.command, {result: os.networkInterfaces()}, msg.callback);
-                }
-            })();
+            if (msg.callback) {
+                sendTo(msg.from, msg.command, {result: os.networkInterfaces()}, msg.callback);
+            }
             break;
 
         case 'upload': {
-            (function (msg) {
-                if (msg.message) {
-                    uploadTasks.push({adapter: msg.message, msg});
-                    // start upload if no tasks running
-                    uploadTasks.length === 1 && startAdapterUpload();
-                } else {
-                    logger.error('host.' + hostname + ' No adapter name is specified for upload command from  ' + msg.from);
-                }
-            })(msg);
+            if (msg.message) {
+                uploadTasks.push({adapter: msg.message, msg});
+                // start upload if no tasks running
+                uploadTasks.length === 1 && startAdapterUpload();
+            } else {
+                logger.error(hostLogPrefix + ' No adapter name is specified for upload command from  ' + msg.from);
+            }
             break;
         }
 
         case 'rebuildAdapter':
-            (function (msg) {
-                if (!installQueue.find(entry => entry && entry.id && entry.id === msg.message.id)) {
-                    logger.info(msg.message.id + ' will be rebuild');
-                    installQueue.push({id: msg.message.id, rebuild: true, rebuildViaInstall: msg.message.rebuildViaInstall});
-                    // start install queue if not started
-                    installQueue.length === 1 && installAdapters();
-                } else {
-                    logger.info(msg.message.id + ' still in installQueue, rebuild will be done with install');
-                }
-            })(msg);
+            if (!installQueue.some(entry => entry.id === msg.message.id)) {
+                logger.info(hostLogPrefix + ' ' + msg.message.id + ' will be rebuilt');
+                installQueue.push({id: msg.message.id, rebuild: true, rebuildViaInstall: msg.message.rebuildViaInstall});
+                // start install queue if not started
+                installQueue.length === 1 && installAdapters();
+            } else {
+                logger.info(hostLogPrefix + ' ' + msg.message.id + ' still in installQueue, rebuild will be done with install');
+            }
             break;
 
     }

--- a/main.js
+++ b/main.js
@@ -2631,16 +2631,19 @@ function installAdapters() {
                 installQueue.shift();
                 if (exitCode === EXIT_CODES.CANNOT_INSTALL_NPM_PACKET) {
                     installQueue.push(task); // We add at the end again to try three times
-                } else if (!task.disabled) {
-                    if (!procs[task.id].config.common.enabled) {
-                        logger.info(hostLogPrefix + ' startInstance ' + task.id + ': should start instance but disabled, re-enable');
-                        states.setState(task.id + '.alive', {val: true, ack: false, from: hostObjectPrefix});
-                    }
-                    else {
-                        startInstance(task.id, task.wakeUp);
-                    }
                 } else {
-                    logger.debug(hostLogPrefix + ' ' + tools.appName + ' ' + commandScope + ' successful but instance disabled');
+                    procs[task.id].needsRebuild = false;
+                    if (!task.disabled) {
+                        if (!procs[task.id].config.common.enabled) {
+                            logger.info(hostLogPrefix + ' startInstance ' + task.id + ': should start instance but disabled, re-enable');
+                            states.setState(task.id + '.alive', {val: true, ack: false, from: hostObjectPrefix});
+                        }
+                        else {
+                            startInstance(task.id, task.wakeUp);
+                        }
+                    } else {
+                        logger.debug(hostLogPrefix + ' ' + tools.appName + ' ' + commandScope + ' successful but instance disabled');
+                    }
                 }
 
                 setTimeout(() => {

--- a/main.js
+++ b/main.js
@@ -1703,6 +1703,7 @@ function processMessage(msg) {
     // important: Do not forget to update the list of protected commands in iobroker.admin/lib/socket.js for "socket.on('sendToHost'"
     // and iobroker.socketio/lib/socket.js
 
+    logger.debug('Incoming Host message ' + msg.command);
     switch (msg.command) {
         case 'shell':
             if (config.system && config.system.allowShellCommands) {
@@ -2233,6 +2234,20 @@ function processMessage(msg) {
             })(msg);
             break;
         }
+
+        case 'rebuildAdapter':
+            (function (msg) {
+                if (!installQueue.find(entry => entry && entry.id && entry.id === msg.message.id)) {
+                    logger.info(msg.message.id + ' will be rebuild');
+                    installQueue.push({id: msg.message.id, rebuild: true, rebuildViaInstall: msg.message.rebuildViaInstall});
+                    // start install queue if not started
+                    installQueue.length === 1 && installAdapters();
+                } else {
+                    logger.info(msg.message.id + ' still in installQueue, rebuild will be done with install');
+                }
+            })(msg);
+            break;
+
     }
 }
 
@@ -2563,6 +2578,7 @@ function installAdapters() {
     if (!installQueue.length) return;
 
     const task = installQueue[0];
+    if (task.inProgress) return;
     let name = task.id.split('.')[2];
     if (task.version && !task.rebuild) {
         name += '@' + task.version;
@@ -2607,11 +2623,15 @@ function installAdapters() {
         else {
             installArgs.push(commandScope);
             installArgs.push(name);
+            if (task.rebuildViaInstall) {
+                installArgs.push('--install');
+            }
         }
         logger.info(hostLogPrefix + ' ' + tools.appName + ' ' + installArgs.join(' ') + (task.rebuild ? '' : ' using ' + ((procs[task.id].downloadRetry < 3 && task.installedFrom) ? 'installedFrom' : 'installedVersion')));
         installArgs.unshift(__dirname + '/' + tools.appName + '.js');
 
         try {
+            task.inProgress = true;
             const child = spawn('node', installArgs, {windowsHide: true});
             if (child.stdout) {
                 child.stdout.on('data', data => {
@@ -2630,6 +2650,7 @@ function installAdapters() {
                 logger.info(hostLogPrefix + ' ' + tools.appName + ' npm-' + commandScope + ': exit ' + exitCode);
                 installQueue.shift();
                 if (exitCode === EXIT_CODES.CANNOT_INSTALL_NPM_PACKET) {
+                    task.inProgress = false;
                     installQueue.push(task); // We add at the end again to try three times
                 } else {
                     procs[task.id].needsRebuild = false;
@@ -2637,6 +2658,10 @@ function installAdapters() {
                         if (!procs[task.id].config.common.enabled) {
                             logger.info(hostLogPrefix + ' startInstance ' + task.id + ': should start instance but disabled, re-enable');
                             states.setState(task.id + '.alive', {val: true, ack: false, from: hostObjectPrefix});
+                        }
+                        else if (task.rebuild) {
+                            // on rebuild we send a restart signal via object change to also reach compact group processes
+                            objects.extendObject(task.id, {})
                         }
                         else {
                             startInstance(task.id, task.wakeUp);
@@ -2666,7 +2691,7 @@ function installAdapters() {
         }
     } else {
         if (task.rebuild) {
-            logger.error(hostLogPrefix + ' Cannot rebuild adapter "' + name + '". To retry it disable/enable the adapter or restart host. Also check the error messages in the log!');
+            logger.error(hostLogPrefix + ' Cannot rebuild adapter "' + name + '". To retry it disable/enable the adapter or restart host. Also check the error messages in the log or execute "npm install --production" in adapter directory manually!');
         } else {
             logger.error(hostLogPrefix + ' Cannot download and install adapter "' + name + '". To retry it disable/enable the adapter or restart host. Also check the error messages in the log!');
         }
@@ -3003,42 +3028,60 @@ function startInstance(id, wakeUp) {
                         }
 
                         if (procs[id].needsRebuild) {
-                            installQueue.push({id: instance._id, rebuild: true});
-                            // start install queue if not started
-                            installQueue.length === 1 && installAdapters();
-                        }
-
-                        if (code !== EXIT_CODES.ADAPTER_REQUESTED_TERMINATION &&
-                            !wakeUp &&
-                            connected &&
-                            !isStopping &&
-                            procs[id] &&
-                            procs[id].config &&
-                            procs[id].config.common &&
-                            procs[id].config.common.enabled &&
-                            (!procs[id].config.common.webExtension || !procs[id].config.native.webInstance) &&
-                            mode !== 'once'
-                        ) {
-                            logger.info(hostLogPrefix + ' Restart adapter ' + id + ' because enabled');
-
-                            const restartTimerExisting = !!procs[id].restartTimer;
-                            //noinspection JSUnresolvedVariable
-                            if (procs[id].restartTimer) {
-                                clearTimeout(procs[id].restartTimer);
-                            }
-                            procs[id].restartTimer = setTimeout(_id => startInstance(_id),
-                                code === EXIT_CODES.START_IMMEDIATELY_AFTER_STOP_HEX ? 1000 : ((procs[id].config.common.restartSchedule || restartTimerExisting) ? 1000 : 30000), id);
-                            // 4294967196 (-100) is special code that adapter wants itself to be restarted immediately
-                        } else {
-                            if (code === EXIT_CODES.ADAPTER_REQUESTED_TERMINATION) {
-                                logger.info(`${hostLogPrefix} Do not restart adapter ${id} because desired by instance`);
-                            } else
-                            if (mode !== 'once') {
-                                logger.info(`${hostLogPrefix} Do not restart adapter ${id} because disabled or deleted`);
+                            procs[id].rebuildCounter = procs[id].rebuildCounter || 0;
+                            procs[id].rebuildCounter++;
+                            if (procs[id].rebuildCounter < 4) {
+                                logger.info(hostLogPrefix + ' Adapter ' + id + ' needs rebuild and will be restarted afterwards.');
+                                const msg = {
+                                    command: 'rebuildAdapter',
+                                    message: {
+                                        id: instance._id,
+                                        rebuildViaInstall: procs[id].rebuildCounter > 1
+                                    }
+                                };
+                                if (!compactGroupController) { // execute directly
+                                    processMessage(msg);
+                                } else { // send to main controller to make sure only one npm process runs at a time
+                                    sendTo('system.host.' + hostname, 'rebuildAdapter', msg);
+                                }
                             } else {
-                                logger.info(`${hostLogPrefix} instance ${id} terminated while should be started once`);
+                                logger.info(hostLogPrefix + ' Rebuild for adapter ' + id + ' not successful in 3 tries. Adapter will not be restarted again. Please execute "npm install --production" in adapter directory manually.');
+                            }
+                        } else {
+                            procs[id].rebuildCounter = 0;
+                            if (code !== EXIT_CODES.ADAPTER_REQUESTED_TERMINATION &&
+                                !wakeUp &&
+                                connected &&
+                                !isStopping &&
+                                procs[id] &&
+                                procs[id].config &&
+                                procs[id].config.common &&
+                                procs[id].config.common.enabled &&
+                                (!procs[id].config.common.webExtension || !procs[id].config.native.webInstance) &&
+                                mode !== 'once'
+                            ) {
+                                logger.info(hostLogPrefix + ' Restart adapter ' + id + ' because enabled');
+
+                                const restartTimerExisting = !!procs[id].restartTimer;
+                                //noinspection JSUnresolvedVariable
+                                if (procs[id].restartTimer) {
+                                    clearTimeout(procs[id].restartTimer);
+                                }
+                                procs[id].restartTimer = setTimeout(_id => startInstance(_id),
+                                    code === EXIT_CODES.START_IMMEDIATELY_AFTER_STOP_HEX ? 1000 : ((procs[id].config.common.restartSchedule || restartTimerExisting) ? 1000 : 30000), id);
+                                // 4294967196 (-100) is special code that adapter wants itself to be restarted immediately
+                            } else {
+                                if (code === EXIT_CODES.ADAPTER_REQUESTED_TERMINATION) {
+                                    logger.info(`${hostLogPrefix} Do not restart adapter ${id} because desired by instance`);
+                                } else
+                                if (mode !== 'once') {
+                                    logger.info(`${hostLogPrefix} Do not restart adapter ${id} because disabled or deleted`);
+                                } else {
+                                    logger.info(`${hostLogPrefix} instance ${id} terminated while should be started once`);
+                                }
                             }
                         }
+
                         storePids(); // Store all pids to make possible kill them all
                     });
                 };


### PR DESCRIPTION
This is "concept PR" to discuss the general solution. code is untested (because I do not want to switch nodejs versions that often ;-)) )

Changes in here: 
* introduce CLI command "npm rebuild <adaptername>" or "npm rebuild self" (for controller) top execute an npm install for the specified adapter. We can flexibly decided later if we want to execute different commands for rebuild

* hook in the stderr messages from adapters when started from controller and check for certain marker phrases that show that a rebuild needs to be done
* if this happens execute the "iobroker rebuild" command for the affected adapter inside the "installQueue" (to make sure only one command runs at a time) up to 3 times

fixes: #538