### PR TITLE
fixes for file commands

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -22,6 +22,8 @@
         "no-multiple-empty-lines": ["error", { "max": 1, "maxEOF": 1 }],
         "no-var": "error",
         "prefer-const": "error",
+        "no-throw-literal": "error",
+        "prefer-promise-reject-errors": "error",
         "quotes": [
             "error",
             "single",

--- a/lib/objects/objectsInMemFileDB.js
+++ b/lib/objects/objectsInMemFileDB.js
@@ -53,8 +53,8 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
 
         this.objectsDir = path.join(this.dataDir, 'files');
 
-        // cached meta objects for file operations
-        this.metaCache = {};
+        // cached meta information for file operations
+        this.existingMetaObjects = {};
 
         /*function prepareRights(options) {
          let fOptions = {};
@@ -108,16 +108,16 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
      * @throws Error if id is invalid
      */
     async validateMetaObject(id) {
-        if (this.metaCache[id] === undefined) {
+        if (this.existingMetaObjects[id] === undefined) {
             // if not cached -> getObject
             const obj = await this.getObjectAsync(id);
             if (obj && obj.type === 'meta') {
-                this.metaCache[id] = true;
+                this.existingMetaObjects[id] = true;
             } else {
-                this.metaCache[id] = false;
+                this.existingMetaObjects[id] = false;
                 return Promise.reject(`${id} is not an object of type "meta"`);
             }
-        } else if (this.metaCache[id] === false) {
+        } else if (this.existingMetaObjects[id] === false) {
             return Promise.reject(`${id} is not an object of type "meta"`);
         }
     }
@@ -1967,8 +1967,8 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
         this.dataset[id] = JSON.parse(JSON.stringify(obj));
 
         // object updated -> if type changed to meta -> cache
-        if (this.dataset[id].type === 'meta' && this.metaCache[id] === false) {
-            this.metaCache[id] = true;
+        if (this.dataset[id].type === 'meta' && this.existingMetaObjects[id] === false) {
+            this.existingMetaObjects[id] = true;
         }
 
         typeof callback === 'function' && setImmediate(() => callback(null, {id: id}));
@@ -2039,8 +2039,8 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
             delete this.dataset[id];
 
             // object has been deleted -> remove from cached meta if there
-            if (this.metaCache[id]) {
-                this.metaCache[id] = false;
+            if (this.existingMetaObjects[id]) {
+                this.existingMetaObjects[id] = false;
             }
 
             typeof callback === 'function' && setImmediate(() => callback(null));
@@ -2337,8 +2337,8 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
         this.dataset[id]._id = id;
 
         // extended -> if its now type meta and currently marked as not -> cache
-        if (this.metaCache[id] === false && this.dataset[id].type === 'meta') {
-            this.metaCache[id] = true;
+        if (this.existingMetaObjects[id] === false && this.dataset[id].type === 'meta') {
+            this.existingMetaObjects[id] = true;
         }
 
         // add user default rights

--- a/lib/objects/objectsInMemFileDB.js
+++ b/lib/objects/objectsInMemFileDB.js
@@ -115,10 +115,10 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
                 this.existingMetaObjects[id] = true;
             } else {
                 this.existingMetaObjects[id] = false;
-                return Promise.reject(`${id} is not an object of type "meta"`);
+                return Promise.reject(new Error(`${id} is not an object of type "meta"`));
             }
         } else if (this.existingMetaObjects[id] === false) {
-            return Promise.reject(`${id} is not an object of type "meta"`);
+            return Promise.reject(new Error(`${id} is not an object of type "meta"`));
         }
     }
 
@@ -449,10 +449,10 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
         try {
             await this.validateMetaObject(id);
         } catch (e) {
-            this.log.warn(`writeFile will not write this file (${name}) in future versions: ${e}`);
+            this.log.warn(`writeFile will not write this file (${name}) in future versions: ${e.message}`);
             // todo: replace by below code in 3.1 + add test
-            // this.log.error(`Cannot write file ${name}: ${e}`);
-            // typeof callback === 'function' && setImmediate(() => callback(e));
+            // this.log.error(`Cannot write file ${name}: ${e.message}`);
+            // typeof callback === 'function' && setImmediate(() => callback(e.message));
         }
 
         const _path = utils.sanitizePath(id, name, callback);
@@ -583,10 +583,10 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
         try {
             await this.validateMetaObject(id);
         } catch (e) {
-            this.log.warn(`readFile will not read this file (${name}) in future versions: ${e}`);
+            this.log.warn(`readFile will not read this file (${name}) in future versions: ${e.message}`);
             // todo: replace by below code in 3.1 + add test
-            // this.log.error(`Cannot read file ${name}: ${e}`);
-            // typeof callback === 'function' && setImmediate(() => callback(e));
+            // this.log.error(`Cannot read file ${name}: ${e.message}`);
+            // typeof callback === 'function' && setImmediate(() => callback(e.message));
         }
 
         const _path = utils.sanitizePath(id, name, callback);
@@ -840,10 +840,10 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
             try {
                 await this.validateMetaObject(id);
             } catch (e) {
-                this.log.warn(`readDir will not read this directory (${name}) in future versions: ${e}`);
+                this.log.warn(`readDir will not read this directory (${name}) in future versions: ${e.message}`);
                 // todo: replace by below code in 3.1 + add test
-                // this.log.error(`Cannot read directory ${name}: ${e}`);
-                // typeof callback === 'function' && setImmediate(() => callback(e));
+                // this.log.error(`Cannot read directory ${name}: ${e.message}`);
+                // typeof callback === 'function' && setImmediate(() => callback(e.message));
             }
 
             const _path = utils.sanitizePath(id, name, callback);

--- a/lib/objects/objectsInMemFileDB.js
+++ b/lib/objects/objectsInMemFileDB.js
@@ -53,6 +53,9 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
 
         this.objectsDir = path.join(this.dataDir, 'files');
 
+        // cached meta objects for file operations
+        this.metaCache = {};
+
         /*function prepareRights(options) {
          let fOptions = {};
          options = options || {};
@@ -98,8 +101,29 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
         }
     }
 
+    /**
+     * Checks if given Id is a meta object, else throws error
+     *
+     * @param {string} id to check
+     * @throws Error if id is invalid
+     */
+    async validateMetaObject(id) {
+        if (this.metaCache[id] === undefined) {
+            // if not cached -> getObject
+            const obj = await this.getObjectAsync(id);
+            if (obj && obj.type === 'meta') {
+                this.metaCache[id] = true;
+            } else {
+                this.metaCache[id] = false;
+                return Promise.reject(`${id} is not an object of type "meta"`);
+            }
+        } else if (this.metaCache[id] === false) {
+            return Promise.reject(`${id} is not an object of type "meta"`);
+        }
+    }
+
     normalizeFilename(name) {
-        return name ? name.replace(/[\/]+/g, '/') : name;
+        return name ? name.replace(/[/\\]+/g, '/') : name;
     }
 
     // -------------- FILE FUNCTIONS -------------------------------------------
@@ -399,7 +423,7 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
         }
     }
 
