### PR TITLE
introduce possibility to use different states for alias read and write

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,9 +356,12 @@ Effectively an `alias` object will mirror the state value of the target object.
 If allowed, both states can be changed and are synced automatically by the ioBroker core system.
 Also both states can be used to subscribe in scripts and should behave exactly identical.
 
-Additionally to defining the target ID theAlias object can also define "read and write functions" to do easy value conversions, so e.g.
+Additionally to defining the target ID the alias object can also define "read and write functions" to do easy value conversions, so e.g.
 the target state could contain a power measurement value in Wh (because an adapter delivers the value that way)
 and the alias could use the same value calculated as kWh.
+
+Some devices have separate states for semantically one state. One to read the current status from and one to write to, to
+control the device. You can combine these states into one alias by using a separate alias id to write to and  another to read from.
 
 As of now (js-controller 2.0.0 release) there are no front-ends to configure alias.
 To create an alias object simple create a new object with a own name in the `alias.0` namespace and add the alias definition in the common section (here for an alias with the id `"alias.0.aliasName"`):
@@ -382,9 +385,37 @@ To create an alias object simple create a new object with a own name in the `ali
     type: 'state'
 }
 ```
+
+or using different read and write ids:
+
+```
+{
+    _id: "alias.0.aliasName",
+    common: {
+        name: 'Test AliasC',
+        type: 'number',
+        role: 'state',
+        min: -10,
+        max: 10,
+        alias: {
+            id: {
+                read: 'state.id.to.read.from',
+                write: 'state.id.to.write.to'
+            }
+            read: 'val * 10 + 1',
+            write: '(val - 1) / 10'
+        }
+    },
+    native: {},
+    type: 'state'
+}
+```
+
 The following fields are allowed in the alias structure:
 
-* `alias.id` contains the ID of the target object/state to mirror
+* `alias.id` contains the ID of the target object/state to mirror or represents an object with the following two properties:
+    * `alias.id.write` contains the ID of the object which will be set when alias is written
+    * `alias.id.read` contains the ID of the object which will be mirrored to the alias object/state   
 * `alias.read` can optionally contain a read script (will be evaluated) to calculate the alias value when the target state changes
 * `alias.write` can optionally contain a write script (will be evaluated) to calculate the target value if the alias value is changed
 

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -1477,7 +1477,7 @@ function Adapter(options) {
                 }
 
                 // If desired, that adapter must be terminated
