### PR TITLE
Refactor Package Manager to use async/await

### DIFF
--- a/lib/setup/setupPacketManager.js
+++ b/lib/setup/setupPacketManager.js
@@ -30,32 +30,27 @@ class PacketManager {
         };
         this.dpkg = false;
         this.sudo = false;
-        /** @type {Promise<any>[]} */
-        this._readyPromises = [];
+        this._readyPromise = this._init();
+    }
 
+    /** Starts the initialization process */
+    async _init() {
         if (process.platform !== 'win32') {
-            !this.manager && this._readyPromises.push(this._detectManager()
-                .then(manager => {
-                    this.logger && this.logger.debug('Detected packet manager: ' + manager);
-                    return this._isSudoAvailable();
-                })
-                .then(isSudo => {
-                    if (isSudo) {
-                        // Check if sudo is available for packet manager and store information
-                        return this._isSudoAvailableForManager().then(res => this.sudo = !!res);
-                    }
-                })
-            );
+            if (!this.manager) {
+                const manager = await this._detectManager();
+                this.logger && this.logger.debug('Detected packet manager: ' + manager);
+                // Check if sudo is available for packet manager and store information
+                this.sudo = await this._isSudoAvailable() && await this._isSudoAvailableForManager();
+            }
 
-            this._readyPromises.push(this._isDpkgAvailable().then(result => {
-                this.dpkg = !!result;
-                this.logger && this.logger.debug('Detected dpkg: ' + this.dpkg);
-            }));
+            // Check if dpkg is available
+            this.dpkg = await this._isDpkgAvailable();
+            this.logger && this.logger.debug('Detected dpkg: ' + this.dpkg);
         }
     }
 
     ready() {
-        return Promise.all(this._readyPromises);
+        return this._readyPromise;
     }
 
     /**
@@ -139,18 +134,22 @@ class PacketManager {
         }
     }
 
-    checkInstalled(packets) {
+    /**
+     * Checks which packages are installed and returns them
+     * @param {string[]} packets The packets to test
+     * @returns {Promise<string[]>}
+     */
+    async checkInstalled(packets) {
         if (!(packets instanceof Array)) {
             packets = [packets];
         }
 
-        return this._listPackages()
-            .catch(() => '')
-            .then(text => packets.map(packet => (text || '').includes(packet)));
+        const installed = await this._listPackages();
+        return packets.filter(p => installed.includes(p));
     }
 
     /**
-     * Installs a packet and returns the stdout if there was any
+     * Installs a single packet using the configured manager and returns the stdout if there was any
      * @param {string} packet The packet to install
      */
     async _installPacket(packet) {
@@ -167,34 +166,50 @@ class PacketManager {
         }
     }
 
