### PR TITLE
make states/objects db file write configurable 

### DIFF
--- a/conf/iobroker-dist.json
+++ b/conf/iobroker-dist.json
@@ -32,6 +32,7 @@
         "pass": "",
         "noFileCache": false,
         "connectTimeout": 2000,
+        "writeFileInterval": 5000,
         "options": {
             "auth_pass" : null,
             "retry_max_delay" : 5000
@@ -57,6 +58,7 @@
         "user": "",
         "pass": "",
         "connectTimeout": 2000,
+        "writeFileInterval": 30000,
         "options": {
             "auth_pass" : null,
             "retry_max_delay" : 5000

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -6480,8 +6480,8 @@ function Adapter(options) {
                     typeof callback === 'function' && callback();
                 }
             } else {
-                logger.warn(this.namespaceLog + ' ' + `Alias ${pattern} has no target 12`);
-                typeof callback === 'function' && callback(`Alias ${pattern} has no target 12`);
+                logger.warn(`${this.namespaceLog} Alias ${aliasObj._id} has no target 12`);
+                typeof callback === 'function' && callback(`Alias ${aliasObj._id} has no target 12`);
             }
         };
 

--- a/lib/objects/objectsInMemFileDB.js
+++ b/lib/objects/objectsInMemFileDB.js
@@ -47,6 +47,9 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
         this.preserveSettings = ['custom'];
         this.defaultNewAcl = this.settings.defaultNewAcl || null;
         this.namespace = this.settings.namespace || this.settings.hostname || '';
+        this.writeFileInterval = this.settings.connection && typeof this.settings.connection.writeFileInterval === 'number' ?
+            parseInt(this.settings.connection.writeFileInterval) : 5000;
+        this.log.silly(`${this.namespace} Objects DB uses file write interval of ${this.writeFileInterval} ms`);
 
         this.objectsDir = path.join(this.dataDir, 'files');
 
@@ -1368,7 +1371,7 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
                 list.push(JSON.parse(JSON.stringify(this.dataset[keys[k]])));
             }
             typeof callback === 'function' && setImmediate(() => callback(null, list));
-            if (!this.stateTimer) this.stateTimer = setTimeout(() => this.saveState(), 5000);
+            if (!this.stateTimer) this.stateTimer = setTimeout(() => this.saveState(), this.writeFileInterval);
         });
     }
     chownObject(pattern, options, callback) {
@@ -1443,7 +1446,7 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
                 list.push(JSON.parse(JSON.stringify(this.dataset[keys[k]])));
             }
             typeof callback === 'function' && setImmediate(() => callback(null, list));