-    writeFile(id, name, data, options, callback) {
+    async writeFile(id, name, data, options, callback) {
         if (typeof options === 'function') {
             callback = options;
             options = null;
@@ -420,6 +444,15 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
                     }
                 });
             });
+        }
+
+        try {
+            await this.validateMetaObject(id);
+        } catch (e) {
+            this.log.warn(`writeFile will not write this file (${name}) in future versions: ${e}`);
+            // todo: replace by below code in 3.1 + add test
+            // this.log.error(`Cannot write file ${name}: ${e}`);
+            // typeof callback === 'function' && setImmediate(() => callback(e));
         }
 
         const _path = utils.sanitizePath(id, name, callback);
@@ -526,7 +559,7 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
         }
     }
 
-    readFile(id, name, options, callback) {
+    async readFile(id, name, options, callback) {
         if (typeof options === 'function') {
             callback = options;
             options  = null;
@@ -545,6 +578,15 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
                     }
                 });
             });
+        }
+
+        try {
+            await this.validateMetaObject(id);
+        } catch (e) {
+            this.log.warn(`readFile will not read this file (${name}) in future versions: ${e}`);
+            // todo: replace by below code in 3.1 + add test
+            // this.log.error(`Cannot read file ${name}: ${e}`);
+            // typeof callback === 'function' && setImmediate(() => callback(e));
         }
 
         const _path = utils.sanitizePath(id, name, callback);
@@ -784,7 +826,7 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
         typeof callback === 'function' && setImmediate(() => callback(null, res));
     }
 