-    _installPackets(packets, cb) {
+    /**
+     * Installs multiple packets. The returned Promise contains the list of failed packets
+     * @param {string[]} packets
+     * @returns {Promise<string[]>}
+     */
+    async _installPackets(packets) {
         if (!packets || !packets.length) {
-            cb && cb();
+            return;
         } else {
-            const packet = packets.shift();
-
-            this._installPacket(packet)
-                .catch(e => this.logger.error(`Cannot install "${packet}": ` + e))
-                .then(() => setImmediate(() => this._installPackets(packets, cb)));
+            /** @type {string[]} */
+            const failed = [];
+            // Install all packets
+            for (const packet of packets) {
+                try {
+                    await this._installPacket(packet);
+                } catch (e) {
+                    failed.push(packet);
+                    this.logger.error(`Cannot install "${packet}": ${e}`);
+                    // Continue with the next packet
+                }
+            }
+            return failed;
         }
     }
 
-    install(packets) {
+    /**
+     * Installs all given packets
+     * @param {string[] | string} packets
+     * @returns {Promise<void>}
+     */
+    async install(packets) {
         packets = packets || [];
         if (!(packets instanceof Array)) {
             packets = [packets];
         }
 
-        return this.ready()
-            .then(() => this.checkInstalled(packets))
-            .then(result => {
-                // filter non installed packets
-                packets = packets.filter((name, i) => !result[i]);
-                // install packets one after each other
-                return new Promise(resolve =>
-                    this._installPackets(packets, () => resolve()));
-            })
-            .catch(() => this.logger && this.logger.warn(`Some ${this.manager || 'OS'} packages could not be installed. Please install them manually`));
+        await this.ready();
+        const installed = await this.checkInstalled(packets);
+        const notInstalled = packets.filter(packet => !installed.includes(packet));
+        // Install all non-installed packets
+        const failed = await this._installPackets(notInstalled);
+        if (failed.length > 0 && this.logger) {
+            this.logger.warn(`The following ${this.manager || 'OS'} packages could not be installed: ${failed.join(', ')}. Please install them manually.`);
+        }
     }
 }
 

--- a/lib/setup/setupPacketManager.js
+++ b/lib/setup/setupPacketManager.js
@@ -130,21 +130,18 @@ class PacketManager {
                 });
                 _cmd.on('exit', code => {
                     if (!code) {
-                        resolve && resolve(true);
+                        resolve(true);
                     } else {
-                        resolve && resolve(false);
+                        resolve(false);
                     }
-                    resolve = null;
                 });
                 _cmd.on('error', e => {
                     this.logger && this.logger.error('Cannot detect sudo: ' + e);
-                    resolve && resolve(false);
-                    resolve = null;
+                    resolve(false);
                 });
             } catch (e) {
                 this.logger && this.logger.error('Cannot detect sudo: ' + e);
-                resolve && resolve(false);
-                resolve = null;
+                resolve(false);
             }
         });
     }

--- a/lib/setup/setupPacketManager.js
+++ b/lib/setup/setupPacketManager.js
@@ -2,7 +2,7 @@
 
 // TODO: how to pass sudo requirement for apt-get?
 
