### PR TITLE
update cache manifest correctly on visdebug

### DIFF
--- a/lib/setup/setupVisDebug.js
+++ b/lib/setup/setupVisDebug.js
@@ -53,9 +53,9 @@ function VisDebug(options) {
             // Try to find out the adapter directory out of a list of options
             const adapterNames2Try = ['vis-' + widgetset, widgetset];
             if (adapterNames2Try[0] === adapterNames2Try[1]) adapterNames2Try.splice(1, 1);
-            for (let i = 0; i < adapterNames2Try.length; i++) {
+            for (const adapterName of adapterNames2Try) {
                 try {
-                    const adapterDir2Try = tools.getAdapterDir(adapterNames2Try[i]);
+                    const adapterDir2Try = tools.getAdapterDir(adapterName);
                     // Query the entry
                     const stats = fs.statSync(adapterDir2Try);
 
@@ -70,7 +70,7 @@ function VisDebug(options) {
                 }
             }
 
-            if (!adapterDir) throw 'Adapter not found. Tried: ' + adapterNames2Try.join(', ');
+            if (!adapterDir) throw `Adapter not found. Tried: ${adapterNames2Try.join(', ')}`;
         }
 
         // copy index.html.original to index.html
@@ -86,30 +86,32 @@ function VisDebug(options) {
                     visDir = __dirname + '/../../../' + tools.appName.toLowerCase() + '.vis';
                     if (!fs.existsSync(visDir)) {
                         console.error('Cannot find ' + tools.appName + '.vis');
-                        processExit(EXIT_CODES.MISSING_ADAPTER_FILES);
+                        return processExit(EXIT_CODES.MISSING_ADAPTER_FILES);
                     }
                 }
             }
         }
 
         /** @type {string} */
-        if (fs.existsSync(visDir + '/www/index.html.original')) {
-            console.log('Upload "' + path.normalize(visDir + '/www/index.html.original') + '"');
-            const file = fs.readFileSync(visDir + '/www/index.html.original', 'utf8');
+        if (fs.existsSync(`${visDir}/www/index.html.original`)) {
+            console.log(`Upload "${path.normalize(`${visDir}/www/index.html.original`)}"`);
+            const file = fs.readFileSync(`${visDir}/www/index.html.original`, 'utf8');
             objects.writeFile('vis', 'index.html', file);
         }
 
-        if (fs.existsSync(visDir + '/www/edit.html.original')) {
-            console.log('Upload "' + path.normalize(visDir + '/www/edit.html.original') + '"');
-            const file = fs.readFileSync(visDir + '/www/edit.html.original', 'utf8');
+        if (fs.existsSync(`${visDir}/www/edit.html.original`)) {
+            console.log(`Upload "${path.normalize(`${visDir}/www/edit.html.original`)}"`);
+            const file = fs.readFileSync(`${visDir}/www/edit.html.original`, 'utf8');
             objects.writeFile('vis', 'edit.html', file);
         }
 
-        if (fs.existsSync(visDir + '/www/cache.manifest')) {
-            console.log('Modify "' + path.normalize(visDir + '/www/cache.manifest') + '"');
-            let file = fs.readFileSync(visDir + '/www/cache.manifest', 'utf8');
+        if (fs.existsSync(`${visDir}/www/cache.manifest`)) {
+            console.log(`Modify "${path.normalize(`${visDir}/www/cache.manifest`)}"`);
+            let file = fs.readFileSync(`${visDir}/www/cache.manifest`, 'utf-8');
             const n = file.match(/# dev build (\d+)/)[1];
-            file = file.replace('# dev build ' + n, '# dev build ' + (parseInt(n, 10) + 1));
+            file = file.replace(`# dev build ${n}`, `# dev build ${parseInt(n, 10) + 1}`);
+            // also update it in the vis npm dir like vis does it by itself
+            fs.writeFileSync(`${visDir}/www/cache.manifest`, file);
             objects.writeFile('vis', 'cache.manifest', file);
         }
 


### PR DESCRIPTION
- and fix process exit on non-existing vis dir (the processExit call is an async function call, which leads to the below code being executed and thus running in other errors which may be confusing for users)
- fixes #648 
- the vis logic is to not only to write the file in objects DB but also to update it in the vis directory hard on fs, see https://github.com/ioBroker/ioBroker.vis/blob/master/main.js#L121
