### PR TITLE
increase timeout of hostinfo

### DIFF
--- a/lib/tools.js
+++ b/lib/tools.js
@@ -1001,7 +1001,7 @@ function getSystemNpmVersion(callback) {
                 callback('timeout');
                 callback = null;
             }
-        }, 5000);
+        }, 10000);
 
         exec('npm -v', {encoding: 'utf8', env: newEnv, windowsHide: true}, (error, stdout) => {//, stderr) {
             if (timeout) {


### PR DESCRIPTION
- currently a timeout of 5 sec is used until cb is called due to timeout, it seems like it's necessary for some low performance devices to increase this
- fixes #672 and fixes #671