-    readDir(id, name, options, callback) {
+    async readDir(id, name, options, callback) {
         if (typeof options === 'function') {
             callback = options;
             options = null;
@@ -795,6 +837,15 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
         if ((id === '' || id === '/' || id === '*') && (name === '' || name === '*')) {
             // read root of xxx-data/files
         } else {
+            try {
+                await this.validateMetaObject(id);
+            } catch (e) {
+                this.log.warn(`readDir will not read this directory (${name}) in future versions: ${e}`);
+                // todo: replace by below code in 3.1 + add test
+                // this.log.error(`Cannot read directory ${name}: ${e}`);
+                // typeof callback === 'function' && setImmediate(() => callback(e));
+            }
+
             const _path = utils.sanitizePath(id, name, callback);
             if (!_path) {
                 return;
@@ -1915,6 +1966,11 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
     _setObjectDirect(id, obj, callback) {
         this.dataset[id] = JSON.parse(JSON.stringify(obj));
 
+        // object updated -> if type changed to meta -> cache
+        if (this.dataset[id].type === 'meta' && this.metaCache[id] === false) {
+            this.metaCache[id] = true;
+        }
+
         typeof callback === 'function' && setImmediate(() => callback(null, {id: id}));
 
         setImmediate(() => this.publishAll('objects', id, obj));
@@ -1981,6 +2037,11 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
             }
 
             delete this.dataset[id];
+
+            // object has been deleted -> remove from cached meta if there
+            if (this.metaCache[id]) {
+                this.metaCache[id] = false;
+            }
 
             typeof callback === 'function' && setImmediate(() => callback(null));
 
@@ -2274,6 +2335,11 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
         this.dataset[id] = this.dataset[id] || {};
         this.dataset[id] = extend(true, this.dataset[id], obj);
         this.dataset[id]._id = id;
+
+        // extended -> if its now type meta and currently marked as not -> cache
+        if (this.metaCache[id] === false && this.dataset[id].type === 'meta') {
+            this.metaCache[id] = true;
+        }
 
         // add user default rights
         if (this.defaultNewAcl && !this.dataset[id].acl) {

--- a/lib/objects/objectsUtils.js
+++ b/lib/objects/objectsUtils.js
@@ -492,8 +492,6 @@ function sanitizePath(id, name, callback) {
     id = id.replace(/[\][*,;'"`<>\\?/]/g, ''); // remove all invalid characters from states plus slashes
     id = id.replace(/\.\./g, ''); // do not allow to write in parent directories
 
-    name = name.replace(/\\/g, '/'); // replace win path backslashes
-
     if (name.includes('..')) {
         name = path.normalize('/' + name);
     }
@@ -502,6 +500,9 @@ function sanitizePath(id, name, callback) {
         name = name.replace(/\.\./g, '');
         name = path.normalize('/' + name);
     }
+
+    name = name.replace(/\\/g, '/'); // replace win path backslashes
+
     if (name[0] === '/') {
         name = name.substring(1);
     } // do not allow absolute paths

--- a/package-lock.json
+++ b/package-lock.json
@@ -3703,9 +3703,9 @@
       "dev": true
     },
     "iobroker.objects-redis": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/iobroker.objects-redis/-/iobroker.objects-redis-3.1.1.tgz",
-      "integrity": "sha512-smue4ll6msClak66DjlEvBWfwXDnKV9komRT7okkfURe+SAzCnkY7JZrXXNfCLcxZ0aOvvJ4tokIdOg32195QQ==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/iobroker.objects-redis/-/iobroker.objects-redis-3.2.0.tgz",
+      "integrity": "sha512-51IU+57pBE5LK8IG65IIMlRy2FLZPHYflt+YVD7iSbU68w8z04ac28fJEHWsWQOOzvd7HDyClxgPejxE8wReWw==",
       "requires": {
         "ioredis": "^4.16.1",
         "node.extend": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "debug": "^4.1.1",
     "decache": "^4.5.1",
     "event-stream": "^4.0.1",
-    "iobroker.objects-redis": "^3.1.1",
+    "iobroker.objects-redis": "^3.2.0",
     "ioredis": "^4.16.1",
     "jsonwebtoken": "^8.5.1",
     "jszip": "^3.3.0",

--- a/test/lib/testObjects.js
+++ b/test/lib/testObjects.js
@@ -309,22 +309,25 @@ function register(it, expect, context) {
 
     it(textName + 'should create and read file', done => {
         const objects = context.objects;
-        objects.writeFile(testId, 'myFile/abc.txt', 'dataInFile', err => {
-            err && console.error(`Got ${JSON.stringify(objects.getStatus())}: ${err}`);
+        objects.setObject(testId, {type: 'meta'}, err => {
             expect(err).to.be.not.ok;
-
-            objects.readFile(testId, 'myFile/abc.txt', (err, data, mimeType) => {
+            objects.writeFile(testId, 'myFile/abc.txt', 'dataInFile', err => {
+                err && console.error(`Got ${JSON.stringify(objects.getStatus())}: ${err}`);
                 expect(err).to.be.not.ok;
-                expect(data).to.be.equal('dataInFile');
-                expect(mimeType).to.be.equal('text/javascript');
-                objects.rm(testId, 'myFile/*', (err, files) => {
+
+                objects.readFile(testId, 'myFile/abc.txt', (err, data, mimeType) => {
                     expect(err).to.be.not.ok;
-                    const file = files.find(f => f.file === 'abc.txt');
-                    expect(file.file).to.be.equal('abc.txt');
-                    expect(file.path).to.be.equal('myFile');
-                    objects.readFile(testId, 'myFile/abc.txt', (err, _data, _mimeType) => {
-                        expect(err).to.be.equal('Not exists');
-                        done();
+                    expect(data).to.be.equal('dataInFile');
+                    expect(mimeType).to.be.equal('text/javascript');
+                    objects.rm(testId, 'myFile/*', (err, files) => {
+                        expect(err).to.be.not.ok;
+                        const file = files.find(f => f.file === 'abc.txt');
+                        expect(file.file).to.be.equal('abc.txt');
+                        expect(file.path).to.be.equal('myFile');
+                        objects.readFile(testId, 'myFile/abc.txt', (err, _data, _mimeType) => {
+                            expect(err).to.be.equal('Not exists');
+                            done();
+                        });
                     });
                 });
             });


### PR DESCRIPTION
- always repalce backslashes for unix paths
- also do this in normalize to fix old files
- fixes #589
- cache meta objects and only allow writing files to objects of type meta (for now, we only deprecate)