-                if (id === 'system.adapter.' + this.namespace && obj && obj.common && obj.common.enabled === false) {
+                if (id === `system.adapter.${this.namespace}` && obj && obj.common && obj.common.enabled === false) {
                     logger.info(this.namespaceLog + ' Adapter is disabled => stop');
                     stop();
                     setTimeout(() => this.terminate(EXIT_CODES.NO_ERROR), 4000);
@@ -1525,7 +1525,9 @@ function Adapter(options) {
 
                             // new sourceId or same
                             if (obj && obj.common && obj.common.alias && obj.common.alias.id) {
-                                const newSourceId = obj.common.alias.id;
+                                // check if id.read or id
+                                const newSourceId = typeof obj.common.alias.id.read === 'string' ? obj.common.alias.id.read : obj.common.alias.id;
+
 
                                 // if linked ID changed
                                 if (newSourceId !== sourceId) {
@@ -1738,7 +1740,7 @@ function Adapter(options) {
                 try {
                     validateId(id);
                 } catch (err) {
-                    logger.error(tools.appendStackTrace(this.namespaceLog + ' ' + err.message));
+                    logger.error(tools.appendStackTrace(`${this.namespaceLog} ${err.message}`));
                     return;
                 }
             }
@@ -2048,8 +2050,31 @@ function Adapter(options) {
                 }
             }
 
-            if (obj.common && obj.common.alias && obj.common.alias.id && obj.common.alias.id.startsWith(ALIAS_STARTS_WITH)) {
-                return typeof callback === 'function' && callback('Aliases cannot be used as target for aliases');
+            // check that alias is valid if given
+            if (obj.common && obj.common.alias && obj.common.alias.id) {
+                // if alias is object validate read and write
+                if (typeof obj.common.alias.id === 'object') {
+                    try {
+                        validateId(obj.common.alias.id.write);
+                        validateId(obj.common.alias.id.read);
+                    } catch (e) {
+                        return typeof callback === 'function' && callback(`Alias id is invalid: ${e.message}`);
+                    }
+
+                    if (obj.common.alias.id.write.startsWith(ALIAS_STARTS_WITH) || obj.common.alias.id.read.startsWith(ALIAS_STARTS_WITH)) {
+                        return typeof callback === 'function' && callback('Aliases cannot be used as target for aliases');
+                    }
+                } else {
+                    try {
+                        validateId(obj.common.alias.id);
+                    } catch (e) {
+                        return typeof callback === 'function' && callback(`Alias id is invalid: ${e.message}`);
+                    }
+
+                    if (obj.common.alias.id.startsWith(ALIAS_STARTS_WITH)) {
+                        return typeof callback === 'function' && callback('Aliases cannot be used as target for aliases');
+                    }
+                }
             }
 
             setObjectWithDefaultValue(id, obj, options, callback);
@@ -4789,9 +4814,11 @@ function Adapter(options) {
         if (id.startsWith(ALIAS_STARTS_WITH)) {
             adapterObjects.getObject(id, (err, obj) => {
                 if (obj && obj.common && obj.common.alias && obj.common.alias.id) {
-                    _setStateChangedHelper(obj.common.alias.id, state, callback);
+                    // id can be string or can have attribute write
+                    const aliasId = typeof obj.common.alias.id.write === 'string' ? obj.common.alias.id.write : obj.common.alias.id;
+                    _setStateChangedHelper(aliasId, state, callback);
                 } else {
-                    logger.warn(this.namespaceLog + ' ' + (err || `Alias ${id} has no target 1`));
+                    logger.warn(`${this.namespaceLog} ${err || `Alias ${id} has no target 1`}`);
                     callback(err || `Alias ${id} has no target`);
                 }
             });
@@ -4930,7 +4957,7 @@ function Adapter(options) {
                     }
                 }
 
-                if (id === 'system.adapter.' + this.namespace + '.logLevel') {
+                if (id === `system.adapter.${this.namespace}.logLevel`) {
                     if (config && config.log && state && !state.ack) {
                         let currentLevel = config.log.level;
                         if (state.val && state.val !== currentLevel && ['silly', 'debug', 'info', 'warn', 'error'].includes(state.val)) {
@@ -4940,26 +4967,26 @@ function Adapter(options) {
                                 if (!logger.transports.hasOwnProperty(transport)) continue;
                                 logger.transports[transport].level = state.val;
                             }
-                            logger.info(this.namespaceLog + ' Loglevel changed from "' + currentLevel + '" to "' + state.val + '"');
+                            logger.info(`${this.namespaceLog} Loglevel changed from "${currentLevel}" to "${state.val}"`);
                             currentLevel = state.val;
                         } else if (state.val && state.val !== currentLevel) {
-                            logger.info(this.namespaceLog + ' Got invalid loglevel "' + state.val + '", ignoring');
+                            logger.info(`${this.namespaceLog} Got invalid loglevel "${state.val}", ignoring`);
                         }
-                        adapterStates && adapterStates.setState('system.adapter.' + this.namespace + '.logLevel', {
+                        adapterStates && adapterStates.setState(`system.adapter.${this.namespace}.logLevel`, {
                             val: currentLevel,
                             ack: true,
-                            from: 'system.adapter.' + this.namespace
+                            from: `system.adapter.${this.namespace}`
                         });
                     }
                 }
 
                 // todo remove it as an error with log will be found
-                if (id === 'system.adapter.' + this.namespace + '.checkLogging') {
+                if (id === `system.adapter.${this.namespace}.checkLogging`) {
                     checkLogging();
                 }
 
                 // someone subscribes or unsubscribes from adapter
-                if (options.subscribable && id === 'system.adapter.' + this.namespace + '.subscribes') {
+                if (options.subscribable && id === `system.adapter.${this.namespace}.subscribes`) {
                     let subs;
                     try {
                         subs = JSON.parse(state.val || '{}');
@@ -4989,11 +5016,11 @@ function Adapter(options) {
                     logger && logger.debug(this.namespaceLog + ' ' + instance + ': logging ' + (state ? state.val : false));
                     this.logRedirect(state ? state.val : false, instance);
                 } else
-                if (id === 'log.system.adapter.' + this.namespace) {
+                if (id === `log.system.adapter.${this.namespace}`) {
                     options.logTransporter && this.processLog && this.processLog(state);
                 } else
                 // If this is messagebox
-                if (id === 'messagebox.system.adapter.' + this.namespace && state) {
+                if (id === `messagebox.system.adapter.${this.namespace}` && state) {
                     const obj = state;
                     if (obj) {
                         // If callback stored for this request
@@ -5425,14 +5452,25 @@ function Adapter(options) {
                         if (id.startsWith(ALIAS_STARTS_WITH)) {
                             // write alias
                             if (obj && obj.common && obj.common.alias && obj.common.alias.id) {
+                                // id can be string or can have attribute write
+                                const aliasId = typeof obj.common.alias.id.write === 'string' ? obj.common.alias.id.write : obj.common.alias.id;
+
+                                // validate here because we use objects/states db directly
+                                try {
+                                    validateId(aliasId);
+                                } catch (e) {
+                                    logger.warn(`${this.namespaceLog} Error validating alias id of ${id}: ${e.message}`);
+                                    callback(`Error validating alias id of ${id}: ${e.message}`)
+                                }
+
                                 // check the rights
-                                checkStates(obj.common.alias.id, options, 'setState', (err, targetObj) => {
+                                checkStates(aliasId, options, 'setState', (err, targetObj) => {
                                     if (err) {
                                         typeof callback === 'function' && callback(err);
                                     } else {
                                         // write target state
                                         this.outputCount++;
-                                        adapterStates.setState(obj.common.alias.id, tools.formatAliasValue(obj && obj.common, targetObj && targetObj.common, state, logger, this.namespaceLog), callback);
+                                        adapterStates.setState(aliasId, tools.formatAliasValue(obj && obj.common, targetObj && targetObj.common, state, logger, this.namespaceLog), callback);
                                     }
                                 });
                             } else {
@@ -5456,11 +5494,21 @@ function Adapter(options) {
                     // read alias id
                     adapterObjects.getObject(id, options, (err, obj) => {
                         if (obj && obj.common && obj.common.alias && obj.common.alias.id) {
+                            const aliasId = typeof obj.common.alias.id.write === 'string' ? obj.common.alias.id.write : obj.common.alias.id;
+
+                            // validate here because we use objects/states db directly
+                            try {
+                                validateId(aliasId);
+                            } catch (e) {
+                                logger.warn(`${this.namespaceLog} Error validating alias id of ${id}: ${e.message}`);
+                                callback(`Error validating alias id of ${id}: ${e.message}`)
+                            }
+
                             // read object for formatting
-                            adapterObjects.getObject(obj.common.alias.id, options, (err, targetObj) => {
+                            adapterObjects.getObject(aliasId, options, (err, targetObj) => {
                                 // write target state
                                 this.outputCount++;
-                                adapterStates.setState(obj.common.alias.id, tools.formatAliasValue(obj && obj.common, targetObj && targetObj.common, state, logger, this.namespaceLog), callback);
+                                adapterStates.setState(aliasId, tools.formatAliasValue(obj && obj.common, targetObj && targetObj.common, state, logger, this.namespaceLog), callback);
                             });
                         } else {
                             logger.warn(`${this.namespaceLog} ${err || `Alias ${id} has no target 3`}`);
@@ -5648,7 +5696,7 @@ function Adapter(options) {
 
             if (!id || typeof id !== 'string') {
                 const warn = id ? `ID can be only string and not "${typeof id}"` : `Empty ID: ${JSON.stringify(state)}`;
-                logger.warn(this.namespaceLog + ' ' + warn);
+                logger.warn(`${this.namespaceLog} ${warn}`);
                 return (typeof callback === 'function') && callback(warn);
             }
 
@@ -5666,13 +5714,24 @@ function Adapter(options) {
                         if (id.startsWith(ALIAS_STARTS_WITH)) {
                             // write alias
                             if (obj && obj.common && obj.common.alias && obj.common.alias.id) {
+                                // id can be string or can have attribute write
+                                const aliasId = typeof obj.common.alias.id.write === 'string' ? obj.common.alias.id.write : obj.common.alias.id;
+
+                                // validate here because we use objects/states db directly
+                                try {
+                                    validateId(aliasId);
+                                } catch (e) {
+                                    logger.warn(`${this.namespaceLog} Error validating alias id of ${id}: ${e.message}`);
+                                    callback(`Error validating alias id of ${id}: ${e.message}`)
+                                }
+
                                 // check the rights
-                                checkStates(obj.common.alias.id, options, 'setState', (err, targetObj) => {
+                                checkStates(aliasId, options, 'setState', (err, targetObj) => {
                                     if (err) {
                                         typeof callback === 'function' && callback(err);
                                     } else {
                                         this.outputCount++;
-                                        adapterStates.setState(obj.common.alias.id, tools.formatAliasValue(obj && obj.common, targetObj && targetObj.common, state, logger, this.namespaceLog), callback);
+                                        adapterStates.setState(aliasId, tools.formatAliasValue(obj && obj.common, targetObj && targetObj.common, state, logger, this.namespaceLog), callback);
                                     }
                                 });
                             } else {
@@ -5696,13 +5755,24 @@ function Adapter(options) {
                     // read alias id
                     adapterObjects.getObject(id, options, (err, obj) => {
                         if (obj && obj.common && obj.common.alias && obj.common.alias.id) {
+                            // alias id can be a string or can have id.write
+                            const aliasId = typeof obj.common.alias.id.write === 'string' ? obj.common.alias.id.write : obj.common.alias.id;
+
+                            // validate here because we use objects/states db directly
+                            try {
+                                validateId(aliasId);
+                            } catch (e) {
+                                logger.warn(`${this.namespaceLog} Error validating alias id of ${id}: ${e.message}`);
+                                callback(`Error validating alias id of ${id}: ${e.message}`)
+                            }
+
                             // read object for formatting
-                            adapterObjects.getObject(obj.common.alias.id, options, (err, targetObj) => {
+                            adapterObjects.getObject(aliasId, options, (err, targetObj) => {
                                 this.outputCount++;
-                                adapterStates.setState(obj.common.alias.id, tools.formatAliasValue(obj && obj.common, targetObj && targetObj.common, state, logger, this.namespaceLog), callback);
+                                adapterStates.setState(aliasId, tools.formatAliasValue(obj && obj.common, targetObj && targetObj.common, state, logger, this.namespaceLog), callback);
                             });
                         } else {
-                            logger.warn(this.namespaceLog + ' ' + (err || `Alias ${id} has no target 5`));
+                            logger.warn(`${this.namespaceLog} ${err || `Alias ${id} has no target 5`}`);
                             callback(err || `Alias ${id} has no target`);
                         }
                     });
@@ -5876,15 +5946,26 @@ function Adapter(options) {
                     } else {
                         if (id.startsWith(ALIAS_STARTS_WITH)) {
                             adapterObjects.getObject(id, options, (err, obj) => {
-                                if (obj && obj.common && obj.common.alias && (obj.common.alias.id || obj.common.alias.val !== undefined)) {
-                                    if (this.oStates && this.oStates[obj.common.alias.id]) {
-                                        adapterObjects.getObject(obj.common.alias.id, (err, sourceObj) => {
-                                            const state = JSON.parse(JSON.stringify(this.oStates[obj.common.alias.id]));
+                                if (obj && obj.common && obj.common.alias && obj.common.alias.id) {
+                                    // alias id can be string or can have attribute id.read
+                                    const aliasId = typeof obj.common.alias.id.read === 'string' ? obj.common.alias.id.read : obj.common.alias.id;
+
+                                    // validate here because we use objects/states db directly
+                                    try {
+                                        validateId(aliasId);
+                                    } catch (e) {
+                                        logger.warn(`${this.namespaceLog} Error validating alias id of ${id}: ${e.message}`);
+                                        callback(`Error validating alias id of ${id}: ${e.message}`)
+                                    }
+
+                                    if (this.oStates && this.oStates[aliasId]) {
+                                        adapterObjects.getObject(aliasId, (err, sourceObj) => {
+                                            const state = JSON.parse(JSON.stringify(this.oStates[aliasId]));
                                             callback(err, tools.formatAliasValue(sourceObj && sourceObj.common, obj.common, state, logger, this.namespaceLog));
                                         });
                                     } else {
-                                        adapterObjects.getObject(obj.common.alias.id, (err, sourceObj) => {
-                                            adapterStates.getState(obj.common.alias.id, (err, state) =>
+                                        adapterObjects.getObject(aliasId, (err, sourceObj) => {
+                                            adapterStates.getState(aliasId, (err, state) =>
                                                 callback(err, tools.formatAliasValue(sourceObj && sourceObj.common, obj.common, state, logger, this.namespaceLog)));
                                         });
                                     }
@@ -5905,18 +5986,29 @@ function Adapter(options) {
             } else {
                 if (id.startsWith(ALIAS_STARTS_WITH)) {
                     adapterObjects.getObject(id, options, (err, obj) => {
-                        if (obj && obj.common && obj.common.alias && (obj.common.alias.id || obj.common.alias.val !== undefined)) {
-                            adapterObjects.getObject(obj.common.alias.id, options, (err, sourceObj) => {
-                                if (this.oStates && this.oStates[obj.common.alias.id]) {
-                                    const state = JSON.parse(JSON.stringify(this.oStates[obj.common.alias.id]));
+                        if (obj && obj.common && obj.common.alias && obj.common.alias.id) {
+                            // alias id can be string or can have attribute id.read
+                            const aliasId = typeof obj.common.alias.id.read === 'string' ? obj.common.alias.id.read : obj.common.alias.id;
+
+                            // validate here because we use objects/states db directly
+                            try {
+                                validateId(aliasId);
+                            } catch (e) {
+                                logger.warn(`${this.namespaceLog} Error validating alias id of ${id}: ${e.message}`);
+                                callback(`Error validating alias id of ${id}: ${e.message}`)
+                            }
+
+                            adapterObjects.getObject(aliasId, options, (err, sourceObj) => {
+                                if (this.oStates && this.oStates[aliasId]) {
+                                    const state = JSON.parse(JSON.stringify(this.oStates[aliasId]));
                                     callback(err, tools.formatAliasValue(sourceObj && sourceObj.common, obj.common, state, logger, this.namespaceLog));
                                 } else {
-                                    adapterStates.getState(obj.common.alias.id, (err, state) =>
+                                    adapterStates.getState(aliasId, (err, state) =>
                                         callback(err, tools.formatAliasValue(sourceObj && sourceObj.common, obj.common, state, logger, this.namespaceLog)));
                                 }
                             });
                         } else {
-                            logger.warn(this.namespaceLog + ' ' + (err || `Alias ${id} has no target 7`));
+                            logger.warn(`${this.namespaceLog} ${err || `Alias ${id} has no target 7`}`);
                             callback(err || `Alias ${id} has no target`);
                         }
                     });
@@ -5985,24 +6077,35 @@ function Adapter(options) {
                         callback(err);
                     } else {
                         if (id.startsWith(ALIAS_STARTS_WITH)) {
-                            if (obj && obj.common && obj.common.alias && (obj.common.alias.id || obj.common.alias.val !== undefined)) {
-                                if (obj.common.alias.id)
-                                    if (this.oStates && this.oStates[obj.common.alias.id]) {
-                                        checkStates(obj.common.alias.id, options, 'getState', (err, sourceObj) => {
+                            if (obj && obj.common && obj.common.alias && obj.common.alias.id) {
+                                // id can be string or can have attribute id.read
+                                const aliasId = typeof obj.common.alias.id.read === 'string' ? obj.common.alias.id.read : obj.common.alias.id;
+
+                                // validate here because we use objects/states db directly
+                                try {
+                                    validateId(aliasId);
+                                } catch (e) {
+                                    logger.warn(`${this.namespaceLog} Error validating alias id of ${id}: ${e.message}`);
+                                    callback(`Error validating alias id of ${id}: ${e.message}`)
+                                }
+
+                                if (aliasId)
+                                    if (this.oStates && this.oStates[aliasId]) {
+                                        checkStates(aliasId, options, 'getState', (err, sourceObj) => {
                                             if (err) {
                                                 callback(err);
                                             } else {
-                                                const state = JSON.parse(JSON.stringify(this.oStates[obj.common.alias.id]));
+                                                const state = JSON.parse(JSON.stringify(this.oStates[aliasId]));
                                                 callback(err, tools.formatAliasValue(sourceObj && sourceObj.common, obj.common, state, logger, this.namespaceLog));
                                             }
                                         });
                                     } else {
-                                        checkStates(obj.common.alias.id, options, 'getState', (err, sourceObj) => {
+                                        checkStates(aliasId, options, 'getState', (err, sourceObj) => {
                                             if (err) {
                                                 callback(err);
                                             } else {
                                                 this.inputCount++;
-                                                adapterStates.getState(obj.common.alias.id, (err, state) =>
+                                                adapterStates.getState(aliasId, (err, state) =>
                                                     callback(err, tools.formatAliasValue(sourceObj && sourceObj.common, obj.common, state, logger, this.namespaceLog)));
                                             }
                                         });
@@ -6023,17 +6126,28 @@ function Adapter(options) {
             } else {
                 if (id.startsWith(ALIAS_STARTS_WITH)) {
                     adapterObjects.getObject(id, (err, obj) => {
-                        if (obj && obj.common && obj.common.alias && (obj.common.alias.id || obj.common.alias.val !== undefined)) {
-                            adapterObjects.getObject(obj.common.alias.id, (err, sourceObj) => {
+                        if (obj && obj.common && obj.common.alias && obj.common.alias.id) {
+                            // id can be string or can have attribute id.read
+                            const aliasId = typeof obj.common.alias.id.read === 'string' ? obj.common.alias.id.read : obj.common.alias.id;
+
+                            // validate here because we use objects/states db directly
+                            try {
+                                validateId(aliasId);
+                            } catch (e) {
+                                logger.warn(`${this.namespaceLog} Error validating alias id of ${id}: ${e.message}`);
+                                callback(`Error validating alias id of ${id}: ${e.message}`)
+                            }
+
+                            adapterObjects.getObject(aliasId, (err, sourceObj) => {
                                 if (err) {
                                     return callback(err);
                                 }
-                                if (this.oStates && this.oStates[obj.common.alias.id]) {
-                                    const state = JSON.parse(JSON.stringify(this.oStates[obj.common.alias.id]));
+                                if (this.oStates && this.oStates[aliasId]) {
+                                    const state = JSON.parse(JSON.stringify(this.oStates[aliasId]));
                                     callback(err, tools.formatAliasValue(sourceObj && sourceObj.common, obj.common, state, logger, this.namespaceLog));
                                 } else {
                                     this.inputCount++;
-                                    adapterStates.getState(obj.common.alias.id, (err, state) =>
+                                    adapterStates.getState(aliasId, (err, state) =>
                                         callback(err, tools.formatAliasValue(sourceObj && sourceObj.common, obj.common, state, logger, this.namespaceLog)));
                                 }
                             });
@@ -6146,7 +6260,7 @@ function Adapter(options) {
             if (!id) return null;
             const parts = id.split('.');
             if (parts[0] + '.' + parts[1] !== this.namespace) {
-                logger.warn(this.namespaceLog + ' Try to decode id not from this adapter');
+                logger.warn(`${this.namespaceLog} Try to decode id not from this adapter`);
                 return null;
             }
             return {device: parts[2], channel: parts[3], state: parts[4]};
@@ -6324,7 +6438,10 @@ function Adapter(options) {
                     // replace aliases ID with targets
                     targetObjs.forEach((obj, i) => {
                         if (obj && obj.common && obj.common.alias) {
-                            keys[i]   = obj.common.alias.id || null;
+                            // alias id can be string or can have attribute write
+                            const aliasId = obj.common.alias.id && typeof obj.common.alias.id.write === 'string' ? obj.common.alias.id.write : obj.common.alias.id;
+
+                            keys[i]   = aliasId || null;
                             srcIds[i] = keys[i];
                         }
                     });
@@ -6451,7 +6568,17 @@ function Adapter(options) {
 
         this._addAliasSubscribe = (aliasObj, pattern, callback) => {
             if (aliasObj && aliasObj.common && aliasObj.common.alias && aliasObj.common.alias.id) {
-                const sourceId = aliasObj.common.alias.id;
+                // id can be string or can have attribute write
+                const sourceId = typeof aliasObj.common.alias.id.write === 'string' ? aliasObj.common.alias.id.write : aliasObj.common.alias.id;
+
+                // validate here because we use objects/states db directly
+                try {
+                    validateId(sourceId);
+                } catch (e) {
+                    logger.warn(`${this.namespaceLog} Error validating alias id of ${aliasObj._id}: ${e.message}`);
+                    callback(`Error validating alias id of ${aliasObj._id}: ${e.message}`);
+                }
+
                 this.aliases[sourceId] = this.aliases[sourceId] || {source: null, targets: []};
 
                 const targetEntry = {
@@ -6808,7 +6935,7 @@ function Adapter(options) {
                                     if (!Object.keys(this.aliases).length) {
                                         if (this._aliasObjectsSubscribed) {
                                             this._aliasObjectsSubscribed = false;
-                                            adapterObjects.unsubscribe(ALIAS_STARTS_WITH + '*');
+                                            adapterObjects.unsubscribe(`${ALIAS_STARTS_WITH}*`);
                                         }
                                     }
                                     typeof callback === 'function' && callback();

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -1528,7 +1528,6 @@ function Adapter(options) {
                                 // check if id.read or id
                                 const newSourceId = typeof obj.common.alias.id.read === 'string' ? obj.common.alias.id.read : obj.common.alias.id;
 
-
                                 // if linked ID changed
                                 if (newSourceId !== sourceId) {
                                     this._removeAliasSubscribe(sourceId, targetAlias, () =>
@@ -5461,7 +5460,7 @@ function Adapter(options) {
                                     validateId(aliasId);
                                 } catch (e) {
                                     logger.warn(`${this.namespaceLog} Error validating alias id of ${id}: ${e.message}`);
-                                    callback(`Error validating alias id of ${id}: ${e.message}`)
+                                    callback(`Error validating alias id of ${id}: ${e.message}`);
                                 }
 
                                 // check the rights
@@ -5502,7 +5501,7 @@ function Adapter(options) {
                                 validateId(aliasId);
                             } catch (e) {
                                 logger.warn(`${this.namespaceLog} Error validating alias id of ${id}: ${e.message}`);
-                                callback(`Error validating alias id of ${id}: ${e.message}`)
+                                callback(`Error validating alias id of ${id}: ${e.message}`);
                             }
 
                             // read object for formatting
@@ -5723,7 +5722,7 @@ function Adapter(options) {
                                     validateId(aliasId);
                                 } catch (e) {
                                     logger.warn(`${this.namespaceLog} Error validating alias id of ${id}: ${e.message}`);
-                                    callback(`Error validating alias id of ${id}: ${e.message}`)
+                                    callback(`Error validating alias id of ${id}: ${e.message}`);
                                 }
 
                                 // check the rights
@@ -5764,7 +5763,7 @@ function Adapter(options) {
                                 validateId(aliasId);
                             } catch (e) {
                                 logger.warn(`${this.namespaceLog} Error validating alias id of ${id}: ${e.message}`);
-                                callback(`Error validating alias id of ${id}: ${e.message}`)
+                                callback(`Error validating alias id of ${id}: ${e.message}`);
                             }
 
                             // read object for formatting
@@ -5956,7 +5955,7 @@ function Adapter(options) {
                                         validateId(aliasId);
                                     } catch (e) {
                                         logger.warn(`${this.namespaceLog} Error validating alias id of ${id}: ${e.message}`);
-                                        callback(`Error validating alias id of ${id}: ${e.message}`)
+                                        callback(`Error validating alias id of ${id}: ${e.message}`);
                                     }
 
                                     if (this.oStates && this.oStates[aliasId]) {
@@ -5996,7 +5995,7 @@ function Adapter(options) {
                                 validateId(aliasId);
                             } catch (e) {
                                 logger.warn(`${this.namespaceLog} Error validating alias id of ${id}: ${e.message}`);
-                                callback(`Error validating alias id of ${id}: ${e.message}`)
+                                callback(`Error validating alias id of ${id}: ${e.message}`);
                             }
 
                             adapterObjects.getObject(aliasId, options, (err, sourceObj) => {
@@ -6087,7 +6086,7 @@ function Adapter(options) {
                                     validateId(aliasId);
                                 } catch (e) {
                                     logger.warn(`${this.namespaceLog} Error validating alias id of ${id}: ${e.message}`);
-                                    callback(`Error validating alias id of ${id}: ${e.message}`)
+                                    callback(`Error validating alias id of ${id}: ${e.message}`);
                                 }
 
                                 if (aliasId)
@@ -6136,7 +6135,7 @@ function Adapter(options) {
                                 validateId(aliasId);
                             } catch (e) {
                                 logger.warn(`${this.namespaceLog} Error validating alias id of ${id}: ${e.message}`);
-                                callback(`Error validating alias id of ${id}: ${e.message}`)
+                                callback(`Error validating alias id of ${id}: ${e.message}`);
                             }
 
                             adapterObjects.getObject(aliasId, (err, sourceObj) => {

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -5053,14 +5053,15 @@ function Adapter(options) {
                 if (this.adapterReady && this.aliases[id]) {
                     this.aliases[id].targets.forEach(target => {
                         const aState = state ? tools.formatAliasValue(this.aliases[id].source, target, JSON.parse(JSON.stringify(state)), logger, this.namespaceLog) : null;
+                        const targetId = target.id.read === 'string' ? target.id.read : target.id;
 
                         if (aState || !state) {
                             if (typeof options.stateChange === 'function') {
-                                options.stateChange(target.id, aState);
+                                options.stateChange(targetId, aState);
                             } else {
                                 // emit 'stateChange' event instantly
                                 setImmediate(() =>
-                                    this.emit('stateChange', target.id, aState));
+                                    this.emit('stateChange', targetId, aState));
                             }
                         }
                     });
@@ -6568,8 +6569,8 @@ function Adapter(options) {
 
         this._addAliasSubscribe = (aliasObj, pattern, callback) => {
             if (aliasObj && aliasObj.common && aliasObj.common.alias && aliasObj.common.alias.id) {
-                // id can be string or can have attribute write
-                const sourceId = typeof aliasObj.common.alias.id.write === 'string' ? aliasObj.common.alias.id.write : aliasObj.common.alias.id;
+                // id can be string or can have attribute read
+                const sourceId = typeof aliasObj.common.alias.id.read === 'string' ? aliasObj.common.alias.id.read : aliasObj.common.alias.id;
 
                 // validate here because we use objects/states db directly
                 try {

--- a/lib/cli/cliStates.js
+++ b/lib/cli/cliStates.js
@@ -76,9 +76,10 @@ module.exports = class CLIStates extends CLICommand {
                 objects.getObject(id, (err, targetObj) => {
                     // alias
                     if (targetObj && targetObj.common && targetObj.common.alias && targetObj.common.alias.id) {
-                        objects.getObject(targetObj.common.alias.id, (err, sourceObj) => {
+                        const aliasId = typeof targetObj.common.alias.id.read === 'string' ? targetObj.common.alias.id.read : targetObj.common.alias.id;
+                        objects.getObject(aliasId, (err, sourceObj) => {
                             // write target
-                            states.getState(targetObj.common.alias.id, (err, state) => {
+                            states.getState(aliasId, (err, state) => {
                                 if (err || !targetObj) {
                                     CLI.error.unknown(err);
                                 } else {
@@ -132,7 +133,9 @@ module.exports = class CLIStates extends CLICommand {
                 objects.getObject(id, (err, obj) => {
                     // alias
                     if (obj && obj.common && obj.common.alias && obj.common.alias.id) {
-                        objects.getObject(obj.common.alias.id, (err, targetObj) => {
+                        const aliasId = typeof obj.common.alias.id.write === 'string' ? obj.common.alias.id.write : obj.common.alias.id;
+
+                        objects.getObject(aliasId, (err, targetObj) => {
                             if (err) {
                                 CLI.error.unknown(err);
                                 return void callback(1); // access error
@@ -154,7 +157,7 @@ module.exports = class CLIStates extends CLICommand {
                             }
 
                             // write target
-                            states.setState(obj.common.alias.id, tools.formatAliasValue(obj.common, targetObj.common, newVal, console, ''), err => {
+                            states.setState(aliasId, tools.formatAliasValue(obj.common, targetObj.common, newVal, console, ''), err => {
                                 if (err) {
                                     CLI.error.unknown(err);
                                     return void callback(1); // ?

--- a/lib/objects/objectsInMemFileDB.js
+++ b/lib/objects/objectsInMemFileDB.js
@@ -1747,9 +1747,24 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
             });
         }
 
-        if (obj.common && obj.common.alias && obj.common.alias.id && obj.common.alias.id.startsWith('alias.')) {
-            typeof callback === 'function' && setImmediate(() => callback('Cannot make alias on alias'));
-            return;
+        if (obj.common && obj.common.alias && obj.common.alias.id) {
+            if (typeof obj.common.alias.id === 'object') {
+                if (typeof obj.common.alias.id.write !== 'string' || typeof obj.common.alias.id.read !== 'string') {
+                    return typeof callback === 'function' && callback('Invalid alias ID');
+                }
+
+                if (obj.common.alias.id.write.startsWith('alias.') || obj.common.alias.id.read.startsWith('alias.')) {
+                    return typeof callback === 'function' && callback('Cannot make alias on alias');
+                }
+            } else {
+                if (typeof obj.common.alias.id !== 'string') {
+                    return typeof callback === 'function' && callback('Invalid alias ID');
+                }
+
+                if (obj.common.alias.id.startsWith('alias.')) {
+                    return typeof callback === 'function' && callback('Cannot make alias on alias');
+                }
+            }
         }
 
         if (this.dataset[id] && this.dataset[id].acl && !obj.acl) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3573,11 +3573,11 @@
       "dev": true
     },
     "iobroker.objects-redis": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/iobroker.objects-redis/-/iobroker.objects-redis-2.0.4.tgz",
-      "integrity": "sha512-m72DtzrT7nvN1BiFJVA6GTC8PKary/ueCl6JaP7Q50Ghf8CdXzB9i+OFnipJI2T+fJomR0KyYwHYZBPZtEkxVQ==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/iobroker.objects-redis/-/iobroker.objects-redis-2.0.5.tgz",
+      "integrity": "sha512-RsBkEHRLAR4u6CZ7/Rmdd5+x3K40iv/N8oBQ7NlBIlvW0//w0wqJs/gTOWOGjkMpcgBWUm+2omwaF7VOvGRkTg==",
       "requires": {
-        "ioredis": "^4.14.1",
+        "ioredis": "^4.16.0",
         "node.extend": "^2.0.2",
         "vinyl-sourcemaps-apply": "^0.2.1"
       }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "debug": "^4.1.1",
     "decache": "^4.5.1",
     "event-stream": "^4.0.1",
-    "iobroker.objects-redis": "^2.0.4",
+    "iobroker.objects-redis": "^2.0.5",
     "ioredis": "^4.16.0",
     "jsonwebtoken": "^8.5.1",
     "jszip": "^3.2.2",

--- a/test/lib/testAliases.js
+++ b/test/lib/testAliases.js
@@ -819,7 +819,7 @@ function register(it, expect, context) {
                 type: 'state'
             }, err => {
                 expect(err).to.not.be.ok;
-                // set our alias read obj with def to set state too
+                // set our alias read obj
                 context.adapter.setForeignObject(`${gid}readOrig`, {
                     common: {
                         name: 'Test ID read',


### PR DESCRIPTION
Alias id can also be an `object` from now on containing properties `read` and `write`. When user does something like `setState(aliasId)` the state will be forwarded to the `write` id. When the `read` id is changed, the state will also be set to the alias state. This would close #565.

For this to work, we have to adjust `objectsInRedis` too. 