### PR TITLE
fix crash of redis setState when undefined is passed

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -5637,6 +5637,14 @@ function Adapter(options) {
                 state = {val: state};
             }
 
+            if (state.val === undefined) {
+                // undefined is not allowed as state.val -> return
+                if (typeof callback === 'function') {
+                    callback('undefined is not a valid state value');
+                }
+                return;
+            }
+
             if (ack !== undefined) {
                 state.ack = ack;
             }
@@ -5794,6 +5802,14 @@ function Adapter(options) {
                 state = {val: state};
             }
 
+            if (state.val === undefined) {
+                // undefined is not allowed as state.val -> return
+                if (typeof callback === 'function') {
+                    callback('undefined is not a valid state value');
+                }
+                return;
+            }
+
             if (ack !== undefined) {
                 state.ack = ack;
             }
@@ -5892,6 +5908,14 @@ function Adapter(options) {
             } else {
                 // wrap non-object values in a state object
                 state = {val: state};
+            }
+
+            if (state.val === undefined) {
+                // undefined is not allowed as state.val -> return
+                if (typeof callback === 'function') {
+                    callback('undefined is not a valid state value');
+                }
+                return;
             }
 
             if (ack !== undefined) {
@@ -6070,6 +6094,14 @@ function Adapter(options) {
             } else {
                 // wrap non-object values in a state object
                 state = {val: state};
+            }
+
+            if (state.val === undefined) {
+                // undefined is not allowed as state.val -> return
+                if (typeof callback === 'function') {
+                    callback('undefined is not a valid state value');
+                }
+                return;
             }
 
             if (ack !== undefined) {

--- a/lib/states/statesInRedis.js
+++ b/lib/states/statesInRedis.js
@@ -438,17 +438,18 @@ class StateRedis {
             return callback && setImmediate(() => callback('Closed'));
         }
 
-        let expire;
-        if (state.expire) {
-            expire = state.expire;
-            delete state.expire;
-        }
         const obj = {};
 
         if (typeof state !== 'object') {
             state = {
                 val: state
             };
+        }
+
+        let expire;
+        if (state.expire) {
+            expire = state.expire;
+            delete state.expire;
         }
 
         if (!id || typeof id !== 'string') {

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -1558,7 +1558,7 @@ function promisify(fn, context, returnArgNames) {
             fn.apply(context, args.concat([
                 function (error, result) {
                     if (error) {
-                        return reject(error);
+                        return reject(new Error(error));
                     } else {
                         // decide on how we want to return the callback arguments
                         switch (arguments.length) {

--- a/test/lib/testStates.js
+++ b/test/lib/testStates.js
@@ -787,6 +787,24 @@ function register(it, expect, context) {
         });
     });
 
+    it(testName + 'Should decline undefined state value', async () => {
+        // set state to 1
+        await context.adapter.setStateAsync(`${gid}undefinedState`, 1);
+        try {
+            // we set state to undefined
+            await context.adapter.setStateAsync(`${gid}undefinedState`, undefined);
+        } catch (e) {
+            if (e.message.includes('undefined is not a valid state value')) {
+                // correct error -> now check that we have old state
+                const state = await context.adapter.getStateAsync(`${gid}undefinedState`);
+                expect(state.val).to.equal(1);
+                return Promise.resolve();
+            } else {
+                return Promise.reject(new Error(e.message));
+            }
+        }
+    });
+
     // getHistory - cannot be tested
 }
 


### PR DESCRIPTION
- and explicitly refuse undefined as a states value
- and promisify now rejects with an error object instead of string