### PR TITLE
Validate the object argument to set[Foreign]State[Changed]

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -5188,7 +5188,10 @@ function Adapter(options) {
                 ...Object.entries(optionalProperties)
             ];
             for (const [key, type] of propertyKeysAndTypes) {
+                // any permits all types
                 if (type === "any") continue;
+                // don't flag optional properties when they don't exist
+                if (!(key in obj)) continue;
                 if (type !== typeof obj[key]) {
                     throw new Error(`The state property "${key}" has the wrong type "${typeof obj[key]}" (should be "${type}")!`);
                 }

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -5261,8 +5261,8 @@ function Adapter(options) {
                     callback && callback(e.message);
                     return;
                 }
-            } else if (state === null || state === undefined || tools.isArray(state)) {
-                // wrap special values in a state object
+            } else {
+                // wrap non-object values in a state object
                 state = {val: state};
             }
 
@@ -5386,8 +5386,8 @@ function Adapter(options) {
                     callback && callback(e.message);
                     return;
                 }
-            } else if (state === null || state === undefined || tools.isArray(state)) {
-                // wrap special values in a state object
+            } else {
+                // wrap non-object values in a state object
                 state = {val: state};
             }
 
@@ -5474,8 +5474,8 @@ function Adapter(options) {
                     callback && callback(e.message);
                     return;
                 }
-            } else if (state === null || state === undefined || tools.isArray(state)) {
-                // wrap special values in a state object
+            } else {
+                // wrap non-object values in a state object
                 state = {val: state};
             }
 
@@ -5618,8 +5618,8 @@ function Adapter(options) {
                     callback && callback(e.message);
                     return;
                 }