-const exec = require('child_process').exec;
+const { execAsync } = require('../tools');
 
 const LOG_LEVELS = {
     'silly': 4,
@@ -18,6 +18,7 @@ class PacketManager {
         options = options || {logLevel: LOG_LEVELS.info};
 
         // detect apt, apt-get or yum
+        /** @type {string} */
         this.manager = (options && options.manager) || '';
         this.logger = (options && options.logger) || {
             silly: text => options.logLevel >= LOG_LEVELS.silly && console.log(text),
@@ -29,6 +30,7 @@ class PacketManager {
         };
         this.dpkg = false;
         this.sudo = false;
+        /** @type {Promise<any>[]} */
         this._readyPromises = [];
 
         if (process.platform !== 'win32') {
@@ -56,144 +58,84 @@ class PacketManager {
         return Promise.all(this._readyPromises);
     }
 
-    _isCmd(cmd) {
-        return new Promise(resolve => {
-            try {
-                const _cmd = exec(cmd, {windowsHide: true}, (err, stdout, stderr) => {
-                    if (!stderr) {
-                        resolve(cmd);
-                    } else {
-                        resolve();
-                    }
-                });
+    /**
+     * Tests if the given command can be executed
+     * @param {string} cmd The command to test
+     * @returns {Promise<boolean>} True if the execution was successful, false otherwise
+     */
+    async _isCmd(cmd) {
+        try {
+            const { stderr } = await execAsync(cmd);
+            return !stderr;
+        } catch (e) {
+            console.error(e);
+            return false;
+        }
+    }
 
-                _cmd.on('error', e => {
-                    console.error(e);
-                    resolve();
-                });
-            } catch (e) {
-                console.error(e);
-                resolve();
+    async _isDpkgAvailable() {
+        try {
+            const { stdout, stderr } = await execAsync('dpkg');
+            if ((stdout && stdout.includes('dpkg --help')) || (stderr && stderr.includes('dpkg --help'))) {
+                return true;
+            } else {
+                return false;
             }
-        });
+        } catch (e) {
+            this.logger && this.logger.error('Cannot detect dpkg: ' + (e.stderr || e.stdout || e));
+            return false;
+        }
     }
 
-    _isDpkgAvailable() {
-        return new Promise(resolve => {
-            try {
-                const _cmd = exec('dpkg', {windowsHide: true}, (err, stdout, stderr) => {
-                    if ((stdout && stdout.includes('dpkg --help')) || (stderr && stderr.includes('dpkg --help'))) {
-                        resolve(true);
-                    } else {
-                        resolve(false);
-                    }
-                });
-
-                _cmd.on('error', e => {
-                    this.logger && this.logger.error('Cannot detect dpkg: ' + e);
-                    resolve(false);
-                });
-            } catch (e) {
-                this.logger && this.logger.error('Cannot detect dpkg: ' + e);
-                resolve(false);
+    async _isSudoAvailable() {
+        try {
+            const { stdout, stderr } = await execAsync('sudo');
+            if ((stdout && stdout.includes('sudo -h')) || (stderr && stderr.includes('sudo -h'))) {
+                return true;
+            } else {
+                return false;
             }
-        });
+        } catch (e) {
+            this.logger && this.logger.error('Cannot detect sudo: ' + (e.stderr || e.stdout || e));
+            return false;
+        }
     }
 
-    _isSudoAvailable() {
-        return new Promise(resolve => {
-            try {
-                const _cmd = exec('sudo', {windowsHide: true}, (err, stdout, stderr) => {
-                    if ((stdout && stdout.includes('sudo -h')) || (stderr && stderr.includes('sudo -h'))) {
-                        resolve(true);
-                    } else {
-                        resolve(false);
-                    }
-                });
+    async _isSudoAvailableForManager() {
+        try {
+            await execAsync(`sudo -n ${this.manager} -v`);
+            return true;
+        } catch (e) {
+            this.logger && this.logger.error(`Cannot detect \\"sudo -n ${this.manager} -v\\": ${e.stderr || e.stdout || e}`);
+            return false;
+        }
+    }
 
-                _cmd.on('error', e => {
-                    this.logger && this.logger.error('Cannot detect sudo: ' + e);
-                    resolve(false);
-                });
-            } catch (e) {
-                this.logger && this.logger.error('Cannot detect sudo: ' + e);
-                resolve(false);
+    /**
+     * Detects which package manager is installed. Throws if none can be found
+     */
+    async _detectManager() {
+        for (const cmd of ['apt-get', 'apt', 'yum']) {
+            if (await this._isCmd(cmd)) {
+                this.manager = cmd;
+                return cmd;
             }
-        });
+        }
+        this.logger && this.logger.info('No supported packet manager found');
+        throw new Error('No supported packet manager found');
     }
 
-    _isSudoAvailableForManager() {
-        return new Promise(resolve => {
-            try {
-                const _cmd = exec('sudo -n ' + this.manager + ' -v', {windowsHide: true}, (err, stdout, stderr) => {
-                    this.logger && stderr && this.logger.error('Cannot detect "sudo -n ' + this.manager + ' -v": ' + stderr);
-                });
-                _cmd.on('exit', code => {
-                    if (!code) {
-                        resolve(true);
-                    } else {
-                        resolve(false);
-                    }
-                });
-                _cmd.on('error', e => {
-                    this.logger && this.logger.error('Cannot detect sudo: ' + e);
-                    resolve(false);
-                });
-            } catch (e) {
-                this.logger && this.logger.error('Cannot detect sudo: ' + e);
-                resolve(false);
-            }
-        });
-    }
-
-    _detectManager() {
-        return this._isCmd('apt-get')
-            .then(result => {
-                if (result) {
-                    this.manager = result;
-                    return this.manager;
-                } else {
-                    return this._isCmd('apt');
-                }
-            })
-            .then(result => {
-                if (result) {
-                    this.manager = result;
-                    return this.manager;
-                } else {
-                    return this._isCmd('yum');
-                }
-            })
-            .then(result => {
-                if (result) {
-                    this.manager = result;
-                    return this.manager;
-                } else {
-                    this.logger && this.logger.info('No supported packet manager found');
-                    return Promise.reject('No supported packet manager found');
-                }
-            });
-    }
-
-    _listPackages() {
+    async _listPackages() {
         if (!this.dpkg) {
-            return Promise.reject('No dpkg detected');
-        } else {
-            return new Promise(resolve => {
-                try {
-                    const _cmd = exec((this.sudo ? 'sudo ' : '') + 'dpkg -l', {windowsHide: true}, (err, stdout) => {
-                        if (stdout) {
-                            resolve(stdout);
-                        } else {
-                            resolve('');
-                        }
-                    });
+            throw new Error('No dpkg detected');
+        }
 
-                    _cmd.on('error', () => resolve(''));
-                } catch (e) {
-                    resolve('');
-                }
-            });
+        try {
+            const { stdout } = await execAsync(`${this.sudo ? 'sudo ' : ''}dpkg -l`);
+            return stdout || '';
+        } catch (e) {
+            // Ignore error
+            return '';
         }
     }
 
@@ -207,27 +149,22 @@ class PacketManager {
             .then(text => packets.map(packet => (text || '').includes(packet)));
     }
 
-    _installPacket(packet) {
+    /**
+     * Installs a packet and returns the stdout if there was any
+     * @param {string} packet The packet to install
+     */
+    async _installPacket(packet) {
         if (!this.manager) {
             // ignore
-            return Promise.resolve(true);
+            return true;
         }
-        return new Promise(resolve => {
-            try {
-                const _cmd = exec((this.sudo ? 'sudo ' : '') + this.manager + ' install ' + packet + ' -y', {windowsHide: true}, (err, stdout) => {
-                    if (err) {
-                        this.logger.error(`Cannot install ${packet}: ${err.toString()}`);
-                        resolve();
-                    } else {
-                        resolve(stdout);
-                    }
-                });
-
-                _cmd.on('error', () => resolve());
-            } catch (e) {
-                resolve();
-            }
-        });
+        try {
+            const { stdout } = await execAsync(`${(this.sudo ? 'sudo ' : '') + this.manager} install ${packet} -y`);
+            return stdout;
+        } catch (e) {
+            // Log error and continue
+            this.logger.error(`Cannot install ${packet}: ${e.stderr || e.stdout || e}`);
+        }
     }
 
     _installPackets(packets, cb) {

--- a/lib/setup/setupPacketManager.js
+++ b/lib/setup/setupPacketManager.js
@@ -207,8 +207,13 @@ class PacketManager {
         const notInstalled = packets.filter(packet => !installed.includes(packet));
         // Install all non-installed packets
         const failed = await this._installPackets(notInstalled);
-        if (failed.length > 0 && this.logger) {
-            this.logger.warn(`The following ${this.manager || 'OS'} packages could not be installed: ${failed.join(', ')}. Please install them manually.`);
+        if (this.logger) {
+            if (failed.length > 0) {
+                this.logger.warn(`The following ${this.manager || 'OS'} packages could not be installed: ${failed.join(', ')}. Please install them manually.`);
+            } else {
+                this.logger.info(`Installed the following ${this.manager || 'OS'} packages: ${notInstalled.join(', ')}`);
+                this.logger.info(`These packages were already installed: ${installed.join(', ')}`);
+            }
         }
     }
 }

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -2208,11 +2208,30 @@ function getInstances(adapter, objects, withObjects, callback) {
     });
 }
 
+/**
+ * Executes a command asynchronously. On success, the promise resolves with stdout and stderr.
+ * On error, the promise rejects with the exit code or signal, as well as stdout and stderr.
+ * @param {string} command The command to execute
+ * @param {import("child_process").ExecOptions} [execOptions] The options for child_process.exec
+ * @returns {import("child_process").ChildProcess & Promise<{stdout?: string; stderr?: string}>}
+ */
+function execAsync(command, execOptions) {
+    const defaultOptions = {
+        // we do not want to show the node.js window on Windows
+        windowsHide: true,
+        // And we want to capture stdout/stderr
+        encoding: 'utf8'
+    };
+    // @ts-ignore We set the encoding, so stdout/stdrr must be a string
+    return require('promisify-child-process').exec(command, { ...defaultOptions, ...execOptions });
+}
+
 module.exports = {
     appName: getAppName(),
     createUuid,
     decryptPhrase,
     encryptPhrase,
+    execAsync,
     findIPs,
     generateDefaultCertificates,
     getAdapterDir,

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -6,6 +6,7 @@ const semver    = require('semver');
 const os        = require('os');
 const forge     = require('node-forge');
 const deepClone = require('deep-clone');
+const cpPromise = require('promisify-child-process');
 
 // @ts-ignore
 require('events').EventEmitter.prototype._maxListeners = 100;
@@ -2223,7 +2224,7 @@ function execAsync(command, execOptions) {
         encoding: 'utf8'
     };
     // @ts-ignore We set the encoding, so stdout/stdrr must be a string
-    return require('promisify-child-process').exec(command, { ...defaultOptions, ...execOptions });
+    return cpPromise.exec(command, { ...defaultOptions, ...execOptions });
 }
 
 module.exports = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,14 @@
       "integrity": "sha512-bC49otXX6N0/VYhgOMh4gnP26E9xnDZK3TmbNpxYzzz9BQLBosQwfyOe9/cXUU3txYhTzLCbcqd5c8y/OmCjHA==",
       "dev": true
     },
+    "@babel/runtime": {
+      "version": "7.9.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.6.tgz",
+      "integrity": "sha512-64AF1xY3OAkFHqOb9s4jpgk1Mm5vDZ4L3acHvAml+53nO1XbXLuDodsVpO4OIUsmemlUHMxNdYMNJmsvOwLrvQ==",
+      "requires": {
+        "regenerator-runtime": "^0.13.4"
+      }
+    },
     "@iobroker/plugin-base": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@iobroker/plugin-base/-/plugin-base-1.2.0.tgz",
@@ -5773,6 +5781,14 @@
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
     },
+    "promisify-child-process": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/promisify-child-process/-/promisify-child-process-3.1.4.tgz",
+      "integrity": "sha512-tLifJs99E4oOXUz/dKQjRgdchfiepmYQzBVrcVX9BtUWi9aGJeGSf2KgXOWBW1JFsSYgLkl1Z9HRm8i0sf4cTg==",
+      "requires": {
+        "@babel/runtime": "^7.1.5"
+      }
+    },
     "prompt": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/prompt/-/prompt-1.0.0.tgz",
@@ -5980,6 +5996,11 @@
       "requires": {
         "redis-errors": "^1.0.0"
       }
+    },
+    "regenerator-runtime": {
+      "version": "0.13.5",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
+      "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
     },
     "regex-not": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
         "node-schedule": "^1.3.2",
         "node.extend": "^2.0.2",
         "pidusage": "^2.0.20",
+    "promisify-child-process": "^3.1.4",
         "prompt": "^1.0.0",
         "readline-sync": "^1.4.10",
         "request": "^2.88.2",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
         "node-schedule": "^1.3.2",
         "node.extend": "^2.0.2",
         "pidusage": "^2.0.20",
-    "promisify-child-process": "^3.1.4",
+        "promisify-child-process": "^3.1.4",
         "prompt": "^1.0.0",
         "readline-sync": "^1.4.10",
         "request": "^2.88.2",


### PR DESCRIPTION
I've stumbled on this mix of Promise and callback-style code and I just couldn't resist :)

* Converted everything to use Promises with a clear return value (we had mixes of boolean|string[]|null in there)
* The init promise array has been replaced with a single call to an async method (which returns a promise that tells us everything is done).
* I've also replaced the bunch of promisified exec calls with a utility function in tools.js to make it clearer what is going on in these calls (no more multiple error handling etc.).
As far as I can see, `promisify-child-process` is one of the cleanest wrappers around `child_process` that I just needed to enhance with two default options. It returns a Promise that resolves when the exit code is successful and rejects otherwise. And it captures stdout and stderr in both the success and error case. 
We should use the new `tools.execAsync` method when we refactor the npm installation stuff (#202). 

* I'm sure there was also a bit of logic that was not entirely correct. 
