### PR TITLE
show combined changelog on upgrade via cli

### DIFF
--- a/lib/setup.js
+++ b/lib/setup.js
@@ -55,9 +55,9 @@ function initYargs() {
                 tools.appName + ' del <adapter> - remove adapter from system\n' +
                 tools.appName + ' del <adapter>.<instance> - remove adapter instance\n' +
                 tools.appName + ' update [repository url] [--updatable/--u] [--installed/--i] [--force/--f] - update repository and optionally filter installed/updateable adapters, use --force to bypass hash check\n' +
-                tools.appName + ' upgrade [repository url]\n' +
-                tools.appName + ' upgrade self [repository url] - upgrade js-controller and all adapters, optionally you can specify the repository url\n' +
-                tools.appName + ' upgrade <adapter> [repository url] - upgrade specified adapter, optionally you can specify the repository url\n' +
+                tools.appName + ' upgrade [repository url] [--y]\n' +
+                tools.appName + ' upgrade self [repository url] [--force] - upgrade js-controller and all adapters, optionally you can specify the repository url\n' +
+                tools.appName + ' upgrade <adapter> [repository url] [--y] - upgrade specified adapter, optionally you can specify the repository url\n' +
                 tools.appName + ' upload <pathToLocalFile> <pathIn' + tools.appName + '>\n' +
                 tools.appName + ' upload all - upload all adapter files to make them available for instances\n' +
                 tools.appName + ' upload <adapter> - upload specified adapter files to make them available for instances\n' +
@@ -708,9 +708,10 @@ function processCommand(command, args, params, callback) {
                             upgrade.upgradeController(repoUrl, params.force, hostAlive && hostAlive.val, callback);
                         });
                     } else {
-                        upgrade.upgradeAdapter(repoUrl, adapter, params.force, callback);
+                        upgrade.upgradeAdapter(repoUrl, adapter, params.force, params.y, callback);
                     }
                 } else {
+                    // upgrade all
                     getRepository(repoUrl, (err, links) => {
                         const result = [];
                         for (const name in links) {
@@ -723,7 +724,7 @@ function processCommand(command, args, params, callback) {
                         }
                         if (links) {
                             result.sort();
-                            upgrade.upgradeAdapterHelper(links, result, 0, false, callback);
+                            upgrade.upgradeAdapterHelper(links, result, 0, false, params.y, callback);
                         } else {
                             // No information
                             return void callback(26);
@@ -737,11 +738,11 @@ function processCommand(command, args, params, callback) {
         case 'clean': {
             const yes = args[0];
             if (yes !== 'yes') {
-                console.log('Command "clean" clears all Objects and States. To execute it write "' + tools.appName + ' clean yes"');
+                console.log(`Command "clean" clears all Objects and States. To execute it write "${tools.appName} clean yes"`);
             } else {
                 dbConnect(params, (_obj, _stat, isNotRun) => {
                     if (!isNotRun) {
-                        console.error('Stop ' + tools.appName + ' first!');
+                        console.error(`Stop ${tools.appName} first!`);
                         return void callback(1);
                     }
                     cleanDatabase(true, count => {

--- a/lib/setup/setupUpgrade.js
+++ b/lib/setup/setupUpgrade.js
@@ -272,28 +272,27 @@ function Upgrade(options) {
         }
 
         // we show changelog (news) and ask user if he really wants to upgrade but only if fd is associated with a tty
-        const showUpgradeDialog = () => {
+        const showUpgradeDialog = (installedVersion, targetVersion) => {
             tty = tty || require('tty');
             if (autoConfirm || !tty.isatty(process.stdout.fd)) {
                 return true;
             }
-            rl = rl || require('readline-sync');
-            let answer;
+
+            semver = semver || require('semver');
+            const isUpgrade = semver.gt(targetVersion, installedVersion);
 
             // if information in repo files -> show news
             if (repoUrl[adapter] && repoUrl[adapter].news) {
                 const news = repoUrl[adapter].news;
-                const installedVersion = ioInstalled.common.version;
-                const targetVersion = version || repoUrl[adapter].version;
 
-                semver = semver || require('semver');
                 let first = true;
                 // check if upgrade or downgrade
-                if (semver.gt(targetVersion, installedVersion)) {
+                if (isUpgrade) {
                     for (const version in news) {
                         if (semver.lte(version, targetVersion) && semver.gt(version, installedVersion)) {
                             if (first === true) {
-                                console.log(`\nThis upgrade of "${adapter}" will at least introduce the following changes:`);
+                                const noMissingNews = news[targetVersion] && news[installedVersion];
+                                console.log(`\nThis upgrade of "${adapter}" will ${noMissingNews ? '' : 'at least '}introduce the following changes:`);
                                 console.log('==========================================================================');
                                 first = false;
                             } else if (first === false) {
@@ -307,7 +306,8 @@ function Upgrade(options) {
                     for (const version in news) {
                         if (semver.gt(version, targetVersion) && semver.lte(version, installedVersion)) {
                             if (first === true) {
-                                console.log(`\nThis downgrade of "${adapter}" will at least remove the following changes:`);
+                                const noMissingNews = news[targetVersion] && news[installedVersion];
+                                console.log(`\nThis downgrade of "${adapter}" will ${noMissingNews ? '' : 'at least '}remove the following changes:`);
                                 console.log('==========================================================================');
                                 first = false;
                             } else if (first === false) {
@@ -323,9 +323,12 @@ function Upgrade(options) {
                 }
             }
 
+            rl = rl || require('readline-sync');
+            let answer;
+
             // ask user if he really wants to upgrade - repeat until (y)es or (n)o given
             do {
-                answer = rl.question(`Would you like to upgrade ${adapter} from @${ioInstalled.common.version} to @${version || repoUrl[adapter].version} now? [(y)es, (n)o]: `, {
+                answer = rl.question(`Would you like to ${isUpgrade ? 'upgrade' : 'downgrade'} ${adapter} from @${ioInstalled.common.version} to @${version || repoUrl[adapter].version} now? [(y)es, (n)o]: `, {
                     defaultInput: 'n'
                 });
 
@@ -356,13 +359,14 @@ function Upgrade(options) {
                     callback();
                 }
             } else {
-                if (!showUpgradeDialog()) {
+                const targetVersion = version || repoUrl[adapter].version;
+                if (!showUpgradeDialog(ioInstalled.common.version, targetVersion)) {
                     console.log(`No upgrade of "${adapter}" desired.`);
                     return typeof callback === 'function' && callback();
                 }
-                console.log(`Update ${adapter} from @${ioInstalled.common.version} to @${version || repoUrl[adapter].version}`);
+                console.log(`Update ${adapter} from @${ioInstalled.common.version} to @${targetVersion}`);
                 // Get the adapter from web site
-                install.downloadPacket(sources, `${adapter}@${version || repoUrl[adapter].version}`, null, (enableAdapterCallback, name, ioPack) => {
+                install.downloadPacket(sources, `${adapter}@${targetVersion}`, null, (enableAdapterCallback, name, ioPack) => {
                     finishUpgrade(name, ioPack, () => enableAdapterCallback(callback));
                 });
             }
@@ -394,19 +398,20 @@ function Upgrade(options) {
                     }
                 } else {
                     // Get the adapter from web site
-                    if (!showUpgradeDialog()) {
+                    const targetVersion = version || ioPack.common.version;
+                    if (!showUpgradeDialog(ioInstalled.common.version, targetVersion)) {
                         console.log(`No upgrade of "${adapter}" desired.`);
                         return typeof callback === 'function' && callback();
                     }
-                    console.log(`Update ${adapter} from @${ioInstalled.common.version} to @${version || ioPack.common.version}`);
-                    install.downloadPacket(sources, `${adapter}@${version || ioPack.common.version}`, null, (enableAdapterCallback, name, ioPack) => {
+                    console.log(`Update ${adapter} from @${ioInstalled.common.version} to @${targetVersion}`);
+                    install.downloadPacket(sources, `${adapter}@${targetVersion}`, null, (enableAdapterCallback, name, ioPack) => {
                         finishUpgrade(name, ioPack, () => enableAdapterCallback(callback));
                     });
                 }
             });
         } else {
             if (forceDowngrade) {
-                if (!showUpgradeDialog()) {
+                if (!showUpgradeDialog(ioInstalled.common.version, version)) {
                     console.log(`No upgrade of "${adapter}" desired.`);
                     return typeof callback === 'function' && callback();
                 }

--- a/lib/setup/setupUpgrade.js
+++ b/lib/setup/setupUpgrade.js
@@ -36,6 +36,8 @@ function Upgrade(options) {
     const params            = options.params;
     const objects           = options.objects;
     let semver;
+    let rl;
+    let tty;
 
     const hostname   = tools.getHostName();
     const EXIT_CODES = require('../exitCodes');
@@ -46,15 +48,30 @@ function Upgrade(options) {
     const Install = require('./setupInstall.js');
     const install = new Install(options);
 
-    this.upgradeAdapterHelper = function (repoUrl, list, i, forceDowngrade, callback) {
-        this.upgradeAdapter(repoUrl, list[i], forceDowngrade, () => {
+    /**
+     * Upgrade multiple adapters from the given repository url
+     *
+     * @param {string} repoUrl url of the selected repository
+     * @param {string[]} list list of adapters to upgrade
+     * @param {number} i current index used by list
+     * @param {boolean} forceDowngrade flag to force downgrade
+     * @param {boolean} autoConfirm automatically confirm the tty questions (bypass)
+     * @param {function} callback callback to be executed after function is finished
+     */
+    this.upgradeAdapterHelper = function (repoUrl, list, i, forceDowngrade, autoConfirm, callback) {
+        if (typeof autoConfirm === 'function') {
+            callback = autoConfirm;
+            autoConfirm = false;
+        }
+
+        this.upgradeAdapter(repoUrl, list[i], forceDowngrade, autoConfirm, () => {
             i++;
             while (repoUrl[list[i]] && repoUrl[list[i]].controller) {
                 i++;
             }
 
             if (list[i]) {
-                setImmediate(() => this.upgradeAdapterHelper(repoUrl, list, i, forceDowngrade, callback));
+                setImmediate(() => this.upgradeAdapterHelper(repoUrl, list, i, forceDowngrade, autoConfirm, callback));
             } else if (callback) {
                 callback();
             }
@@ -136,25 +153,39 @@ function Upgrade(options) {
         }
     }
 
-    this.upgradeAdapter = async function (repoUrl, adapter, forceDowngrade, callback) {
+    /**
+     * Try to upgrade adapter from given source with some checks
+     *
+     * @param {string} repoUrl url of the selected repository
+     * @param {string} adapter name of the adapter
+     * @param {boolean} forceDowngrade flag to force downgrade
+     * @param {boolean} autoConfirm automatically confirm the tty questions (bypass)
+     * @param {function} callback callback to be executed after function is finished
+     */
+    this.upgradeAdapter = async function (repoUrl, adapter, forceDowngrade, autoConfirm, callback) {
+        if (typeof autoConfirm === 'function') {
+            callback = autoConfirm;
+            autoConfirm = false;
+        }
+
         if (!repoUrl || typeof repoUrl !== 'object') {
             getRepository(repoUrl, params, (err, sources) => {
                 if (err) {
                     processExit(err);
                 } else {
-                    this.upgradeAdapter(sources, adapter, forceDowngrade, callback);
+                    this.upgradeAdapter(sources, adapter, forceDowngrade, autoConfirm, callback);
                 }
             });
             return;
         }
 
-        function finishUpgrade(name, iopack, callback) {
+        const finishUpgrade = (name, iopack, callback) => {
             if (!iopack) {
                 const adapterDir = tools.getAdapterDir(name);
                 try {
-                    iopack = JSON.parse(fs.readFileSync(adapterDir + '/io-package.json', 'utf8'));
+                    iopack = JSON.parse(fs.readFileSync(`${adapterDir}/io-package.json`, 'utf8'));
                 } catch (e) {
-                    console.error('Cannot find io-package.json in ' + adapterDir);
+                    console.error(`Cannot find io-package.json in ${adapterDir}`);
                     processExit(EXIT_CODES.MISSING_ADAPTER_FILES);
                 }
             }
@@ -172,7 +203,7 @@ function Upgrade(options) {
                         upload.upgradeAdapterObjects(name, iopack, () => {
                             count--;
                             if (!count) {
-                                console.log('Adapter "' + name + '" updated');
+                                console.log(`Adapter "${name}" updated`);
                                 if (callback) {
                                     callback(name);
                                 }
@@ -191,7 +222,7 @@ function Upgrade(options) {
                     });
                 }
             });
-        }
+        };
 
         const sources = repoUrl;
         let version;
@@ -240,6 +271,73 @@ function Upgrade(options) {
             ioInstalled = {common: {version: '0.0.0'}};
         }
 
+        // we show changelog (news) and ask user if he really wants to upgrade but only if fd is associated with a tty
+        const showUpgradeDialog = () => {
+            tty = tty || require('tty');
+            if (autoConfirm || !tty.isatty(process.stdout.fd)) {
+                return true;
+            }
+            rl = rl || require('readline-sync');
+            let answer;
+
+            // if information in repo files -> show news
+            if (repoUrl[adapter] && repoUrl[adapter].news) {
+                const news = repoUrl[adapter].news;
+                const installedVersion = ioInstalled.common.version;
+                const targetVersion = version || repoUrl[adapter].version;
+
+                semver = semver || require('semver');
+                let first = true;
+                // check if upgrade or downgrade
+                if (semver.gt(targetVersion, installedVersion)) {
+                    for (const version in news) {
+                        if (semver.lte(version, targetVersion) && semver.gt(version, installedVersion)) {
+                            if (first === true) {
+                                console.log(`\nThis upgrade of "${adapter}" will at least introduce the following changes:`);
+                                console.log('==========================================================================');
+                                first = false;
+                            } else if (first === false) {
+                                console.log();
+                            }
+                            console.log(`-> ${version}:`);
+                            console.log(news[version].en);
+                        }
+                    }
+                } else {
+                    for (const version in news) {
+                        if (semver.gt(version, targetVersion) && semver.lte(version, installedVersion)) {
+                            if (first === true) {
+                                console.log(`\nThis downgrade of "${adapter}" will at least remove the following changes:`);
+                                console.log('==========================================================================');
+                                first = false;
+                            } else if (first === false) {
+                                console.log();
+                            }
+                            console.log(`-> ${version}`);
+                            console.log(news[version].en);
+                        }
+                    }
+                }
+                if (first === false) {
+                    console.log('==========================================================================\n');
+                }
+            }
+
+            // ask user if he really wants to upgrade - repeat until (y)es or (n)o given
+            do {
+                answer = rl.question(`Would you like to upgrade ${adapter} from @${ioInstalled.common.version} to @${version || repoUrl[adapter].version} now? [(y)es, (n)o]: `, {
+                    defaultInput: 'n'
+                });
+
+                answer = answer.toLowerCase();
+
+                if (answer === 'n' || answer === 'no') {
+                    return false;
+                }
+            } while (answer !== 'y' && answer !== 'yes');
+            return true;
+        };
+
         // If version is included in repository
         if (repoUrl[adapter].version) {
             if (!forceDowngrade) {
@@ -258,9 +356,13 @@ function Upgrade(options) {
                     callback();
                 }
             } else {
+                if (!showUpgradeDialog()) {
+                    console.log(`No upgrade of "${adapter}" desired.`);
+                    return typeof callback === 'function' && callback();
+                }
                 console.log(`Update ${adapter} from @${ioInstalled.common.version} to @${version || repoUrl[adapter].version}`);
                 // Get the adapter from web site
-                install.downloadPacket(sources, adapter + '@' + (version || repoUrl[adapter].version), null, (enableAdapterCallback, name, ioPack) => {
+                install.downloadPacket(sources, `${adapter}@${version || repoUrl[adapter].version}`, null, (enableAdapterCallback, name, ioPack) => {
                     finishUpgrade(name, ioPack, () => enableAdapterCallback(callback));
                 });
             }
@@ -268,7 +370,7 @@ function Upgrade(options) {
             // Read repository from url or file
             tools.getJson(repoUrl[adapter].meta, async ioPack => {
                 if (!ioPack) {
-                    console.error('Cannot parse file' + repoUrl[adapter].meta);
+                    console.error(`Cannot parse file${repoUrl[adapter].meta}`);
                     if (callback) {
                         callback();
                     }
@@ -286,28 +388,36 @@ function Upgrade(options) {
 
                 if (!version && (ioPack.common.version === ioInstalled.common.version ||
                     (!forceDowngrade && tools.upToDate(ioPack.common.version, ioInstalled.common.version)))) {
-                    console.log('Adapter "' + adapter + '"' + ((adapter.length < 15) ? new Array(15 - adapter.length).join(' ') : '') + ' is up to date.');
+                    console.log(`Adapter "${adapter}"${(adapter.length < 15) ? new Array(15 - adapter.length).join(' ') : ''} is up to date.`);
                     if (callback) {
                         callback();
                     }
                 } else {
                     // Get the adapter from web site
-                    console.log('Update ' + adapter + ' from @' + ioInstalled.common.version + ' to @' + (version || ioPack.common.version));
-                    install.downloadPacket(sources, adapter + '@' + (version || ioPack.common.version), null, (enableAdapterCallback, name, ioPack) => {
+                    if (!showUpgradeDialog()) {
+                        console.log(`No upgrade of "${adapter}" desired.`);
+                        return typeof callback === 'function' && callback();
+                    }
+                    console.log(`Update ${adapter} from @${ioInstalled.common.version} to @${version || ioPack.common.version}`);
+                    install.downloadPacket(sources, `${adapter}@${version || ioPack.common.version}`, null, (enableAdapterCallback, name, ioPack) => {
                         finishUpgrade(name, ioPack, () => enableAdapterCallback(callback));
                     });
                 }
             });
         } else {
             if (forceDowngrade) {
-                console.warn('Unable to get version for "' + adapter + '". Update anyway.');
-                console.log('Update ' + adapter + ' from @' + ioInstalled.common.version + ' to @' + version);
+                if (!showUpgradeDialog()) {
+                    console.log(`No upgrade of "${adapter}" desired.`);
+                    return typeof callback === 'function' && callback();
+                }
+                console.warn(`Unable to get version for "${adapter}". Update anyway.`);
+                console.log(`Update ${adapter} from @${ioInstalled.common.version} to @${version}`);
                 // Get the adapter from web site
-                install.downloadPacket(sources, adapter + '@' + version, null, (enableAdapterCallback, name, ioPack) => {
+                install.downloadPacket(sources, `${adapter}@${version}`, null, (enableAdapterCallback, name, ioPack) => {
                     finishUpgrade(name, ioPack, () => enableAdapterCallback(callback));
                 });
             } else {
-                console.error('Unable to get version for "' + adapter + '".');
+                console.error(`Unable to get version for "${adapter}".`);
                 if (callback) {
                     callback();
                 }
@@ -323,7 +433,7 @@ function Upgrade(options) {
         if (!repoUrl || typeof repoUrl !== 'object') {
             getRepository(repoUrl, params, (err, sources) => {
                 if (!sources) {
-                    console.warn('Cannot get repository under "' + repoUrl + '"');
+                    console.warn(`Cannot get repository under "${repoUrl}"`);
                     if (callback) {
                         callback(err);
                     }
@@ -355,7 +465,7 @@ function Upgrade(options) {
         if (repoUrl[installed.common.name].version) {
             if (!forceDowngrade && (repoUrl[installed.common.name].version === installed.common.version ||
                 tools.upToDate(repoUrl[installed.common.name].version, installed.common.version))) {
-                console.log('Host    "' + hostname + '"' + ((hostname.length < 15) ? new Array(15 - hostname.length).join(' '): '') + ' is up to date.');
+                console.log(`Host    "${hostname}"${(hostname.length < 15) ? new Array(15 - hostname.length).join(' ') : ''} is up to date.`);
                 if (callback) {
                     callback();
                 }
@@ -365,9 +475,9 @@ function Upgrade(options) {
                     callback();
                 }
             } else {
-                console.log('Update ' +  installed.common.name + ' from @' + installed.common.version + ' to @' +  repoUrl[installed.common.name].version);
+                console.log(`Update ${installed.common.name} from @${installed.common.version} to @${repoUrl[installed.common.name].version}`);
                 // Get the controller from web site
-                install.downloadPacket(repoUrl, installed.common.name + '@' + repoUrl[installed.common.name].version, null, (enableAdapterCallback, _name) => {
+                install.downloadPacket(repoUrl, `${installed.common.name}@${repoUrl[installed.common.name].version}`, null, (enableAdapterCallback, _name) => {
                     installNpm((err, _name) => {
                         if (err) {
                             processExit(err);
@@ -380,7 +490,7 @@ function Upgrade(options) {
         } else {
             tools.getJson(repoUrl[installed.common.name].meta, ioPack => {
                 if ((!ioPack || !ioPack.common) && !forceDowngrade) {
-                    console.warn('Cannot read version. Write "' + tools.appName + ' upgrade self --force" to upgrade controller anyway.');
+                    console.warn(`Cannot read version. Write "${tools.appName} upgrade self --force" to upgrade controller anyway.`);
                     if (callback) {
                         callback();
                     }
@@ -388,12 +498,12 @@ function Upgrade(options) {
                 }
                 let version = (ioPack && ioPack.common) ? ioPack.common.version : '';
                 if (version) {
-                    version = '@' + version;
+                    version = `@${version}`;
                 }
 
                 if ((ioPack && ioPack.common && ioPack.common.version === installed.common.version) ||
                     (!forceDowngrade && ioPack && ioPack.common && tools.upToDate(ioPack.common.version, installed.common.version))) {
-                    console.log('Host    "' + hostname + '"' + ((hostname.length < 15) ? new Array(15 - hostname.length).join(' '): '') + ' is up to date.');
+                    console.log(`Host    "${hostname}"${(hostname.length < 15) ? new Array(15 - hostname.length).join(' ') : ''} is up to date.`);
                     if (callback) {
                         callback();
                     }
@@ -404,7 +514,7 @@ function Upgrade(options) {
                     }
                 } else {
                     const name = (ioPack && ioPack.common && ioPack.common.name) ? ioPack.common.name : installed.common.name;
-                    console.log('Update ' + name + ' from @' + installed.common.version + ' to ' + version);
+                    console.log(`Update ${name} from @${installed.common.version} to ${version}`);
                     // Get the controller from web site
                     install.downloadPacket(repoUrl, name + version, null, (enableAdapterCallback, _name) => {
                         installNpm((err, _name) => {


### PR DESCRIPTION
- you can bypass this by --y flag
- if output isnt a tty check is bypassed automatically
- this is meant for v3.1
- closes #541 

Example:
```
moritz@moritz-XPS-13-9360:~/workspaces/ioBroker.js-controller$ iob upgrade hm-rega@2.6.2

This downgrade of "hm-rega" will at least remove the following changes:
==========================================================================
-> 2.6.4
we are now using iobroker file storage for regascripts
==========================================================================

Would you like to upgrade hm-rega from @2.6.4 to @2.6.2 now? [(y)es, (n)o]: 
```

and 

```
moritz@moritz-XPS-13-9360:~/workspaces/ioBroker.js-controller$ iob upgrade hm-rega

This upgrade of "hm-rega" will at least introduce the following changes:
==========================================================================
-> 2.6.4:
we are now using iobroker file storage for regascripts

-> 2.6.2:
minor fix on CCU object

-> 2.6.1:
added Sentry plugin support

-> 2.5.5:
logging of script name added, when script is still in pending queue

-> 2.5.4:
made port fully configurable also with https enabled

-> 2.5.3:
improved error handling in edge cases and more verbose logging on errors
==========================================================================

Would you like to upgrade hm-rega from @2.5.2 to @2.6.4 now? [(y)es, (n)o]: 
```