### PR TITLE
Add 'NPM_AUTO_REBUILD' to supported features

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -44,7 +44,8 @@ const supportedFeatures = [
     'ADAPTER_DEL_OBJECT_RECURSIVE', // delObject supports options.recursive flag to delete objects structures recursive, Since js-controller 2.2
     'ADAPTER_SET_OBJECT_SETS_DEFAULT_VALUE', // setObject(*) methods set the default (def) value via setState after the object is created. Since js-controller 2.0
     'ADAPTER_AUTO_DECRYPT_NATIVE', // all native attributes, that are listed in an array `encryptedNative` in io-pack will be automatically decrypted and encrypted. Since js-controller 3.0
-    'PLUGINS' // configurable plugins supported. Since js-controller 3.0
+    'PLUGINS', // configurable plugins supported. Since js-controller 3.0
+    'NPM_AUTO_REBUILD' // Automatic rebuild when node version mismatch is detected. Since JS-Controller 3.0
 ];
 
 //const ACCESS_EVERY_EXEC  = 0x1;


### PR DESCRIPTION
I noticed that this feature does not have a feature flag. Would be helpful to detect this in adapters that try-catch their require calls. If this is supported, some exceptions could be re-thrown to let JS-Controller do its thing.

I'm open for other feature names.