### PR TITLE
obj.common.desc can also be obj containing different languages

### DIFF
--- a/lib/tools.js
+++ b/lib/tools.js
@@ -2114,8 +2114,8 @@ function validateGeneralObjectProperties(obj) {
         throw new Error(`obj.common.role has an invalid type! Expected "string", received  "${typeof obj.common.role}"`);
     }
 
-    if (obj.common.desc !== undefined && typeof obj.common.desc !== 'string') {
-        throw new Error(`obj.common.desc has an invalid type! Expected "string", received  "${typeof obj.common.desc}"`);
+    if (obj.common.desc !== undefined && typeof obj.common.desc !== 'string' && typeof obj.common.desc !== 'object') {
+        throw new Error(`obj.common.desc has an invalid type! Expected "string" or "object", received  "${typeof obj.common.desc}"`);
     }
 }
 


### PR DESCRIPTION
- respect this on object validation
- fixes #753 