### PR TITLE
if we cannot find adapter dir, log the adaptername and do not try to …

### DIFF
--- a/lib/setup/setupInstall.js
+++ b/lib/setup/setupInstall.js
@@ -555,14 +555,13 @@ function Install(options) {
 
             if (objs && objs.rows && objs.rows.length) {
                 for (const dName in deps) {
-                    let version = null;
                     let isFound = false;
 
-                    version = deps[dName];
+                    const version = deps[dName];
 
                     if (dName === 'js-controller') {
-                        // Check only version
-                        if (version) {
+                        // Check only if version not *, else we dont have to read io-pack unnecessarily
+                        if (version !== '*') {
                             const iopkg_ = JSON.parse(fs.readFileSync(`${__dirname}/../../package.json`, 'utf8'));
                             if (!semver.satisfies(iopkg_.version, version)) {
                                 console.error(`host.${hostname} Invalid version of "${dName}". Installed "${iopkg_.version}", required "${version}`);
@@ -579,14 +578,9 @@ function Install(options) {
                         const obj = objs.rows.find(obj => obj && obj.value && obj.value.common && obj.value.common.name === dName);
 
                         if (obj) {
-                            if (version !== null) {
-                                // var iopkg = JSON.parse(fs.readFileSync(__dirname + '/../../package.json'));
-                                if (!semver.satisfies(obj.value.common.version, version)) {
-                                    console.error(`host.${hostname} Invalid version of "${dName}". Installed "${obj.value.common.version}", required "${version}`);
-                                    processExit(EXIT_CODES.INVALID_DEPENDENCY_VERSION);
-                                } else {
-                                    isFound = true;
-                                }
+                            if (!semver.satisfies(obj.value.common.version, version)) {
+                                console.error(`host.${hostname} Invalid version of "${dName}". Installed "${obj.value.common.version}", required "${version}`);
+                                processExit(EXIT_CODES.INVALID_DEPENDENCY_VERSION);
                             } else {
                                 isFound = true;
                             }

--- a/lib/setup/setupInstall.js
+++ b/lib/setup/setupInstall.js
@@ -660,7 +660,7 @@ function Install(options) {
             objs = [];
         }
 
-        // check if some dependencies are missing and install them if some foung
+        // check if some dependencies are missing and install them if some found
         checkDependencies(adapter, adapterConf.common.dependencies, adapterConf.common.globalDependencies, params, () => {
             adapterConf.common.installedVersion = adapterConf.common.version;
 

--- a/lib/setup/setupInstall.js
+++ b/lib/setup/setupInstall.js
@@ -538,12 +538,15 @@ function Install(options) {
 
     // this command is executed always on THIS host
     function checkDependencies(adapter, deps, globalDeps, _options, callback) {
-        if ((!deps || !deps.length) && (!globalDeps || !globalDeps.length)) {
+        if (!deps && !globalDeps) {
             return callback && callback(adapter);
         }
 
-        // combine both dependencies
-        deps = (deps || []).concat(globalDeps || []);
+        deps = tools.parseDependencies(deps);
+        globalDeps = tools.parseDependencies(globalDeps);
+
+        // combine both dependencies for now
+        Object.assign(deps, globalDeps);
 
         let cnt = 0;
         // Get all installed adapters
@@ -551,24 +554,18 @@ function Install(options) {
             err && console.error(err);
 
             if (objs && objs.rows && objs.rows.length) {
-                for (let i = 0; i < deps.length; i++) {
-                    let dName;
+                for (const dName in deps) {
                     let version = null;
                     let isFound = false;
 
-                    if (typeof deps[i] === 'object') {
-                        dName = Object.keys(deps[i])[0];
-                        version = deps[i][dName];
-                    } else {
-                        dName = deps[i];
-                    }
+                    version = deps[dName];
 
                     if (dName === 'js-controller') {
                         // Check only version
                         if (version) {
-                            const iopkg_ = JSON.parse(fs.readFileSync(__dirname + '/../../package.json', 'utf8'));
+                            const iopkg_ = JSON.parse(fs.readFileSync(`${__dirname}/../../package.json`, 'utf8'));
                             if (!semver.satisfies(iopkg_.version, version)) {
-                                console.error('host.' + hostname + ' Invalid version of "' + dName + '". Installed "' + iopkg_.version + '", required "' + version);
+                                console.error(`host.${hostname} Invalid version of "${dName}". Installed "${iopkg_.version}", required "${version}`);
                                 processExit(EXIT_CODES.INVALID_DEPENDENCY_VERSION);
                             } else {
                                 isFound = true;
@@ -585,7 +582,7 @@ function Install(options) {
                             if (version !== null) {
                                 // var iopkg = JSON.parse(fs.readFileSync(__dirname + '/../../package.json'));
                                 if (!semver.satisfies(obj.value.common.version, version)) {
-                                    console.error('host.' + hostname + ' Invalid version of "' + dName + '". Installed "' + obj.value.common.version + '", required "' + version);
+                                    console.error(`host.${hostname} Invalid version of "${dName}". Installed "${obj.value.common.version}", required "${version}`);
                                     processExit(EXIT_CODES.INVALID_DEPENDENCY_VERSION);
                                 } else {
                                     isFound = true;
@@ -602,7 +599,7 @@ function Install(options) {
                         that.createInstance(dName, _options, name =>
                             upload.uploadAdapter(name, true, false, () =>
                                 upload.uploadAdapter(name, false, false, () =>
-                                    !--cnt && callback && callback(adapter))));
+                                    !--cnt && callback && callback(dName))));
                     }
                 }
             }

--- a/lib/setup/setupUpgrade.js
+++ b/lib/setup/setupUpgrade.js
@@ -64,48 +64,14 @@ function Upgrade(options) {
         if (!dependencies && !globalDependencies) {
             return '';
         }
-        let adapters;
-        if (dependencies) {
-            // if like [{"js-controller": ">=0.10.1"}]
-            if (Array.isArray(dependencies)) {
-                adapters = {};
-                dependencies.filter(a => typeof dependencies[a] !== 'string')
-                    .forEach(rule => {
-                        if (typeof rule === 'string') {
-                            // No version given, all are okay
-                            adapters[rule] = '*';
-                        } else if (tools.isObject(rule)) {
-                            Object.keys(rule).filter(adapter => !adapters[adapter]).forEach(adapter => adapters[adapter] = rule[adapter]);
-                        }
-                    });
-            } else {
-                // if like {"js-controller": ">=0.10.1", "admin": ">=0.5.6"}
-                adapters = dependencies;
-            }
-        }
 
-        if (globalDependencies) {
-            // if like [{"js-controller": ">=0.10.1"}]
-            if (Array.isArray(globalDependencies)) {
-                adapters = adapters || {};
-                globalDependencies.filter(a => typeof globalDependencies[a] !== 'string')
-                    .forEach(rule => {
-                        if (typeof rule === 'string') {
-                            // No version given, all are okay
-                            adapters[rule] = '*';
-                        } else if (tools.isObject(rule)) {
-                            Object.keys(rule).filter(adapter => !adapters[adapter]).forEach(adapter => adapters[adapter] = rule[adapter]);
-                        }
-                    });
-            } else {
-                // if like {"js-controller": ">=0.10.1", "admin": ">=0.5.6"}
-                adapters = adapters || {};
-                Object.assign(adapters, globalDependencies);
-            }
-        }
+        dependencies = tools.parseDependencies(dependencies);
+        globalDependencies = tools.parseDependencies(globalDependencies);
+        // currently just combine them
+        Object.assign(dependencies, globalDependencies);
 
         let error = '';
-        Object.keys(adapters).find(adapter => {
+        Object.keys(dependencies).find(adapter => {
             const adapterDir = tools.getAdapterDir(adapter);
             let iopack;
 
@@ -113,17 +79,17 @@ function Upgrade(options) {
 
             if (adapter === 'js-controller') {
                 try {
-                    iopack = JSON.parse(fs.readFileSync(__dirname + '/../../io-package.json', 'utf8'));
+                    iopack = JSON.parse(fs.readFileSync(`${__dirname}/../../io-package.json`, 'utf8'));
                 } catch (e) {
-                    error = 'Cannot find io-package.json in "' + __dirname + '/../../": ' + e;
+                    error = `Cannot find io-package.json in "${__dirname}/../../": ${e}`;
                     return true;
                 }
                 if (!iopack || !iopack.common || !iopack.common.version) {
                     error = 'No version of "js-controller"';
                     return true;
                 }
-                if (!semver.satisfies(iopack.common.version, adapters[adapter])) {
-                    error = 'Invalid version of js-controler. Required ' + adapters[adapter];
+                if (!semver.satisfies(iopack.common.version, dependencies[adapter])) {
+                    error = `Invalid version of js-controler. Required ${dependencies[adapter]}`;
                     return true;
                 }
             } else if (adapterDir === null) {
@@ -132,7 +98,7 @@ function Upgrade(options) {
                 return true;
             } else {
                 try {
-                    iopack = JSON.parse(fs.readFileSync(adapterDir + '/io-package.json', 'utf8'));
+                    iopack = JSON.parse(fs.readFileSync(`${adapterDir}/io-package.json`, 'utf8'));
                 } catch (e) {
                     error = 'Cannot find io-package.json in "' + adapterDir + '": ' + e;
                     return true;
@@ -142,7 +108,7 @@ function Upgrade(options) {
                     error = 'No version of "' + adapter + '"';
                     return true;
                 }
-                if (!semver.satisfies(iopack.common.version, adapters[adapter])) {
+                if (!semver.satisfies(iopack.common.version, dependencies[adapter])) {
                     error = 'Invalid version of "' + adapter + '"';
                     return true;
                 }

--- a/lib/setup/setupUpgrade.js
+++ b/lib/setup/setupUpgrade.js
@@ -89,7 +89,7 @@ function Upgrade(options) {
                     return true;
                 }
                 if (!semver.satisfies(iopack.common.version, dependencies[adapter])) {
-                    error = `Invalid version of js-controler. Required ${dependencies[adapter]}`;
+                    error = `Invalid version of js-controller. Required ${dependencies[adapter]}`;
                     return true;
                 }
             } else if (adapterDir === null) {

--- a/lib/setup/setupUpgrade.js
+++ b/lib/setup/setupUpgrade.js
@@ -67,24 +67,38 @@ function Upgrade(options) {
         let adapters;
         if (dependencies) {
             // if like [{"js-controller": ">=0.10.1"}]
-            if (dependencies instanceof Array) {
+            if (Array.isArray(dependencies)) {
                 adapters = {};
                 dependencies.filter(a => typeof dependencies[a] !== 'string')
-                    .forEach(rule => Object.keys(rule).filter(adapter => !adapters[adapter]).forEach(adapter => adapters[adapter] = rule[adapter]));
-            } // if like {"js-controller": ">=0.10.1", "admin": ">=0.5.6"}
-            else {
+                    .forEach(rule => {
+                        if (typeof rule === 'string') {
+                            // No version given, all are okay
+                            adapters[rule] = '*';
+                        } else if (tools.isObject(rule)) {
+                            Object.keys(rule).filter(adapter => !adapters[adapter]).forEach(adapter => adapters[adapter] = rule[adapter]);
+                        }
+                    });
+            } else {
+                // if like {"js-controller": ">=0.10.1", "admin": ">=0.5.6"}
                 adapters = dependencies;
             }
         }
 
         if (globalDependencies) {
             // if like [{"js-controller": ">=0.10.1"}]
-            if (globalDependencies instanceof Array) {
+            if (Array.isArray(globalDependencies)) {
                 adapters = adapters || {};
                 globalDependencies.filter(a => typeof globalDependencies[a] !== 'string')
-                    .forEach(rule => Object.keys(rule).filter(adapter => !adapters[adapter]).forEach(adapter => adapters[adapter] = rule[adapter]));
-            } // if like {"js-controller": ">=0.10.1", "admin": ">=0.5.6"}
-            else {
+                    .forEach(rule => {
+                        if (typeof rule === 'string') {
+                            // No version given, all are okay
+                            adapters[rule] = '*';
+                        } else if (tools.isObject(rule)) {
+                            Object.keys(rule).filter(adapter => !adapters[adapter]).forEach(adapter => adapters[adapter] = rule[adapter]);
+                        }
+                    });
+            } else {
+                // if like {"js-controller": ">=0.10.1", "admin": ">=0.5.6"}
                 adapters = adapters || {};
                 Object.assign(adapters, globalDependencies);
             }

--- a/lib/setup/setupUpgrade.js
+++ b/lib/setup/setupUpgrade.js
@@ -112,6 +112,10 @@ function Upgrade(options) {
                     error = 'Invalid version of js-controler. Required ' + adapters[adapter];
                     return true;
                 }
+            } else if (adapterDir === null) {
+                // no adapter directory found
+                error = `Cannot determine adapter directory of ${adapter}`;
+                return true;
             } else {
                 try {
                     iopack = JSON.parse(fs.readFileSync(adapterDir + '/io-package.json', 'utf8'));

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -2014,7 +2014,7 @@ function removeIdFromAllEnums(objects, id) {
  * @returns {object} parsed dependencies
  */
 function parseDependencies(dependencies) {
-    const adapters = {};
+    let adapters = {};
     if (Array.isArray(dependencies)) {
         dependencies.forEach(rule => {
             if (typeof rule === 'string') {
@@ -2028,6 +2028,9 @@ function parseDependencies(dependencies) {
     } else if (typeof dependencies === 'string') {
         // its a single string without version requirement
         adapters[dependencies] = '*';
+    } else if (isObject(dependencies)) {
+        // if dependencies is already an object, just use it
+        adapters = dependencies;
     }
     return adapters;
 }

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -1026,6 +1026,14 @@ function sendDiagInfo(obj, callback) {
     });
 }
 
+/**
+ * Finds the adapter directory of a given adapter
+ *
+ * @alias getAdapterDir
+ * @memberof tools
+ * @param {string} adapter name of the adapter, e.g. hm-rpc
+ * @returns {string|null} path to adapter directory or null if no directory found
+ */
 function getAdapterDir(adapter) {
     const appName = module.exports.appName;
 
@@ -1034,19 +1042,19 @@ function getAdapterDir(adapter) {
     }
 
     const possibilities = [
-        appName.toLowerCase() + '.' + adapter + '/package.json',
-        appName + '.' + adapter + '/package.json'
+        `${appName.toLowerCase()}.${adapter}/package.json`,
+        `${appName}.${adapter}/package.json`
     ];
 
     /** @type {string} */
     let adapterPath;
-    for (let i = 0; i < possibilities.length; i++) {
+    for (const possibility of possibilities) {
         // special case to not read adapters from js-controller/node_module/adapter adn check first in parent directory
-        if (fs.existsSync(__dirname + '/../../' + possibilities[i])) {
-            adapterPath = __dirname + '/../../' + possibilities[i];
+        if (fs.existsSync(`${__dirname}/../../${possibility}`)) {
+            adapterPath = `${__dirname}/../../${possibility}`;
         } else {
             try {
-                adapterPath = require.resolve(possibilities[i]);
+                adapterPath = require.resolve(possibility);
                 break;
             } catch (e) { /* not found */ }
         }

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -2006,6 +2006,33 @@ function removeIdFromAllEnums(objects, id) {
 }
 
 /**
+ * Parses dependencies to standardized object of form
+ *
+ * @alias parseDependencies
+ * @memberof tools
+ * @param {string[]|object[]|string} dependencies dependencies array or single dependency
+ * @returns {object} parsed dependencies
+ */
+function parseDependencies(dependencies) {
+    const adapters = {};
+    if (Array.isArray(dependencies)) {
+        dependencies.forEach(rule => {
+            if (typeof rule === 'string') {
+                // No version given, all are okay
+                adapters[rule] = '*';
+            } else if (isObject(rule)) {
+                // can be object containing single adapter or multiple
+                Object.keys(rule).filter(adapter => !adapters[adapter]).forEach(adapter => adapters[adapter] = rule[adapter]);
+            }
+        });
+    } else if (typeof dependencies === 'string') {
+        // its a single string without version requirement
+        adapters[dependencies] = '*';
+    }
+    return adapters;
+}
+
+/**
  * Validates types of obj.common properties and object.type, if invalid types are used, an error is thrown.
  * If attributes of obj.common are not provided, no error is thrown. obj.type has to be there and has to be valid.
  *
@@ -2184,6 +2211,7 @@ module.exports = {
     promiseSequence,
     removeIdFromAllEnums,
     rmdirRecursiveSync,
+    parseDependencies,
     sendDiagInfo,
     upToDate,
     validateGeneralObjectProperties,


### PR DESCRIPTION
…go on with code anymore

- added jsdoc of getAdapterDir
- handle strings as dep, like

```
[
   "hm-rega",
   {"js-controller": ">=2.0.0"}
]
```