-            } else if (state === null || state === undefined || tools.isArray(state)) {
-                // wrap special values in a state object
+            } else {
+                // wrap non-object values in a state object
                 state = {val: state};
             }
 

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -5142,6 +5142,60 @@ function Adapter(options) {
         this.sendToHostAsync = tools.promisifyNoError(this.sendToHost, this);
 
         /**
+         * Validates the object-type argument that is passed to setState
+         * @param {Record<string, any>} obj 
+         */
+        function validateSetStateObjectArgument(obj) {
+            /*
+                The following object parameters and types are allowed:
+                val:    any,     (required)
+                ack:    boolean, (optional)
+                ts:     number,  (optional)
+                q:      number,  (optional)
+                from:   string,  (optional)
+                c:      string,  (optional)
+                expire: number   (optional)
+                
+                Everything else is forbidden
+            */
+            const requiredProperties = {val: "any"};
+            const optionalProperties = {
+                ack:    "boolean",
+                ts:     "number",
+                q:      "number",
+                from:   "string",
+                c:      "string",
+                expire: "number",
+            };
+            const allowedPropertyNames = [...Object.keys(requiredProperties), ...Object.keys(optionalProperties)];
+            // Are there any forbidden properties?
+            const forbiddenProperties = Object.keys(obj).filter(k => !allowedPropertyNames.includes(k));
+            if (forbiddenProperties.length) {
+                throw new Error(`The state contains the forbidden properties ${forbiddenProperties.join(", ")}!`);
+            }
+            // Do all required properties exist?
+            const missingProperties = Object.keys(requiredProperties).filter(k => !(k in obj));
+            if (missingProperties.length) {
+                throw new Error(
+                    `The state is missing the required ${
+                        missingProperties.length === 1 ? 'property' : 'properties'
+                    } ${missingProperties.join(", ")}!`
+                );
+            }
+            // Do all properties have the correct type?
+            const propertyKeysAndTypes = [
+                ...Object.entries(requiredProperties),
+                ...Object.entries(optionalProperties)
+            ];
+            for (const [key, type] of propertyKeysAndTypes) {
+                if (type === "any") continue;
+                if (type !== typeof obj[key]) {
+                    throw new Error(`The state property "${key}" has the wrong type "${typeof obj[key]}" (should be "${type}")!`);
+                }
+            }
+        }
+
+        /**
          * Writes value into states DB.
          *
          * This function can write values into states DB for this adapter.
@@ -5196,7 +5250,16 @@ function Adapter(options) {
                 return;
             }
 
-            if (typeof state !== 'object' || state === null || state === undefined || Array.isArray(state)) {
+            if (tools.isObject(state)) {
+                // Verify that the passed state object is valid
+                try {
+                    validateSetStateObjectArgument(state);
+                } catch (e) {
+                    callback && callback(e.message);
+                    return;
+                }
+            } else if (state === null || state === undefined || tools.isArray(state)) {
+                // wrap special values in a state object
                 state = {val: state};
             }
 
@@ -5312,7 +5375,16 @@ function Adapter(options) {
                 return;
             }
 
-            if (typeof state !== 'object' || state === null || state === undefined || Array.isArray(state)){
+            if (tools.isObject(state)) {
+                // Verify that the passed state object is valid
+                try {
+                    validateSetStateObjectArgument(state);
+                } catch (e) {
+                    callback && callback(e.message);
+                    return;
+                }
+            } else if (state === null || state === undefined || tools.isArray(state)) {
+                // wrap special values in a state object
                 state = {val: state};
             }
 
@@ -5391,7 +5463,16 @@ function Adapter(options) {
                 return;
             }
 
-            if (typeof state !== 'object' || state === null || state === undefined || Array.isArray(state)) {
+            if (tools.isObject(state)) {
+                // Verify that the passed state object is valid
+                try {
+                    validateSetStateObjectArgument(state);
+                } catch (e) {
+                    callback && callback(e.message);
+                    return;
+                }
+            } else if (state === null || state === undefined || tools.isArray(state)) {
+                // wrap special values in a state object
                 state = {val: state};
             }
 
@@ -5526,7 +5607,16 @@ function Adapter(options) {
                 return;
             }
 
-            if (typeof state !== 'object' || state === null || state === undefined || Array.isArray(state)) {
+            if (tools.isObject(state)) {
+                // Verify that the passed state object is valid
+                try {
+                    validateSetStateObjectArgument(state);
+                } catch (e) {
+                    callback && callback(e.message);
+                    return;
+                }
+            } else if (state === null || state === undefined || tools.isArray(state)) {
+                // wrap special values in a state object
                 state = {val: state};
             }
 

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -5160,12 +5160,12 @@ function Adapter(options) {
             */
             const requiredProperties = {val: "any"};
             const optionalProperties = {
-                ack:    "boolean",
-                ts:     "number",
-                q:      "number",
-                from:   "string",
-                c:      "string",
-                expire: "number",
+                ack:    'boolean',
+                ts:     'number',
+                q:      'number',
+                from:   'string',
+                c:      'string',
+                expire: 'number',
             };
             const allowedPropertyNames = [...Object.keys(requiredProperties), ...Object.keys(optionalProperties)];
             // Are there any forbidden properties?
@@ -5179,7 +5179,7 @@ function Adapter(options) {
                 throw new Error(
                     `The state is missing the required ${
                         missingProperties.length === 1 ? 'property' : 'properties'
-                    } ${missingProperties.join(", ")}!`
+                    } ${missingProperties.join(', ')}!`
                 );
             }
             // Do all properties have the correct type?
@@ -5189,9 +5189,13 @@ function Adapter(options) {
             ];
             for (const [key, type] of propertyKeysAndTypes) {
                 // any permits all types
-                if (type === "any") continue;
+                if (type === 'any') {
+                    continue;
+                }
                 // don't flag optional properties when they don't exist
-                if (!(key in obj)) continue;
+                if (!(key in obj)) {
+                    continue;
+                }
                 if (type !== typeof obj[key]) {
                     throw new Error(`The state property "${key}" has the wrong type "${typeof obj[key]}" (should be "${type}")!`);
                 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,29 +37,37 @@
       "optional": true
     },
     "@sinonjs/commons": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.7.0.tgz",
-      "integrity": "sha512-qbk9AP+cZUsKdW1GJsBpxPKFmCJ0T8swwzVje3qFd+AkQb74Q/tiuzrdfFg8AD2g5HH/XbE/I8Uc1KYHVYWfhg==",
-      "optional": true,
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.7.1.tgz",
+      "integrity": "sha512-Debi3Baff1Qu1Unc3mjJ96MgpbwTn43S1+9yJ0llWygPwDNu2aaWBD6yc9y/Z8XDRNhx7U+u2UDg2OGQXkclUQ==",
       "requires": {
         "type-detect": "4.0.8"
       }
     },
+    "@sinonjs/fake-timers": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-6.0.0.tgz",
+      "integrity": "sha512-atR1J/jRXvQAb47gfzSK8zavXy7BcpnYq21ALon0U99etu99vsir0trzIO3wpeLtW+LLVY6X7EkfVTbjGSH8Ww==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.0"
+      }
+    },
     "@sinonjs/formatio": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-4.0.1.tgz",
-      "integrity": "sha512-asIdlLFrla/WZybhm0C8eEzaDNNrzymiTqHMeJl6zPW2881l3uuVRpm0QlRQEjqYWv6CcKMGYME3LbrLJsORBw==",
-      "optional": true,
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-5.0.1.tgz",
+      "integrity": "sha512-KaiQ5pBf1MpS09MuA0kp6KBQt2JUOQycqVG1NZXvzeaXe5LGFqAKueIS0bw4w0P9r7KuBSVdUk5QjXsUdu2CxQ==",
+      "dev": true,
       "requires": {
         "@sinonjs/commons": "^1",
-        "@sinonjs/samsam": "^4.2.0"
+        "@sinonjs/samsam": "^5.0.2"
       }
     },
     "@sinonjs/samsam": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-4.2.1.tgz",
-      "integrity": "sha512-7+5S4C4wpug5pzHS+z/63+XUwsH7dtyYELDafoT1QnfruFh7eFjlDWwZXltUB0GLk6y5eMeAt34Bjx8wJ4KfSA==",
-      "optional": true,
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-5.0.3.tgz",
+      "integrity": "sha512-QucHkc2uMJ0pFGjJUDP3F9dq5dx8QIaqISl9QgwLOh6P9yv877uONPGXh/OH/0zmM3tW1JjuJltAZV2l7zU+uQ==",
+      "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.6.0",
         "lodash.get": "^4.4.2",
@@ -69,8 +77,7 @@
     "@sinonjs/text-encoding": {
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
-      "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
-      "optional": true
+      "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ=="
     },
     "@types/color-name": {
       "version": "1.1.1",
@@ -81,6 +88,15 @@
       "version": "3.3.34",
       "resolved": "https://registry.npmjs.org/@types/event-stream/-/event-stream-3.3.34.tgz",
       "integrity": "sha512-LLiivgWKii4JeMzFy3trrxqkRrVSdue8WmbXyHuSJLwNrhIQU5MTrc65jhxEPwMyh5HR1xevSdD+k2nnSRKw9g==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/iobroker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@types/iobroker/-/iobroker-2.2.1.tgz",
+      "integrity": "sha512-UMLkmBPS74G+FbU9wyAl9nDPk9wVMdg4E7yzI24AZo9hu2ibLgGUvsmIaZsw+md36DNcCPmS7U7HlgY7z8gbkg==",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -4861,10 +4877,9 @@
       "dev": true
     },
     "just-extend": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.0.2.tgz",
-      "integrity": "sha512-FrLwOgm+iXrPV+5zDU6Jqu4gCRXbWEQg2O3SKONsWE4w7AXFRkryS53bpWdaL9cNol+AmR3AEYz6kn+o0fCPnw==",
-      "optional": true
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.1.0.tgz",
+      "integrity": "sha512-ApcjaOdVTJ7y4r08xI5wIqpvwS48Q0PBG4DJROcEkH1f8MdAiNFyFxz3xoL0LWAVwjrwPYZdVHHxhRHcx/uGLA=="
     },
     "jwa": {
       "version": "1.4.1",
@@ -5104,8 +5119,7 @@
     "lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
-      "optional": true
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
     },
     "lodash.includes": {
       "version": "4.3.0",
@@ -5648,16 +5662,15 @@
       "dev": true
     },
     "nise": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/nise/-/nise-3.0.1.tgz",
-      "integrity": "sha512-fYcH9y0drBGSoi88kvhpbZEsenX58Yr+wOJ4/Mi1K4cy+iGP/a73gNoyNhu5E9QxPdgTlVChfIaAlnyOy/gHUA==",
-      "optional": true,
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-4.0.3.tgz",
+      "integrity": "sha512-EGlhjm7/4KvmmE6B/UFsKh7eHykRl9VH+au8dduHLCyWUO/hr7+N+WtTvDUwc9zHuM1IaIJs/0lQ6Ag1jDkQSg==",
+      "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.7.0",
-        "@sinonjs/formatio": "^4.0.1",
+        "@sinonjs/fake-timers": "^6.0.0",
         "@sinonjs/text-encoding": "^0.7.1",
         "just-extend": "^4.0.2",
-        "lolex": "^5.0.1",
         "path-to-regexp": "^1.7.0"
       }
     },
@@ -6093,7 +6106,6 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
       "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
-      "optional": true,
       "requires": {
         "isarray": "0.0.1"
       },
@@ -6101,8 +6113,7 @@
         "isarray": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-          "optional": true
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
         }
       }
     },
@@ -6834,42 +6845,48 @@
       }
     },
     "sinon": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-8.0.2.tgz",
-      "integrity": "sha512-8W1S7BnCyvk7SK+Xi15B1QAVLuS81G/NGmWefPb31+ly6xI3fXaug/g5oUdfc8+7ruC4Ay51AxuLlYm8diq6kA==",
-      "optional": true,
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-9.0.0.tgz",
+      "integrity": "sha512-c4bREcvuK5VuEGyMW/Oim9I3Rq49Vzb0aMdxouFaA44QCFpilc5LJOugrX+mkrvikbqCimxuK+4cnHVNnLR41g==",
+      "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.7.0",
-        "@sinonjs/formatio": "^4.0.1",
-        "@sinonjs/samsam": "^4.2.1",
-        "diff": "^4.0.1",
-        "lolex": "^5.1.2",
-        "nise": "^3.0.1",
+        "@sinonjs/fake-timers": "^6.0.0",
+        "@sinonjs/formatio": "^5.0.0",
+        "@sinonjs/samsam": "^5.0.1",
+        "diff": "^4.0.2",
+        "nise": "^4.0.1",
         "supports-color": "^7.1.0"
       },
       "dependencies": {
         "diff": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.1.tgz",
-          "integrity": "sha512-s2+XdvhPCOF01LRQBC8hf4vhbVmI2CGS5aZnxLJlT5FtdhPCDFq80q++zK2KlrVorVDdL5BOGZ/VfLrVtYNF+Q==",
-          "optional": true
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+          "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+          "dev": true
         },
         "has-flag": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "optional": true
+          "dev": true
         },
         "supports-color": {
           "version": "7.1.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
           "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-          "optional": true,
+          "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
           }
         }
       }
+    },
+    "sinon-chai": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-3.5.0.tgz",
+      "integrity": "sha512-IifbusYiQBpUxxFJkR3wTU68xzBN0+bxCScEaKMjBvAQERg6FnTTc1F17rseLb1tjmkJ23730AXpFI0c47FgAg==",
+      "dev": true
     },
     "slice-ansi": {
       "version": "2.1.0",
@@ -7998,6 +8015,79 @@
         "sinon": "^8.0.2",
         "unix-dgram": "2.0.3",
         "vows": "^0.8.3"
+      },
+      "dependencies": {
+        "@sinonjs/formatio": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-4.0.1.tgz",
+          "integrity": "sha512-asIdlLFrla/WZybhm0C8eEzaDNNrzymiTqHMeJl6zPW2881l3uuVRpm0QlRQEjqYWv6CcKMGYME3LbrLJsORBw==",
+          "optional": true,
+          "requires": {
+            "@sinonjs/commons": "^1",
+            "@sinonjs/samsam": "^4.2.0"
+          }
+        },
+        "@sinonjs/samsam": {
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-4.2.2.tgz",
+          "integrity": "sha512-z9o4LZUzSD9Hl22zV38aXNykgFeVj8acqfFabCY6FY83n/6s/XwNJyYYldz6/9lBJanpno9h+oL6HTISkviweA==",
+          "optional": true,
+          "requires": {
+            "@sinonjs/commons": "^1.6.0",
+            "lodash.get": "^4.4.2",
+            "type-detect": "^4.0.8"
+          }
+        },
+        "diff": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+          "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+          "optional": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "optional": true
+        },
+        "nise": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/nise/-/nise-3.0.1.tgz",
+          "integrity": "sha512-fYcH9y0drBGSoi88kvhpbZEsenX58Yr+wOJ4/Mi1K4cy+iGP/a73gNoyNhu5E9QxPdgTlVChfIaAlnyOy/gHUA==",
+          "optional": true,
+          "requires": {
+            "@sinonjs/commons": "^1.7.0",
+            "@sinonjs/formatio": "^4.0.1",
+            "@sinonjs/text-encoding": "^0.7.1",
+            "just-extend": "^4.0.2",
+            "lolex": "^5.0.1",
+            "path-to-regexp": "^1.7.0"
+          }
+        },
+        "sinon": {
+          "version": "8.1.1",
+          "resolved": "https://registry.npmjs.org/sinon/-/sinon-8.1.1.tgz",
+          "integrity": "sha512-E+tWr3acRdoe1nXbHMu86SSqA1WGM7Yw3jZRLvlCMnXwTHP8lgFFVn5BnKnF26uc5SfZ3D7pA9sN7S3Y2jG4Ew==",
+          "optional": true,
+          "requires": {
+            "@sinonjs/commons": "^1.7.0",
+            "@sinonjs/formatio": "^4.0.1",
+            "@sinonjs/samsam": "^4.2.2",
+            "diff": "^4.0.2",
+            "lolex": "^5.1.2",
+            "nise": "^3.0.1",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "optional": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
       }
     },
     "winston-transport": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   },
   "devDependencies": {
     "@types/event-stream": "^3.3.34",
+    "@types/iobroker": "^2.2.1",
     "@types/mocha": "^7.0.1",
     "@types/node": "^13.5.0",
     "@types/yargs": "^15.0.0",
@@ -55,7 +56,9 @@
     "gulp-jsdoc3": "^2.0.0",
     "gulp-replace": "^1.0.0",
     "istanbul": "^0.4.5",
-    "mocha": "^7.0.0"
+    "mocha": "^7.0.0",
+    "sinon": "^9.0.0",
+    "sinon-chai": "^3.5.0"
   },
   "homepage": "http://www.iobroker.com",
   "description": "Updated by reinstall.js on 2018-06-11T15:19:56.688Z",


### PR DESCRIPTION
With this PR, we now validate the state object developers pass to the following methods:
* setState
* setStateChanged
* setForeignState
* setForeignStateChanged

We check that all required properties exist (i.e. `val`), that no unexpected properties exist (i.e. `{val: 1, foo: "bar"}`) and that all required and optional properties have the correct type. This means the following is now forbidden (due to all three reasons):
```
adapter.setState(id, {foo: "bar", ack: 1});
```

As discussed in #584, we could also go one step further and check that the type of `val` matches the defined type in the state object. Thoughts?

Fixes: #584