### PR TITLE
Add command `iobroker debug adapter` to start Node.js debug sessions

### DIFF
--- a/lib/cli/cliCompact.js
+++ b/lib/cli/cliCompact.js
@@ -1,6 +1,6 @@
 'use strict';
+const CLI = require('./messages.js');
 const CLICommand = require('./cliCommand.js');
-const messages = require('./messages.js');
 const tools = require('../tools.js');
 const fs = require('fs');
 
@@ -47,7 +47,7 @@ module.exports = class CLICompact extends CLICommand {
                     }
                 }
 
-                messages.error.unknownCommand('compact', command);
+                CLI.error.unknownCommand('compact', command);
                 showHelp();
                 return void callback(3);
         }
@@ -120,7 +120,7 @@ module.exports = class CLICompact extends CLICommand {
                     console.log('Compact group:                     ' + (obj.common.compactGroup !== undefined ? obj.common.compactGroup : 1));
                     return void callback();
                 } else {
-                    messages.error.invalidInstance(instance);
+                    CLI.error.invalidInstance(instance);
                     return void callback(24);
                 }
             });
@@ -182,7 +182,7 @@ module.exports = class CLICompact extends CLICommand {
                         return void callback();
                     }
                 } else {
-                    messages.error.invalidInstance(instance);
+                    CLI.error.invalidInstance(instance);
                     return void callback(24);
                 }
             });

--- a/lib/cli/cliDebug.js
+++ b/lib/cli/cliDebug.js
@@ -1,0 +1,84 @@
+'use strict';
+const CLI = require('./messages.js');
+const CLICommand = require('./cliCommand.js');
+const tools = require('../tools.js');
+const fs = require('fs');
+const path = require('path');
+const child_process = require('child_process');
+
+/** Command ioBroker compact ... */
+module.exports = class CLICompact extends CLICommand {
+    /** @param {import('./cliCommand.js').CLICommandOptions} options */
+    constructor(options) {
+        super(options);
+    }
+
+    /**
+     * Executes a command
+     * @param {any[]} args
+     */
+    execute(args) {
+        const { callback, ...params } = this.options;
+        const adapter = args[0];
+        if (!adapter) {
+            CLI.error.requiredArgumentMissing(
+                'adaptername',
+                'debug <adaptername>'
+            );
+            return void callback(34);
+        }
+
+        const adapterDir = tools.getAdapterDir(adapter);
+        if (!adapterDir) {
+            CLI.error.adapterDirNotFound(adapter);
+            return void callback(34);
+        }
+
+        let ioPack;
+        try {
+            ioPack = JSON.parse(
+                fs.readFileSync(
+                    path.join(adapterDir, 'io-package.json'),
+                    'utf8'
+                )
+            );
+        } catch (e) {
+            CLI.error.cannotLoadIoPackage(adapter);
+            return void callback(34);
+        }
+
+        const possibleMainFiles = [
+            ioPack.common.main,
+            'main.js',
+            `${adapter}.js`
+        ];
+        // Try all possible main files
+        for (const mainFile of possibleMainFiles) {
+            const fullFileName = path.join(adapterDir, mainFile);
+            if (fs.existsSync(fullFileName)) {
+                // Start the adapter with force and console logs
+                const adapterArgs = ['--force', '--logs'];
+                // Tell node to attach a debugger
+                const nodeArgs = [
+                    // --inspect[-brk][=[ip]:[port]]
+                    `--inspect${params.wait ? '-brk' : ''}${
+                        !!params.ip || !!params.port ? '=' : ''
+                    }${params.ip || ''}${
+                        !!params.ip && !!params.port ? ':' : ''
+                    }${params.port || ''}`
+                ];
+                // And wait until the sub process has finished
+                const cp = child_process.fork(fullFileName, adapterArgs, {
+                    cwd: adapterDir,
+                    execArgv: nodeArgs
+                });
+                cp.on('exit', code => callback(code || 0));
+                // We've found our main file
+                return;
+            }
+        }
+
+        CLI.error.mainFileNotFound(adapter);
+        callback(1);
+    }
+};

--- a/lib/cli/cliDebug.js
+++ b/lib/cli/cliDebug.js
@@ -34,30 +34,48 @@ module.exports = class CLICompact extends CLICommand {
             return void callback(34);
         }
 
