### PR TITLE
hold the logic of encryptedNative and protectedNative on same level a…

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -1628,8 +1628,8 @@ function Adapter(options) {
                 // remove protectedNative if not admin or own adapter
                 const adapterName = this.namespace.split('.')[0];
                 if (obj && obj._id && obj._id.startsWith('system.adapter.') && adapterName !== 'admin' &&
-                    adapterName !== obj._id.split('.')[2] && obj.common && obj.common.protectedNative && obj.common.protectedNative.length) {
-                    for (const attr of obj.common.protectedNative) {
+                    adapterName !== obj._id.split('.')[2] && obj.protectedNative && obj.protectedNative.length) {
+                    for (const attr of obj.protectedNative) {
                         delete obj.native[attr];
                     }
                 }
@@ -2755,8 +2755,8 @@ function Adapter(options) {
                 const adapterName = this.namespace.split('.')[0];
                 // remove protectedNative if not admin or own adapter
                 if(obj && obj._id && obj._id.startsWith('system.adapter.') && adapterName !== 'admin' &&
-                    adapterName !== obj._id.split('.')[2] && obj.common && obj.common.protectedNative && obj.common.protectedNative.length) {
-                    for (const attr of obj.common.protectedNative) {
+                    adapterName !== obj._id.split('.')[2] && obj.protectedNative && obj.protectedNative.length) {
+                    for (const attr of obj.protectedNative) {
                         delete obj.native[attr];
                     } // endFor
                 } // endIf
@@ -7816,8 +7816,8 @@ function Adapter(options) {
 
                 // Decrypt all attributes of encryptedNative
                 const promises = [];
-                if (this.common && Array.isArray(this.common.encryptedNative)) {
-                    for (const attr of this.common.encryptedNative) {
+                if (Array.isArray(adapterConfig.encryptedNative)) {
+                    for (const attr of adapterConfig.encryptedNative) {
                         // we can only decrypt strings
                         if (typeof this.config[attr] === 'string') {
                             promises.push(this.getEncryptedConfig(attr)

--- a/lib/setup/setupUpload.js
+++ b/lib/setup/setupUpload.js
@@ -645,8 +645,12 @@ function Upload(options) {
                             // all common settings should be taken from new one
                             newObject.common = extendCommon(newObject.common, iopack.common, newObject._id.split('.').pop());
                             newObject.native = extendNative(newObject.native, iopack.native);
+                            // protected/encryptedNative also needs to be updated
                             newObject.protectedNative = iopack.protectedNative || [];
                             newObject.encryptedNative = iopack.encryptedNative || [];
+                            // update instanceObjects and objects
+                            newObject.instanceObjects = iopack.instanceObjects || [];
+                            newObject.objects = iopack.objects || [];
 
                             newObject.common.version          = iopack.common.version;
                             newObject.common.installedVersion = iopack.common.version;
@@ -761,8 +765,13 @@ function Upload(options) {
                 }
                 obj.common = iopack.common || {};
                 obj.native = iopack.native || {};
+                // protected/encryptedNative also needs to be updated
                 obj.protectedNative = iopack.protectedNative || [];
                 obj.encryptedNative = iopack.encryptedNative || [];
+                // update instanceObjects and objects
+                obj.instanceObjects = iopack.instanceObjects || [];
+                obj.objects = iopack.objects || [];
+
                 obj.type   = 'adapter';
 
                 obj.common.installedVersion = iopack.common.version;

--- a/lib/setup/setupUpload.js
+++ b/lib/setup/setupUpload.js
@@ -645,6 +645,8 @@ function Upload(options) {
                             // all common settings should be taken from new one
                             newObject.common = extendCommon(newObject.common, iopack.common, newObject._id.split('.').pop());
                             newObject.native = extendNative(newObject.native, iopack.native);
+                            newObject.protectedNative = iopack.protectedNative || [];
+                            newObject.encryptedNative = iopack.encryptedNative || [];
 
                             newObject.common.version          = iopack.common.version;
                             newObject.common.installedVersion = iopack.common.version;
@@ -759,6 +761,8 @@ function Upload(options) {
                 }
                 obj.common = iopack.common || {};
                 obj.native = iopack.native || {};
+                obj.protectedNative = iopack.protectedNative || [];
+                obj.encryptedNative = iopack.encryptedNative || [];
                 obj.type   = 'adapter';
 
                 obj.common.installedVersion = iopack.common.version;

--- a/test/lib/io-package.json
+++ b/test/lib/io-package.json
@@ -30,10 +30,7 @@
         "en": "fix reconnect",
         "de": "Korrigiere Wiederverbindung",
         "ru": "Исправлено распознавание дисконнекта"
-      },
-      "encryptedNative": [
-        "password"
-      ]
+      }
     },
     "authors": [
       "bluefox <dogafox@gmail.com>"

--- a/test/lib/objects.json
+++ b/test/lib/objects.json
@@ -672,14 +672,7 @@
       "config": {
         "width ": 1224,
         "height": 520
-      },
-      "protectedNative": [
-        "username",
-        "password"
-      ],
-      "encryptedNative": [
-        "password"
-      ]
+      }
     },
     "native": {
       "paramString": "value1",
@@ -688,6 +681,13 @@
       "username": "tesla",
       "password": "-\u000e\b\u001c\\X\u0000"
     },
+    "protectedNative": [
+      "username",
+      "password"
+    ],
+    "encryptedNative": [
+      "password"
+    ],
     "_id": "system.adapter.test.0",
     "type": "adapter"
   }

--- a/test/lib/testObjectsFunctions.js
+++ b/test/lib/testObjectsFunctions.js
@@ -290,17 +290,17 @@ function register(it, expect, context) {
                 name: 'tesla',
                 type: 'number',
                 role: 'level',
-                members: ['A'],
-                protectedNative: [
-                    'username',
-                    'password'
-                ]
+                members: ['A']
             },
             native: {
                 model: 'S P85D',
                 username: 'tesla',
                 password: 'winning'
-            }
+            },
+            protectedNative: [
+                'username',
+                'password'
+            ]
         }, function (err) {
             expect(err).to.be.null;
 
@@ -327,17 +327,17 @@ function register(it, expect, context) {
                 name: 'tesla',
                 type: 'number',
                 role: 'level',
-                members: ['A'],
-                protectedNative: [
-                    'username',
-                    'password'
-                ]
+                members: ['A']
             },
             native: {
                 model: 'S P85D',
                 username: 'tesla',
                 password: 'winning'
-            }
+            },
+            protectedNative: [
+                'username',
+                'password'
+            ]
         }, function (err) {
             expect(err).to.be.null;
 
@@ -864,17 +864,17 @@ function register(it, expect, context) {
                     name: 'tesla',
                     type: 'number',
                     role: 'level',
-                    members: ['A'],
-                    protectedNative: [
-                        'username',
-                        'password'
-                    ]
+                    members: ['A']
                 },
                 native: {
                     model: 'S P85D',
                     username: 'tesla',
                     password: 'winning'
-                }
+                },
+                protectedNative: [
+                    'username',
+                    'password'
+                ]
             },
             function (err) {
                 expect(err).to.be.null;
@@ -904,17 +904,17 @@ function register(it, expect, context) {
                     name: 'tesla',
                     type: 'number',
                     role: 'level',
-                    members: ['A'],
-                    protectedNative: [
-                        'username',
-                        'password'
-                    ]
+                    members: ['A']
                 },
                 native: {
                     model: 'S P85D',
                     username: 'tesla',
                     password: 'winning'
-                }
+                },
+                protectedNative: [
+                    'username',
+                    'password'
+                ]
             },
             function (err) {
                 expect(err).to.be.null;


### PR DESCRIPTION
…s native

- and solve the issue by updating them on upload
- this is an alternative to https://github.com/ioBroker/ioBroker.js-controller/commit/11d21c10a95375c3847f3e8ee8e9a31ee7591cda which is backward compatible and holds our decision on keeping `protectedNative` and `encryptedNative` on same level as `native`