-            if (!this.stateTimer) this.stateTimer = setTimeout(() => this.saveState(), 5000);
+            if (!this.stateTimer) this.stateTimer = setTimeout(() => this.saveState(), this.writeFileInterval);
         });
     }
     chmodObject(pattern, options, callback) {
@@ -1795,7 +1798,7 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
 
         setImmediate(() => this.publishAll('objects', id, obj));
 
-        this.stateTimer = this.stateTimer || setTimeout(() => this.saveState(), 5000);
+        this.stateTimer = this.stateTimer || setTimeout(() => this.saveState(), this.writeFileInterval);
     }
 
     /**
@@ -1860,7 +1863,7 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
 
             setImmediate(() => this.publishAll('objects', id, null));
 
-            if (!this.stateTimer) this.stateTimer = setTimeout(() => this.saveState(), 5000);
+            if (!this.stateTimer) this.stateTimer = setTimeout(() => this.saveState(), this.writeFileInterval);
         } else {
             typeof callback === 'function' && setImmediate(() => callback(utils.ERRORS.ERROR_NOT_FOUND));
         }
@@ -2163,7 +2166,7 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
 
         setImmediate(obj => this.publishAll('objects', id, obj), this.dataset[id]);
 
-        this.stateTimer = this.stateTimer || setTimeout(() => this.saveState(), 5000);
+        this.stateTimer = this.stateTimer || setTimeout(() => this.saveState(), this.writeFileInterval);
     }
     extendObject(id, obj, options, callback) {
         if (typeof options === 'function') {

--- a/lib/states/statesInMemFileDB.js
+++ b/lib/states/statesInMemFileDB.js
@@ -61,6 +61,9 @@ class StatesInMemoryFileDB extends InMemoryFileDB {
         this.sessionExpires = {};
         this.ONE_DAY_IN_SECS = 24*60*60*1000;
         this.adapterSubs = [];
+        this.writeFileInterval = this.settings.connection && typeof this.settings.connection.writeFileInterval === 'number' ?
+            parseInt(this.settings.connection.writeFileInterval) : 30000;
+        this.log.silly(`${this.namespace} States DB uses file write interval of ${this.writeFileInterval} ms`);
 
         //this.settings.connection.maxQueue = this.settings.connection.maxQueue || 1000;
 
@@ -81,7 +84,7 @@ class StatesInMemoryFileDB extends InMemoryFileDB {
             }
         });
 
-        if (!this.stateTimer) this.stateTimer = setTimeout(() => this.saveState(), 30000);
+        if (!this.stateTimer) this.stateTimer = setTimeout(() => this.saveState(), this.writeFileInterval);
     }
 
     expireState(id, dontPublish) {
@@ -94,7 +97,7 @@ class StatesInMemoryFileDB extends InMemoryFileDB {
             !dontPublish && setImmediate(() => this.publishAll('state', id, null));
         }
 
-        if (!this.stateTimer) this.stateTimer = setTimeout(() => this.saveState(), 30000);
+        if (!this.stateTimer) this.stateTimer = setTimeout(() => this.saveState(), this.writeFileInterval);
     }
 
     expireSession(id) {
@@ -261,18 +264,18 @@ class StatesInMemoryFileDB extends InMemoryFileDB {
         // If val === undefined, the state was just created and not filled with value
         if (obj.val !== undefined) setImmediate(() => {
             // publish event in states
-            this.log.silly(this.namespace + ' memory publish ' + id + ' ' + JSON.stringify(obj));
+            this.log.silly(`${this.namespace} memory publish ${id} ${JSON.stringify(obj)}`);
             this.publishAll('state', id, obj);
         });
 
-        if (!this.stateTimer) this.stateTimer = setTimeout(() => this.saveState(), 30000);
+        if (!this.stateTimer) this.stateTimer = setTimeout(() => this.saveState(), this.writeFileInterval);
     }
 
     setRawState(id, state, callback) {
         this.dataset[id] = state;
         typeof callback === 'function' && setImmediate(() => callback(null, id));
 
-        if (!this.stateTimer) this.stateTimer = setTimeout(() => this.saveState(), 30000);
+        if (!this.stateTimer) this.stateTimer = setTimeout(() => this.saveState(), this.writeFileInterval);
     }
 
     delState(id, callback) {
@@ -291,7 +294,7 @@ class StatesInMemoryFileDB extends InMemoryFileDB {
             typeof callback === 'function' && setImmediate(callback, null, id);
         }
 
-        if (!this.stateTimer) this.stateTimer = setTimeout(() => this.saveState(), 30000);
+        if (!this.stateTimer) this.stateTimer = setTimeout(() => this.saveState(), this.writeFileInterval);
     }
 
     getKeys(pattern, callback, _dontModify) {
@@ -540,7 +543,7 @@ class StatesInMemoryFileDB extends InMemoryFileDB {
         this.dataset[id] = data;
         typeof callback === 'function' && setImmediate(() => callback(null, id));
 
-        if (!this.stateTimer) this.stateTimer = setTimeout(() => this.saveState(), 30000);
+        if (!this.stateTimer) this.stateTimer = setTimeout(() => this.saveState(), this.writeFileInterval);
     }
 
     getBinaryState(id, callback) {
@@ -557,7 +560,7 @@ class StatesInMemoryFileDB extends InMemoryFileDB {
         }
         typeof callback === 'function' && setImmediate(() => callback(null, id));
 
-        if (!this.stateTimer) this.stateTimer = setTimeout(() => this.saveState(), 30000);
+        if (!this.stateTimer) this.stateTimer = setTimeout(() => this.saveState(), this.writeFileInterval);
     }
 }
 


### PR DESCRIPTION
- only in iobroker.json
- closes #730
- logging adjustment on alias warning

@Apollon77 should we also add an option to make the file write intervals configurable via cli? Probably this is such an edge case, that it's enough to have it in iobroker.json?