### PR TITLE
add getObjectViewAsync to inmemfiledb non-simulated

### DIFF
--- a/lib/objects/objectsInMemFileDB.js
+++ b/lib/objects/objectsInMemFileDB.js
@@ -2228,6 +2228,19 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
         }
     }
 
+    /** Async version of getObjectView **/
+    getObjectViewAsync(design, search, params, options) {
+        return new Promise((resolve, reject) => {
+            this.getObjectView(design, search, params, options, (err, res) => {
+                if (err) {
+                    reject(err);
+                } else {
+                    resolve(res);
+                }
+            });
+        });
+    }
+
     _getObjectList(params, options, callback) {
         // return rows with id and doc
         const result = {


### PR DESCRIPTION
- in mem file db still used when js-c not running
- getObjectViewAsync is then called when using iob upgrade `<adapter>` via cli but non-existing