-        let ioPack;
+        // Compile a list of all possible main files
+        const possibleMainFiles = [
+            'main.js',
+            `${adapter}.js`
+        ];
+
+        // Add package.json -> main as the 2nd choice
         try {
-            ioPack = JSON.parse(
+            const pack = JSON.parse(
+                fs.readFileSync(
+                    path.join(adapterDir, 'package.json'),
+                    'utf8'
+                )
+            );
+            if (pack && typeof pack.main === 'string') {
+                possibleMainFiles.unshift(pack.main);
+            }
+        } catch (e) {
+            // Ignore, we have fallback solutions
+        }
+
+        // Add io-package.json -> common.main as the preferred choice
+        try {
+            const ioPack = JSON.parse(
                 fs.readFileSync(
                     path.join(adapterDir, 'io-package.json'),
                     'utf8'
                 )
             );
+            if (ioPack && ioPack.common && typeof ioPack.common.main === 'string') {
+                possibleMainFiles.unshift(ioPack.common.main);
+            }
         } catch (e) {
-            CLI.error.cannotLoadIoPackage(adapter);
-            return void callback(34);
+            // Ignore, we have fallback solutions
         }
 
-        const possibleMainFiles = [
-            ioPack.common.main,
-            'main.js',
-            `${adapter}.js`
-        ];
         // Try all possible main files
         for (const mainFile of possibleMainFiles) {
             const fullFileName = path.join(adapterDir, mainFile);
             if (fs.existsSync(fullFileName)) {
                 // Start the adapter with force and console logs
-                const adapterArgs = ['--force', '--logs'];
+                const adapterArgs = ['--debug'];
                 // Tell node to attach a debugger
                 const nodeArgs = [
                     // --inspect[-brk][=[ip]:[port]]

--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -14,6 +14,7 @@ module.exports = {
         logs:    require('./cliLogs.js'),
         host:    require('./cliHost.js'),
         cert:    require('./cliCert.js'),
-        compact: require('./cliCompact.js')
+        compact: require('./cliCompact.js'),
+        debug:    require('./cliDebug.js')
     }
 };

--- a/lib/cli/messages.js
+++ b/lib/cli/messages.js
@@ -40,6 +40,9 @@ const errorMessages = Object.freeze({
     noInstancesFound: adapter => `Cannot find any instances of "${adapter}"!`,
     invalidInstance: instance => `The instance "${instance}" does not exist!`,
     specifyInstance: (/** @type {string} */ adapter, /** @type {Array<string>?} */adapterInstances) => `The adapter "${adapter}" has multiple instances! Please specify which one should be started: "${adapterInstances.join('", "')}".`,
+    adapterDirNotFound: adapter => `Cannot find the installation dir for adapter "${adapter}"!`,
+    mainFileNotFound: adapter => `Cannot find the main file for adapter "${adapter}"!`,
+    cannotLoadIoPackage: adapter => `Cannot load the io-package.json file for adapter "${adapter}"!`,
 
     wrongCommandPrefix: (
         /** @type {string} */ wrongPrefix,

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -41,6 +41,9 @@ function initYargs() {
                 tools.appName + ' start all - starts js-controller and all adapters\n' +
                 tools.appName + ' restart - restarts the js-controller\n' +
                 tools.appName + ' restart <adapter>[.instance] - restarts a specified adapter\n' +
+                tools.appName + ' debug <adapter> [--ip=<ip>] [--port=<port>] [--wait] - Starts a Node.js debugging session for the adapter\n' +
+                '    --wait stops the execution until the debugger is attached.\n' +
+                '    --ip and --port can be used to change the listen IP and port. Use IP 0.0.0.0 for remote debugging.\n' +
                 tools.appName + ' info - shows the host info\n' +
                 tools.appName + ' logs [adapter] [--watch] [--lines=1000]\n' +
                 tools.appName + ' add <adapter> [desiredNumber] [--enabled] [--host <host>] [--port <port>]\n' +
@@ -180,6 +183,12 @@ function processCommand(command, args, params, callback) {
         case 'stop': {
             const procCommand = new cli.command.process(commandOptions);
             procCommand[command](args);
+            break;
+        }
+
+        case 'debug': {
+            const debugCommand = new cli.command.debug(commandOptions);
+            debugCommand.execute(args);
             break;
         }
 


### PR DESCRIPTION
Fixes: #334 

```
iobroker debug <adapter> [--ip=<ip>] [--port=<port>] [--wait]
```
The base commands starts
```
node --inspect <adapter-main-file> --force --logs
```
--ip and --port change the default listen port for the debugger (e.g. to 0.0.0.0 for remote debugging)
--wait sets a breakpoint in the very first line.