### PR TITLE
show meta data on list files <filter>

### DIFF
--- a/lib/setup/setupList.js
+++ b/lib/setup/setupList.js
@@ -207,7 +207,9 @@ function List(options) {
         }
         if (filter) {
             filter = filter.replace(/\*/g, '');
-            if (filter[filter.length - 1] === '/') filter = filter.substring(0, filter.length - 1);
+            if (filter[filter.length - 1] === '/') {
+                filter = filter.substring(0, filter.length - 1);
+            }
         }
 
         if (adapters && adapters.length) {
@@ -215,16 +217,14 @@ function List(options) {
             this.listDirectory(adapter, filter, files => {
                 files.sort(sortFiles);
                 that.showFileHeader(adapter);
-                for (let k = 0; k < files.length; k++) {
-                    if (filter && filter !== (files[k].path + '/'+ files[k].file.file).substring(0, filter.length)) continue;
 
-                    that.showFile(files[k].adapter, files[k].path, files[k].file);
-                }
+                files.filter(f => !(filter && filter !== (f.path + '/'+ f.file.file).substring(0, filter.length))
+                     .forEach(f => that.showFile(f.adapter, f.path, f.file));
 
                 that.listAdaptersFiles(adapters, callback);
             });
         } else {
-            if (callback) callback ();
+            typeof callback === 'function' &&  callback ();
         }
     };
 
@@ -286,7 +286,7 @@ function List(options) {
                         states.getStates(keys, (err, states) => {
                             if (err) {
                                 console.error(err);
-                                processExit(EXIT_CODES.CANNOT_GET_STATES);
+                                return processExit(EXIT_CODES.CANNOT_GET_STATES);
                             }
                             for (let i = 0; i < states.length; i++) {
                                 let id = keys[i];
@@ -618,22 +618,16 @@ function List(options) {
                     objects.getObjectList({startkey: '', endkey: '\u9999'}, (err, objs) => {
                         const adapter = filter || null;
                         const names = filter ? filter.split('/') : null;
-                        if (names && !names[0]) names.splice(0, 1);
-
-                        const adapters = [];
-
-                        for (const row of objs.rows) {
-                            if (row.value.type === 'meta') {
-                                // if matches exactly or starts with <filter>. for e.g. iqontrol.meta, iqontrol.admin
-                                if (adapter && row.value._id !== names[0] && !row.value._id.startsWith(`${names[0]}.`)) continue;
-                                adapters.push(row.value._id);
-                            }
+                        if (names && !names[0]) {
+                            names.splice(0, 1);
                         }
-                        if (names) names.shift();
 
-                        that.listAdaptersFiles(adapters, names ? names.join('/') : null, function () {
-                            setTimeout(processExit, 1000, null);
-                        });
+                        const adapters = objs.rows.filter(row => row.value.type === 'meta' && !(adapter && row.value._id !== names[0] && !row.value._id.startsWith(`${names[0]}.`))).map(row => row.value._id);
+                        
+                        names && names.shift();
+
+                        that.listAdaptersFiles(adapters, names ? names.join('/') : null, () =>
+                            setTimeout(processExit, 1000, null));
                     });
                     break;
 

--- a/lib/setup/setupList.js
+++ b/lib/setup/setupList.js
@@ -211,7 +211,7 @@ function List(options) {
         }
 
         if (adapters && adapters.length) {
-            const adapter = adapters.pop();
+            const adapter = adapters.shift();
             this.listDirectory(adapter, filter, files => {
                 files.sort(sortFiles);
                 that.showFileHeader(adapter);
@@ -221,16 +221,7 @@ function List(options) {
                     that.showFile(files[k].adapter, files[k].path, files[k].file);
                 }
 
-                that.listDirectory(adapter + '.admin', filter, files => {
-                    files.sort(sortFiles);
-                    for (let k = 0; k < files.length; k++) {
-                        if (filter && filter !== (files[k].path + '/'+ files[k].file.file).substring(0, filter.length)) continue;
-
-                        that.showFile(files[k].adapter, files[k].path, files[k].file);
-                    }
-
-                    that.listAdaptersFiles(adapters, callback);
-                });
+                that.listAdaptersFiles(adapters, callback);
             });
         } else {
             if (callback) callback ();
@@ -624,22 +615,22 @@ function List(options) {
 
                 case 'files':
                 case 'f':
-                    objects.getObjectList({startkey: 'system.adapter.', endkey: 'system.adapter.\u9999'}, (err, objs) => {
+                    objects.getObjectList({startkey: '', endkey: '\u9999'}, (err, objs) => {
                         const adapter = filter || null;
                         const names = filter ? filter.split('/') : null;
                         if (names && !names[0]) names.splice(0, 1);
 
                         const adapters = [];
-                        for (let i = 0; i < objs.rows.length; i++) {
-                            if (objs.rows[i].value.type === 'adapter') {
-                                if (adapter && objs.rows[i].value.common.name !== names[0]) continue;
-                                adapters.push(objs.rows[i].value.common.name);
-                            } else if (objs.rows[i].value.type === 'instance') {
-                                if (adapter && objs.rows[i].value._id.substring(15) !== names[0]) continue;
-                                adapters.push(objs.rows[i].value._id.substring(15));
+
+                        for (const row of objs.rows) {
+                            if (row.value.type === 'meta') {
+                                // if matches exactly or starts with <filter>. for e.g. iqontrol.meta, iqontrol.admin
+                                if (adapter && row.value._id !== names[0] && !row.value._id.startsWith(`${names[0]}.`)) continue;
+                                adapters.push(row.value._id);
                             }
                         }
                         if (names) names.shift();
+
                         that.listAdaptersFiles(adapters, names ? names.join('/') : null, function () {
                             setTimeout(processExit, 1000, null);
                         });


### PR DESCRIPTION
- we can only check for meta data no need to check for instance/adapter
- show headline for every folder (do not merge `<adapter>.admin` files with `<adapter>` only files)
- filter by id, the check for name was not appropriate due to the fact, that name is sometimes a description, e.g. name of vis was 'user files and images for vis' and also name can be an object..
- you can now get only one folder not only filter for adapters, e.g. filter exactlly for `iqontrol.admin`, `iqontrol.meta`
- fixes #463 