### PR TITLE
no longer require restart of instance after alias dp changes

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -190,6 +190,7 @@ function Adapter(options) {
 
     this.logList = [];
     this.aliases = {};
+    this.aliasPatterns = [];
 
     // TODO: Remove this backward compatibility shim in the future
     this.objects = {};
@@ -1547,7 +1548,15 @@ function Adapter(options) {
 
                     // it's a new alias, we add it to our subscription
                     if (isNewAlias) {
-                        this._addAliasSubscribe(obj, obj._id);
+                        for (const aliasPattern of this.aliasPatterns) {
+                            // check if its in our subs range, if so add it
+                            const testPattern = (aliasPattern.slice(-1) === '*') ? new RegExp(tools.pattern2RegEx(aliasPattern)) : aliasPattern;
+
+                            if (typeof testPattern === 'string' && aliasPattern === obj._id  || testPattern instanceof RegExp && testPattern.test(obj._id)) {
+                                this._addAliasSubscribe(obj, obj._id);
+                                break;
+                            }
+                        }
                     }
                 }
 
@@ -6578,6 +6587,15 @@ function Adapter(options) {
 
                     let count = aliasesIds.length + nonAliasesIds.length;
 
+                    for (let aliasPattern of pattern) {
+                        aliasPattern = aliasPattern instanceof RegExp ? JSON.stringify(aliasPattern) : aliasPattern;
+                        if (typeof aliasPattern === 'string' && (aliasPattern.startsWith(ALIAS_STARTS_WITH) || aliasPattern.includes('*'))
+                            && !this.aliasPatterns.includes(aliasPattern)) {
+                            // its a new alias conform pattern to store
+                            this.aliasPatterns.push(aliasPattern);
+                        }
+                    }
+
                     if (aliasesIds.length) {
                         if (!this._aliasObjectsSubscribed) {
                             this._aliasObjectsSubscribed = true;
@@ -6607,6 +6625,10 @@ function Adapter(options) {
                         this.getForeignObjects(pattern, null, null, options, (err, objs) => {
                             let count = 0;
                             const aliasPattern = pattern instanceof RegExp ? JSON.stringify(pattern) : pattern;
+                            if (!this.aliasPatterns.includes(aliasPattern)) {
+                                // its a new pattern to store
+                                this.aliasPatterns.push(aliasPattern);
+                            }
 
                             Object.keys(objs).forEach(id => {
                                 // If alias
@@ -6765,6 +6787,11 @@ function Adapter(options) {
                 count++;
                 adapterStates.unsubscribeUser(pattern, () =>
                     !--count && typeof callback === 'function' && callback());
+            }
+
+            // remove the pattern from alias patterns to not subscribe to further matching aliases
+            if (this.aliasPatterns.includes(aliasPattern)) {
+                this.aliasPatterns.splice(this.aliasPatterns.indexOf(aliasPattern), 1);
             }
 
             if (aliasPattern) {

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -1465,7 +1465,7 @@ function Adapter(options) {
                     this.terminate(EXIT_CODES.NO_ERROR);
                 }, 4000);
             },
-            change: (id, obj) => { // System level object changes
+            change: (id, obj) => { // System level object changes (and alias objects)
                 if (obj === 'null' || obj === '') {
                     obj = null;
                 }
@@ -1510,6 +1510,9 @@ function Adapter(options) {
                     //     ]
                     // };
 
+                    // if this.aliases is empty, or no target found its a new alias
+                    let isNewAlias = true;
+
                     Object.keys(this.aliases).forEach(sourceId => {
                         const alias = this.aliases[sourceId];
 
@@ -1517,6 +1520,8 @@ function Adapter(options) {
 
                         // Find entry for this alias
                         if (targetAlias) {
+                            isNewAlias = false;
+
                             // new sourceId or same
                             if (obj && obj.common && obj.common.alias && obj.common.alias.id) {
                                 const newSourceId = obj.common.alias.id;
@@ -1539,6 +1544,11 @@ function Adapter(options) {
                             }
                         }
                     });
+
+                    // it's a new alias, we add it to our subscription
+                    if (isNewAlias) {
+                        this._addAliasSubscribe(obj, obj._id);
+                    }
                 }
 
                 // process autosubscribe adapters
@@ -6571,7 +6581,7 @@ function Adapter(options) {
                     if (aliasesIds.length) {
                         if (!this._aliasObjectsSubscribed) {
                             this._aliasObjectsSubscribed = true;
-                            adapterObjects.subscribe(ALIAS_STARTS_WITH + '*');
+                            adapterObjects.subscribe(`${ALIAS_STARTS_WITH}*`);
                         }
 
                         this._getObjectsByArray(aliasesIds, null, options, (errors, aliasObjs) =>
@@ -6590,7 +6600,7 @@ function Adapter(options) {
                     if (typeof pattern === 'string' && (pattern === '*' || pattern.startsWith(ALIAS_STARTS_WITH)) || pattern instanceof RegExp) {
                         if (!this._aliasObjectsSubscribed) {
                             this._aliasObjectsSubscribed = true;
-                            adapterObjects.subscribe(ALIAS_STARTS_WITH + '*');
+                            adapterObjects.subscribe(`${ALIAS_STARTS_WITH}*`);
                         }
 
                         // read all aliases

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -6789,9 +6789,12 @@ function Adapter(options) {
                     !--count && typeof callback === 'function' && callback());
             }
 
-            // remove the pattern from alias patterns to not subscribe to further matching aliases
-            if (this.aliasPatterns.includes(aliasPattern)) {
-                this.aliasPatterns.splice(this.aliasPatterns.indexOf(aliasPattern), 1);
+            // if pattern known, remove it from alias patterns to not subscribe to further matching aliases
+            for (const i in this.aliasPatterns) {
+                if (this.aliasPatterns[i] === aliasPattern) {
+                    this.aliasPatterns.splice(i, 1);
+                    break;
+                }
             }
 
             if (aliasPattern) {

--- a/test/lib/testAliases.js
+++ b/test/lib/testAliases.js
@@ -657,13 +657,10 @@ function register(it, expect, context) {
                             if (id === gid + 'NotAlias') {
                                 expect(state.val).to.be.equal(2);
                                 count++;
-                            } else
-                            if (id === gAliasID + 'Star') {
+                            } else if (id === gAliasID + 'Star') {
                                 count++;
                                 expect(state.val).to.be.equal(-8);
-                            }
-                            else
-                            if (id === gid + 'Star') {
+                            } else if (id === gid + 'Star') {
                                 count++;
                                 expect(state.val).to.be.equal(10);
                             }
@@ -689,6 +686,55 @@ function register(it, expect, context) {
                                 // go to B:
                             }));
                     }))));
+    }).timeout(3000);
+
+    it(testName + 'Test newly created alias after subscribe', done => {
+        // at first we subscribe
+        context.adapter.subscribeForeignStates('*', err => {
+            // create orig object
+            expect(err).to.be.not.ok;
+            context.adapter.setForeignObject(`${gid}afterSub`, {
+                common: {
+                    name: 'for Alias',
+                    type: 'number',
+                    role: 'level',
+                    min: 0,
+                    max: 100
+                },
+                native: {},
+                type: 'state'
+            }, err => {
+                expect(err).to.be.not.ok;
+                // alias created after existing subscription
+                context.adapter.setForeignObject(`${gAliasID}afterSubAlias`, {
+                    common: {
+                        name: 'Test Alias',
+                        type: 'number',
+                        role: 'state',
+                        min: -10,
+                        max: 10,
+                        alias: {
+                            id: `${gid}afterSub`
+                        }
+                    },
+                    native: {},
+                    type: 'state'
+                }, err => {
+                    expect(err).to.be.not.ok;
+                    // listen on state changes
+                    context.onAdapterStateChanged = (id, state) => {
+                        if (id === `${gAliasID}afterSubAlias`) {
+                            expect(state.val).to.be.equal(0);
+                            done();
+                        }
+                    };
+                    // give adapter time to update alias subscription
+                    setTimeout(() => {
+                        context.states.setState(`${gid}afterSub`, 50);
+                    }, 100);
+                });
+            });
+        });
     }).timeout(3000);
 }
 

--- a/test/lib/testAliases.js
+++ b/test/lib/testAliases.js
@@ -6,174 +6,174 @@
 
 function prepareGroupsAndUsers(objects) {
     return objects.setObject('system.group.userC', {
-        '_id' : 'system.group.userC',
-        'type' : 'group',
-        'common' : {
-            'name' : {
-                'en' : 'User C',
-                'de' : 'Benutzer C',
-                'ru' : 'Пользователь',
-                'pt' : 'Do utilizador',
-                'nl' : 'Gebruiker',
-                'fr' : 'Utilisateur',
-                'it' : 'Utente',
-                'es' : 'Usuario',
-                'pl' : 'Użytkownik'
+        '_id': 'system.group.userC',
+        'type': 'group',
+        'common': {
+            'name': {
+                'en': 'User C',
+                'de': 'Benutzer C',
+                'ru': 'Пользователь',
+                'pt': 'Do utilizador',
+                'nl': 'Gebruiker',
+                'fr': 'Utilisateur',
+                'it': 'Utente',
+                'es': 'Usuario',
+                'pl': 'Użytkownik'
             },
-            'description' : {
-                'en' : 'Cannot modify everything',
-                'de' : 'Kann nicht alles ändern',
-                'ru' : 'Не может изменять все',
-                'pt' : 'Não é possível modificar tudo',
-                'nl' : 'Kan niet alles wijzigen',
-                'fr' : 'Impossible de tout modifier',
-                'it' : 'Non è possibile modificare tutto',
-                'es' : 'No se puede modificar todo',
-                'pl' : 'Nie można modyfikować wszystkiego'
+            'description': {
+                'en': 'Cannot modify everything',
+                'de': 'Kann nicht alles ändern',
+                'ru': 'Не может изменять все',
+                'pt': 'Não é possível modificar tudo',
+                'nl': 'Kan niet alles wijzigen',
+                'fr': 'Impossible de tout modifier',
+                'it': 'Non è possibile modificare tutto',
+                'es': 'No se puede modificar todo',
+                'pl': 'Nie można modyfikować wszystkiego'
             },
-            'members' : ['system.user.userC'],
-            'dontDelete' : true,
-            'url' : 'https://github.com/ioBroker/ioBroker.js-controller/archive/master.zip',
-            'meta' : 'https://raw.githubusercontent.com/ioBroker/ioBroker.js-controller/master/io-package.json',
-            'acl' : {
-                'object' : {
-                    'list' : true,
-                    'read' : true,
-                    'write' : false,
-                    'delete' : false
+            'members': ['system.user.userC'],
+            'dontDelete': true,
+            'url': 'https://github.com/ioBroker/ioBroker.js-controller/archive/master.zip',
+            'meta': 'https://raw.githubusercontent.com/ioBroker/ioBroker.js-controller/master/io-package.json',
+            'acl': {
+                'object': {
+                    'list': true,
+                    'read': true,
+                    'write': false,
+                    'delete': false
                 },
-                'state' : {
-                    'list' : true,
-                    'read' : true,
-                    'write' : true,
-                    'create' : true,
-                    'delete' : false
+                'state': {
+                    'list': true,
+                    'read': true,
+                    'write': true,
+                    'create': true,
+                    'delete': false
                 },
-                'users' : {
-                    'list' : true,
-                    'read' : true,
-                    'write' : false,
-                    'create' : false,
-                    'delete' : false
+                'users': {
+                    'list': true,
+                    'read': true,
+                    'write': false,
+                    'create': false,
+                    'delete': false
                 },
-                'other' : {
-                    'execute' : false,
-                    'http' : true,
-                    'sendto' : false
+                'other': {
+                    'execute': false,
+                    'http': true,
+                    'sendto': false
                 },
-                'file' : {
-                    'list' : true,
-                    'read' : true,
-                    'write' : false,
-                    'create' : false,
-                    'delete' : false
+                'file': {
+                    'list': true,
+                    'read': true,
+                    'write': false,
+                    'create': false,
+                    'delete': false
                 }
             }
         }
     }).then(() => objects.setObject('system.user.userC', {
-        '_id' : 'system.user.userC',
-        'common' : {
-            'name' : 'UserC',
-            'icon' : '',
-            'color' : '#44d8f1',
-            'desc' : '',
-            'enabled' : true,
-            'password' : 'pbkdf2$10000$47785e10d8e468765c06b371f45981d625274dec3f8f6261b12d67320d07e7844e1e30df575f55ed3686804fbbae442ee9503c9c93fdcff4c46b8243200e1839b77fa18f769c9f71b13f12c4002e1cee03e6fa54878a2d6a9629589bd9169459989fc63abddce94690e5744e69658be43e1a9c7b38f1535eb9946a05394ee16f3724b75e0829ece04a05ef8848509d27b7944a9e064bba9341350d39d7a7e5bc4fe1980ae6da737c9e5e79e5a5a7e969825e94302c047a6054f3524b71c52acd33f2f83b1ed026c05af514da0a2e57c2267aeb10021f9503b5db02d8cc946421604f73548ceecc2a10b44be6a5b859e43e706cc86ee36b21984fc33abf9b2d66$0c4a5d538c84116846aac1c20fdc3fdd'
+        '_id': 'system.user.userC',
+        'common': {
+            'name': 'UserC',
+            'icon': '',
+            'color': '#44d8f1',
+            'desc': '',
+            'enabled': true,
+            'password': 'pbkdf2$10000$47785e10d8e468765c06b371f45981d625274dec3f8f6261b12d67320d07e7844e1e30df575f55ed3686804fbbae442ee9503c9c93fdcff4c46b8243200e1839b77fa18f769c9f71b13f12c4002e1cee03e6fa54878a2d6a9629589bd9169459989fc63abddce94690e5744e69658be43e1a9c7b38f1535eb9946a05394ee16f3724b75e0829ece04a05ef8848509d27b7944a9e064bba9341350d39d7a7e5bc4fe1980ae6da737c9e5e79e5a5a7e969825e94302c047a6054f3524b71c52acd33f2f83b1ed026c05af514da0a2e57c2267aeb10021f9503b5db02d8cc946421604f73548ceecc2a10b44be6a5b859e43e706cc86ee36b21984fc33abf9b2d66$0c4a5d538c84116846aac1c20fdc3fdd'
         },
-        'type' : 'user',
-        'native' : {},
-        'from' : 'system.adapter.admin.0',
-        'user' : 'system.user.admin',
-        'ts' : 1534947164702,
-        'acl' : {
-            'object' : 1636, // 0664
-            'owner' : 'system.user.admin',
-            'ownerGroup' : 'system.group.administrator'
+        'type': 'user',
+        'native': {},
+        'from': 'system.adapter.admin.0',
+        'user': 'system.user.admin',
+        'ts': 1534947164702,
+        'acl': {
+            'object': 1636, // 0664
+            'owner': 'system.user.admin',
+            'ownerGroup': 'system.group.administrator'
         }
     })).then(() => objects.setObject('system.group.userD', {
-        '_id' : 'system.group.userD',
-        'type' : 'group',
-        'common' : {
-            'name' : {
-                'en' : 'User D',
-                'de' : 'Benutzer D',
-                'ru' : 'Пользователь',
-                'pt' : 'Do utilizador',
-                'nl' : 'Gebruiker',
-                'fr' : 'Utilisateur',
-                'it' : 'Utente',
-                'es' : 'Usuario',
-                'pl' : 'Użytkownik'
+        '_id': 'system.group.userD',
+        'type': 'group',
+        'common': {
+            'name': {
+                'en': 'User D',
+                'de': 'Benutzer D',
+                'ru': 'Пользователь',
+                'pt': 'Do utilizador',
+                'nl': 'Gebruiker',
+                'fr': 'Utilisateur',
+                'it': 'Utente',
+                'es': 'Usuario',
+                'pl': 'Użytkownik'
             },
-            'description' : {
-                'en' : 'Cannot modify everything',
-                'de' : 'Kann nicht alles ändern',
-                'ru' : 'Не может изменять все',
-                'pt' : 'Não é possível modificar tudo',
-                'nl' : 'Kan niet alles wijzigen',
-                'fr' : 'Impossible de tout modifier',
-                'it' : 'Non è possibile modificare tutto',
-                'es' : 'No se puede modificar todo',
-                'pl' : 'Nie można modyfikować wszystkiego'
+            'description': {
+                'en': 'Cannot modify everything',
+                'de': 'Kann nicht alles ändern',
+                'ru': 'Не может изменять все',
+                'pt': 'Não é possível modificar tudo',
+                'nl': 'Kan niet alles wijzigen',
+                'fr': 'Impossible de tout modifier',
+                'it': 'Non è possibile modificare tutto',
+                'es': 'No se puede modificar todo',
+                'pl': 'Nie można modyfikować wszystkiego'
             },
-            'members' : ['system.user.userD'],
-            'dontDelete' : true,
-            'url' : 'https://github.com/ioBroker/ioBroker.js-controller/archive/master.zip',
-            'meta' : 'https://raw.githubusercontent.com/ioBroker/ioBroker.js-controller/master/io-package.json',
-            'acl' : {
-                'object' : {
-                    'list' : true,
-                    'read' : true,
-                    'write' : false,
-                    'delete' : false
+            'members': ['system.user.userD'],
+            'dontDelete': true,
+            'url': 'https://github.com/ioBroker/ioBroker.js-controller/archive/master.zip',
+            'meta': 'https://raw.githubusercontent.com/ioBroker/ioBroker.js-controller/master/io-package.json',
+            'acl': {
+                'object': {
+                    'list': true,
+                    'read': true,
+                    'write': false,
+                    'delete': false
                 },
-                'state' : {
-                    'list' : true,
-                    'read' : true,
-                    'write' : true,
-                    'create' : true,
-                    'delete' : false
+                'state': {
+                    'list': true,
+                    'read': true,
+                    'write': true,
+                    'create': true,
+                    'delete': false
                 },
-                'users' : {
-                    'list' : true,
-                    'read' : true,
-                    'write' : false,
-                    'create' : false,
-                    'delete' : false
+                'users': {
+                    'list': true,
+                    'read': true,
+                    'write': false,
+                    'create': false,
+                    'delete': false
                 },
-                'other' : {
-                    'execute' : false,
-                    'http' : true,
-                    'sendto' : false
+                'other': {
+                    'execute': false,
+                    'http': true,
+                    'sendto': false
                 },
-                'file' : {
-                    'list' : true,
-                    'read' : true,
-                    'write' : false,
-                    'create' : false,
-                    'delete' : false
+                'file': {
+                    'list': true,
+                    'read': true,
+                    'write': false,
+                    'create': false,
+                    'delete': false
                 }
             }
         }
     }).then(() => objects.setObject('system.user.userD', {
-        '_id' : 'system.user.userD',
-        'common' : {
-            'name' : 'UserC',
-            'icon' : '',
-            'color' : '#44d8f1',
-            'desc' : '',
-            'enabled' : true,
-            'password' : 'pbkdf2$10000$47785e10d8e468765c06b371f45981d625274dec3f8f6261b12d67320d07e7844e1e30df575f55ed3686804fbbae442ee9503c9c93fdcff4c46b8243200e1839b77fa18f769c9f71b13f12c4002e1cee03e6fa54878a2d6a9629589bd9169459989fc63abddce94690e5744e69658be43e1a9c7b38f1535eb9946a05394ee16f3724b75e0829ece04a05ef8848509d27b7944a9e064bba9341350d39d7a7e5bc4fe1980ae6da737c9e5e79e5a5a7e969825e94302c047a6054f3524b71c52acd33f2f83b1ed026c05af514da0a2e57c2267aeb10021f9503b5db02d8cc946421604f73548ceecc2a10b44be6a5b859e43e706cc86ee36b21984fc33abf9b2d66$0c4a5d538c84116846aac1c20fdc3fdd'
+        '_id': 'system.user.userD',
+        'common': {
+            'name': 'UserC',
+            'icon': '',
+            'color': '#44d8f1',
+            'desc': '',
+            'enabled': true,
+            'password': 'pbkdf2$10000$47785e10d8e468765c06b371f45981d625274dec3f8f6261b12d67320d07e7844e1e30df575f55ed3686804fbbae442ee9503c9c93fdcff4c46b8243200e1839b77fa18f769c9f71b13f12c4002e1cee03e6fa54878a2d6a9629589bd9169459989fc63abddce94690e5744e69658be43e1a9c7b38f1535eb9946a05394ee16f3724b75e0829ece04a05ef8848509d27b7944a9e064bba9341350d39d7a7e5bc4fe1980ae6da737c9e5e79e5a5a7e969825e94302c047a6054f3524b71c52acd33f2f83b1ed026c05af514da0a2e57c2267aeb10021f9503b5db02d8cc946421604f73548ceecc2a10b44be6a5b859e43e706cc86ee36b21984fc33abf9b2d66$0c4a5d538c84116846aac1c20fdc3fdd'
         },
-        'type' : 'user',
-        'native' : {},
-        'from' : 'system.adapter.admin.0',
-        'user' : 'system.user.admin',
-        'ts' : 1534947164702,
-        'acl' : {
-            'object' : 1636, // 0664
-            'owner' : 'system.user.admin',
-            'ownerGroup' : 'system.group.administrator'
+        'type': 'user',
+        'native': {},
+        'from': 'system.adapter.admin.0',
+        'user': 'system.user.admin',
+        'ts': 1534947164702,
+        'acl': {
+            'object': 1636, // 0664
+            'owner': 'system.user.admin',
+            'ownerGroup': 'system.group.administrator'
         }
     })));
 }
@@ -732,6 +732,62 @@ function register(it, expect, context) {
                     setTimeout(() => {
                         context.states.setState(`${gid}afterSub`, 50);
                     }, 100);
+                });
+            });
+        });
+    }).timeout(3000);
+
+    it(testName + 'Test newly created alias after partial subscribe', done => {
+        // at first we subscribe, but only partial
+        context.adapter.unsubscribeForeignStates('*', () => {
+            context.adapter.subscribeForeignStates(`${gAliasID}okay*`, err => {
+                // create orig object
+                expect(err).to.be.not.ok;
+                context.adapter.setForeignObject(`${gid}partialOrig`, {
+                    common: {
+                        name: 'for Alias',
+                        type: 'number',
+                        role: 'level',
+                        min: 0,
+                        max: 100
+                    },
+                    native: {},
+                    type: 'state'
+                }, err => {
+                    expect(err).to.be.not.ok;
+                    // alias created after existing subscription which does not match pattern
+                    context.adapter.setForeignObject(`${gAliasID}notOkay`, {
+                        common: {
+                            name: 'Test Alias',
+                            type: 'number',
+                            role: 'state',
+                            min: -10,
+                            max: 10,
+                            alias: {
+                                id: `${gid}partialOrig`
+                            }
+                        },
+                        native: {},
+                        type: 'state'
+                    }, err => {
+                        expect(err).to.be.not.ok;
+                        // listen on state changes
+
+                        context.onAdapterStateChanged = (id) => {
+                            if (id === `${gAliasID}notOkay`) {
+                                clearTimeout(doneTimer);
+                                expect('Sparta').to.be.equal('Athens');
+                            }
+                        };
+
+                        // give adapter time to update alias subscription
+                        setTimeout(() => {
+                            context.states.setState(`${gid}partialOrig`, 50);
+                        }, 100);
+
+                        // if state change not triggered in 1 sec -> pass
+                        const doneTimer = setTimeout(done, 1000);
+                    });
                 });
             });
         });


### PR DESCRIPTION
- fixes #659 
- draft, because we have to discuss the following:

If an ALIAS DP falls into the foreign subscription range (subscription starts with 'alias.', then adapter.js subscribes to 'alias.*'. Now to be correct, we would have to store all subscribed patterns and check if a newly created alias really falls in this range on object change, to decide if we add this specific alias dp or not. 

Another (IMHO cleaner) option would be to only subscribe to the defined alias pattern instead of on all aliases, thus we would only get object changes that fall in the range of the subscription. Which means we would replace e. g. https://github.com/ioBroker/ioBroker.js-controller/blob/master/lib/adapter.js#L6572-L6575 by ` to subscribe only the specific pattern.

All in all, it is to say, that this scenario only kicks in, when an adapter subscribes alias states only partial e.g. `alias.0.homeatic*` which is probably never done.

EDIT: should be all working now