### PR TITLE
fix adapter exiting with wrong exit codes

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -7539,7 +7539,7 @@ function Adapter(options) {
     };
 
     const stop = (isPause, isScheduled, exitCode, updateAliveState) => {
-        exitCode = exitCode || isScheduled ? EXIT_CODES.START_IMMEDIATELY_AFTER_STOP : 0;
+        exitCode = exitCode || (isScheduled ? EXIT_CODES.START_IMMEDIATELY_AFTER_STOP : 0);
         if (updateAliveState === undefined) updateAliveState = true;
 
         if (reportInterval || config.isInstall) { // when interval is deleted we already had a stop call before


### PR DESCRIPTION
- the previous implementation will often pick the wrong exitCode
- the logic we want is, if no_error exit (0), check for schedule if yes convert zero to 156
- what it did was: if exitCode > 0 or scheduled, use 156 (-100), so every exitCode > 0 has been converted to the 156 (-100) exit code