### PR TITLE
Re-introduce --prefix for Linux to avoid placing modules in parent dirs

### DIFF
--- a/lib/setup/setupInstall.js
+++ b/lib/setup/setupInstall.js
@@ -21,6 +21,7 @@ function Install(options) {
     const child_process    = require('child_process');
     const request          = require('request');
     const PacketManager    = require('./setupPacketManager');
+    const osPlatform       = require('os').platform();
 
     // todo solve it somehow
     const unsafePermAlways = [tools.appName.toLowerCase() + '.zwave', tools.appName.toLowerCase() + '.amazon-dash', tools.appName.toLowerCase() + '.xbox'];
@@ -377,9 +378,14 @@ function Install(options) {
         // We don't need --production and --save here.
         // --production doesn't do anything when installing a specific package (which we do here)
         // --save is the default since npm 3
-        // Also, set the working directory (cwd) of the process instead of using --prefix
-        // because that has ugly bugs on Windows
-        const cmd = `npm install ${npmUrl} --loglevel error${options.unsafePerm ? ' --unsafe-perm' : ''}`;
+        // Don't use --prefix on Windows, because that has ugly bugs
+        const cmd = [
+            'npm install',
+            npmUrl,
+            '--loglevel error',
+            options.unsafePerm ? '--unsafe-perm' : '',
+            osPlatform !== 'win32' ? `--prefix "${cwd}"` : ''
+        ].filter(arg => !!arg).join(' ');
 
         console.log(cmd + ' (System call)');
         // Install node modules as system call
@@ -471,9 +477,14 @@ function Install(options) {
             cwd = cwd.join('/');
         }
 
-        // Don't use --prefix here, because that has ugly bugs on Windows
+        // Don't use --prefix on Windows, because that has ugly bugs
         // Instead set the working directory (cwd) of the process
-        const cmd = `npm uninstall ${packageName} --silent --save`;
+        const cmd = [
+            'npm uninstall',
+            packageName,
+            '--silent',
+            osPlatform !== 'win32' ? `--prefix "${cwd}"` : ''
+        ].filter(arg => !!arg).join(' ');
 
         console.log(cmd + ' (System call)');
         // Install node modules as system call
@@ -680,12 +691,12 @@ function Install(options) {
 
         // Check if the operation system is ok
         if (adapterConf.common && adapterConf.common.os) {
-            if (typeof adapterConf.common.os === 'string' && adapterConf.common.os !== require('os').platform()) {
-                console.error('host.' + hostname + ' Adapter does not support current os. Required ' + adapterConf.common.os + '. Actual platform: ' + require('os').platform());
+            if (typeof adapterConf.common.os === 'string' && adapterConf.common.os !== osPlatform) {
+                console.error('host.' + hostname + ' Adapter does not support current os. Required ' + adapterConf.common.os + '. Actual platform: ' + osPlatform);
                 processExit(EXIT_CODES.INVALID_OS);
             } else {
-                if (!adapterConf.common.os.includes(require('os').platform())) {
-                    console.error('host.' + hostname + ' Adapter does not support current os. Required one of ' + adapterConf.common.os.join(', ') + '. Actual platform: ' + require('os').platform());
+                if (!adapterConf.common.os.includes(osPlatform)) {
+                    console.error('host.' + hostname + ' Adapter does not support current os. Required one of ' + adapterConf.common.os.join(', ') + '. Actual platform: ' + osPlatform);
                     processExit(EXIT_CODES.INVALID_OS);
                 }
             }


### PR DESCRIPTION
On Windows, we keep NOT using --prefix, since the installation environment is more under our control.