### PR TITLE
make callback consistent when client has closed connection

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -2094,7 +2094,7 @@ function Adapter(options) {
                         }
                         if (!currentState) {
                             try {
-                                await this.setForeignStateAsync(id, defState, true);
+                                await this.setForeignStateAsync(id, {val: defState}, true);
                             } catch (e) {
                                 logger.info(`Default value for State ${id} could not be set: ${e}`);
                             }
@@ -2298,7 +2298,7 @@ function Adapter(options) {
                         }
                         if (!currentState) {
                             try {
-                                await this.setForeignStateAsync(id, defState, true);
+                                await this.setForeignStateAsync(id, {val: defState}, true);
                             } catch (e) {
                                 logger.info(`Default value for State ${id} could not be set: ${e}`);
                             }

--- a/lib/objects/objectsInMemServerRedis.js
+++ b/lib/objects/objectsInMemServerRedis.js
@@ -460,7 +460,7 @@ class ObjectsInMemoryServer extends ObjectsInMemoryFileDB {
                         if (err || data === undefined) {
                             handler.sendNull(responseId);
                         } else {
-                            handler.sendBufBulk(responseId, Buffer.from(data));
+                            handler.sendBufBulk(responseId, Buffer.from(data.file));
                         }
                     });
                 }

--- a/lib/objects/objectsInMemServerRedis.js
+++ b/lib/objects/objectsInMemServerRedis.js
@@ -457,10 +457,15 @@ class ObjectsInMemoryServer extends ObjectsInMemoryFileDB {
                 // Handle request for File data
                 else {
                     this.readFile(id, name, (err, data, _mimeType) => {
-                        if (err || data === undefined) {
+                        if (err || data === undefined || data === null) {
                             handler.sendNull(responseId);
                         } else {
-                            handler.sendBufBulk(responseId, Buffer.from(data.file));
+                            if (!Buffer.isBuffer(data) && typeof data === 'object') {
+                                // if its an invalid object, stringify it and log warning
+                                data = JSON.stringify(data);
+                                this.log.warn(`${this.namespace} Data of "${id}/${name}" has invalid structure at file data request: ${data}`);
+                            }
+                            handler.sendBufBulk(responseId, Buffer.from(data));
                         }
                     });
                 }

--- a/lib/states/statesInRedis.js
+++ b/lib/states/statesInRedis.js
@@ -432,11 +432,16 @@ class StateRedis {
      *      <li><b>lc</b>   a unix timestamp indicating the last change of the actual value. this should be undefined
      *                      when calling setState, it will be set by the setValue method itself.</li></ul>
      *
-     * @param callback {Function}   will be called when redis confirmed reception of the command
+     * @param callback {function(String, String):void}   will be called when redis confirmed reception of the command
      */
     setState(id, state, callback) {
+        if (!id || typeof id !== 'string') {
+            typeof callback === 'function' && setImmediate(callback, `invalid id ${JSON.stringify(id)}`);
+            return;
+        }
+
         if (!this.client) {
-            return callback && setImmediate(() => callback('Closed'));
+            return typeof callback === 'function' && setImmediate(callback, tools.ERRORS.ERROR_DB_CLOSED);
         }
 
         const obj = {};
@@ -451,11 +456,6 @@ class StateRedis {
         if (state.expire) {
             expire = state.expire;
             delete state.expire;
-        }
-
-        if (!id || typeof id !== 'string') {
-            typeof callback === 'function' && setImmediate(() => callback('invalid id ' + JSON.stringify(id)));
-            return;
         }
 
         this.client.get(this.namespaceRedis + id, (err, oldObj) => {
@@ -569,8 +569,12 @@ class StateRedis {
     // Used for restore function (do not call it)
     setRawState(id, state, callback) {
         if (!id || typeof id !== 'string') {
-            typeof callback === 'function' && setImmediate(() => callback('invalid id ' + JSON.stringify(id)));
+            typeof callback === 'function' && setImmediate(callback, `invalid id ${JSON.stringify(id)}`);
             return;
+        }
+
+        if (!this.client) {
+            return typeof callback === 'function' && setImmediate(callback, tools.ERRORS.ERROR_DB_CLOSED);
         }
 
         this.client.set(this.namespaceRedis + id, JSON.stringify(state), err =>
@@ -585,8 +589,12 @@ class StateRedis {
      */
     getState(id, callback) {
         if (!id || typeof id !== 'string') {
-            typeof callback === 'function' && setImmediate(() => callback(`invalid id ${JSON.stringify(id)}`));
+            typeof callback === 'function' && setImmediate(callback, `invalid id ${JSON.stringify(id)}`);
             return;
+        }
+
+        if (!this.client) {
+            return typeof callback === 'function' && setImmediate(callback, tools.ERRORS.ERROR_DB_CLOSED);
         }
 
         this.client.get(this.namespaceRedis + id, (err, obj) => {
@@ -631,10 +639,13 @@ class StateRedis {
             return;
         }
         if (!keys || !Array.isArray(keys)) {
-            return setImmediate(() => callback('no keys', null));
+            return setImmediate(callback, 'no keys', null);
         }
         if (!keys.length) {
-            return setImmediate(() => callback(null, []));
+            return setImmediate(callback, null, []);
+        }
+        if (!this.client) {
+            return setImmediate(callback, tools.ERRORS.ERROR_DB_CLOSED);
         }
         let _keys;
         if (!dontModify) {
@@ -696,7 +707,7 @@ class StateRedis {
 
     delState(id, callback) {
         if (!id || typeof id !== 'string') {
-            typeof callback === 'function' && setImmediate(() => callback('invalid id ' + JSON.stringify(id)));
+            typeof callback === 'function' && setImmediate(callback, `invalid id ${JSON.stringify(id)}`);
             return;
         }
 
@@ -713,7 +724,7 @@ class StateRedis {
 
     getKeys(pattern, callback, dontModify) {
         if (!pattern || typeof pattern !== 'string') {
-            typeof callback === 'function' && setImmediate(() => callback('invalid pattern ' + JSON.stringify(pattern)));
+            typeof callback === 'function' && setImmediate(callback, `invalid pattern ${JSON.stringify(pattern)}`);
             return;
         }
 
@@ -733,11 +744,11 @@ class StateRedis {
      * @method subscribe
      *
      * @param pattern
-     * @param {function} callback callback function (optional)
+     * @param {function(String):void} callback callback function (optional)
      */
     subscribe(pattern, subClient, callback) {
         if (!pattern || typeof pattern !== 'string') {
-            typeof callback === 'function' && setImmediate(() => callback('invalid pattern ' + JSON.stringify(pattern)));
+            typeof callback === 'function' && setImmediate(callback, `invalid pattern ${JSON.stringify(pattern)}`);
             return;
         }
 
@@ -748,7 +759,7 @@ class StateRedis {
         subClient = subClient || this.subSystem;
 
         if (!subClient) {
-            return typeof callback === 'function' && setImmediate(() => callback(tools.ERRORS.ERROR_DB_CLOSED));
+            return typeof callback === 'function' && setImmediate(callback, tools.ERRORS.ERROR_DB_CLOSED);
         }
 
         this.settings.connection.enhancedLogging && this.log.silly(this.namespace + ' redis psubscribe ' + this.namespaceRedis + pattern);
@@ -764,7 +775,7 @@ class StateRedis {
      * @method subscribeUser
      *
      * @param pattern
-     * @param {function} callback callback function (optional)
+     * @param {function(String):void} callback callback function (optional)
      */
     subscribeUser(pattern, callback) {
         return this.subscribe(pattern, this.sub, callback);
@@ -772,7 +783,7 @@ class StateRedis {
 
     unsubscribe(pattern, subClient, callback) {
         if (!pattern || typeof pattern !== 'string') {
-            typeof callback === 'function' && setImmediate(() => callback('invalid pattern ' + JSON.stringify(pattern)));
+            typeof callback === 'function' && setImmediate(callback, `invalid pattern ${JSON.stringify(pattern)}`);
             return;
         }
         if (typeof subClient === 'function') {
@@ -782,7 +793,7 @@ class StateRedis {
         subClient = subClient || this.subSystem;
 
         if (!subClient) {
-            return typeof callback === 'function' && setImmediate(() => callback(tools.ERRORS.ERROR_DB_CLOSED));
+            return typeof callback === 'function' && setImmediate(callback, tools.ERRORS.ERROR_DB_CLOSED);
         }
 
         this.settings.connection.enhancedLogging && this.log.silly(this.namespace + ' redis punsubscribe ' + this.namespaceRedis + pattern);
@@ -806,8 +817,12 @@ class StateRedis {
 
     pushMessage(id, state, callback) {
         if (!id || typeof id !== 'string') {
-            typeof callback === 'function' && callback('invalid id ' + JSON.stringify(id));
+            typeof callback === 'function' && setImmediate(callback, `invalid id ${JSON.stringify(id)}`);
             return;
+        }
+
+        if (!this.client) {
+            return typeof callback === 'function' && setImmediate(callback, tools.ERRORS.ERROR_DB_CLOSED);
         }
 
         state._id = this.globalMessageId++;
@@ -820,12 +835,12 @@ class StateRedis {
 
     subscribeMessage(id, callback) {
         if (!id || typeof id !== 'string') {
-            typeof callback === 'function' && setImmediate(() => callback('invalid id ' + JSON.stringify(id)));
+            typeof callback === 'function' && setImmediate(callback, `invalid id ${JSON.stringify(id)}`);
             return;
         }
 
         if (!this.subSystem) {
-            return typeof callback === 'function' && setImmediate(() => callback(tools.ERRORS.ERROR_DB_CLOSED));
+            return typeof callback === 'function' && setImmediate(callback, tools.ERRORS.ERROR_DB_CLOSED);
         }
 
         if (id.startsWith('.')) {
@@ -842,12 +857,12 @@ class StateRedis {
 
     unsubscribeMessage(id, callback) {
         if (!id || typeof id !== 'string') {
-            typeof callback === 'function' && setImmediate(() => callback('invalid id ' + JSON.stringify(id)));
+            typeof callback === 'function' && setImmediate(callback, `invalid id ${JSON.stringify(id)}`);
             return;
         }
 
         if (!this.subSystem) {
-            return typeof callback === 'function' && setImmediate(() => callback(tools.ERRORS.ERROR_DB_CLOSED));
+            return typeof callback === 'function' && setImmediate(callback, tools.ERRORS.ERROR_DB_CLOSED);
         }
 
         if (id.startsWith('.')) {
@@ -907,12 +922,12 @@ class StateRedis {
 
     subscribeLog(id, callback) {
         if (!id || typeof id !== 'string') {
-            typeof callback === 'function' && setImmediate(() => callback('invalid id ' + JSON.stringify(id)));
+            typeof callback === 'function' && setImmediate(callback, `invalid id ${JSON.stringify(id)}`);
             return;
         }
 
         if (!this.subSystem) {
-            return typeof callback === 'function' && setImmediate(() => callback(tools.ERRORS.ERROR_DB_CLOSED));
+            return typeof callback === 'function' && setImmediate(callback, tools.ERRORS.ERROR_DB_CLOSED);
         }
 
         this.settings.connection.enhancedLogging && this.log.silly(this.namespace + ' redis subscribeMessage ' + this.namespaceLog + id);
@@ -926,12 +941,12 @@ class StateRedis {
 
     unsubscribeLog(id, callback) {
         if (!id || typeof id !== 'string') {
-            typeof callback === 'function' && setImmediate(() => callback('invalid id ' + JSON.stringify(id)));
+            typeof callback === 'function' && setImmediate(callback, `invalid id ${JSON.stringify(id)}`);
             return;
         }
 
         if (!this.subSystem) {
-            return typeof callback === 'function' && setImmediate(() => callback(tools.ERRORS.ERROR_DB_CLOSED));
+            return typeof callback === 'function' && setImmediate(callback, tools.ERRORS.ERROR_DB_CLOSED);
         }
 
         this.settings.connection.enhancedLogging && this.log.silly(this.namespace + ' redis unsubscribeMessage ' + this.namespaceLog + id);
@@ -945,8 +960,12 @@ class StateRedis {
 
     getSession(id, callback) {
         if (!id || typeof id !== 'string') {
-            typeof callback === 'function' && setImmediate(() => callback('invalid id ' + JSON.stringify(id)));
+            typeof callback === 'function' && setImmediate(callback, `invalid id ${JSON.stringify(id)}`);
             return;
+        }
+
+        if (!this.client) {
+            return typeof callback === 'function' && setImmediate(callback, tools.ERRORS.ERROR_DB_CLOSED);
         }
 
         this.client.get(this.namespaceSession + id, (_err, obj) => {
@@ -963,8 +982,12 @@ class StateRedis {
 
     setSession(id, expire, obj, callback) {
         if (!id || typeof id !== 'string') {
-            typeof callback === 'function' && setImmediate(() => callback('invalid id ' + JSON.stringify(id)));
+            typeof callback === 'function' && setImmediate(callback, `invalid id ${JSON.stringify(id)}`);
             return;
+        }
+
+        if (!this.client) {
+            return typeof callback === 'function' && setImmediate(callback, tools.ERRORS.ERROR_DB_CLOSED);
         }
 
         this.client.setex(this.namespaceSession + id, expire, JSON.stringify(obj), err => {
@@ -975,8 +998,12 @@ class StateRedis {
 
     destroySession(id, callback) {
         if (!id || typeof id !== 'string') {
-            typeof callback === 'function' && setImmediate(() => callback('invalid id ' + JSON.stringify(id)));
+            typeof callback === 'function' && setImmediate(callback, `invalid id ${JSON.stringify(id)}`);
             return;
+        }
+
+        if (!this.client) {
+            return typeof callback === 'function' && setImmediate(callback, tools.ERRORS.ERROR_DB_CLOSED);
         }
 
         id = this.namespaceSession + id;
@@ -986,8 +1013,12 @@ class StateRedis {
 
     setBinaryState(id, data, callback) {
         if (!id || typeof id !== 'string') {
-            typeof callback === 'function' && setImmediate(() => callback('invalid id ' + JSON.stringify(id)));
+            typeof callback === 'function' && setImmediate(callback, `invalid id ${JSON.stringify(id)}`);
             return;
+        }
+
+        if (!this.client) {
+            return typeof callback === 'function' && setImmediate(callback, tools.ERRORS.ERROR_DB_CLOSED);
         }
 
         if (!Buffer.isBuffer(data)) {
@@ -998,8 +1029,12 @@ class StateRedis {
 
     getBinaryState(id, callback) {
         if (!id || typeof id !== 'string') {
-            typeof callback === 'function' && setImmediate(() => callback('invalid id ' + JSON.stringify(id)));
+            typeof callback === 'function' && setImmediate(callback, `invalid id ${JSON.stringify(id)}`);
             return;
+        }
+
+        if (!this.client) {
+            return typeof callback === 'function' && setImmediate(callback, tools.ERRORS.ERROR_DB_CLOSED);
         }
 
         this.client.getBuffer(this.namespaceRedis + id, (err, data) => {
@@ -1017,8 +1052,12 @@ class StateRedis {
 
     delBinaryState(id, callback) {
         if (!id || typeof id !== 'string') {
-            typeof callback === 'function' && setImmediate(() => callback('invalid id ' + JSON.stringify(id)));
+            typeof callback === 'function' && setImmediate(callback, 'invalid id ' + JSON.stringify(id));
             return;
+        }
+
+        if (!this.client) {
+            return typeof callback === 'function' && setImmediate(callback, tools.ERRORS.ERROR_DB_CLOSED);
         }
 
         this.client.del(this.namespaceRedis + id, err => typeof callback === 'function' && callback(err, id));

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -2244,6 +2244,7 @@ module.exports = {
     formatAliasValue,
     ERRORS: {
         ERROR_NOT_FOUND: 'Not exists',
-        ERROR_EMPTY_OBJECT: 'null object'
+        ERROR_EMPTY_OBJECT: 'null object',
+        ERROR_DB_CLOSED: 'DB closed'
     }
 };

--- a/test/lib/testObjectsFunctions.js
+++ b/test/lib/testObjectsFunctions.js
@@ -1123,17 +1123,17 @@ function register(it, expect, context) {
 
         // delete state but not object
         await context.adapter.delStateAsync('testDefaultValExtend');
-        // extend it again - def should be created again, because state has been removed
+        // extend it again - def should be created again, because state has been removed - now we set a def object
         obj = await context.adapter.extendObjectAsync('testDefaultValExtend', {
             common: {
-                def: 'Please, do not set me up'
+                def: {hello: 'world'}
             }
         });
 
         expect(obj).to.be.ok,
 
         state = await context.adapter.getStateAsync('testDefaultValExtend');
-        expect(state.val).to.equal('Please, do not set me up');
+        expect(state.val.hello).to.equal('world');
         expect(state.ack).to.equal(true);
 
         return Promise.resolve();


### PR DESCRIPTION
- Sentry IOBROKER-JS-CONTROLLER-R
- add missing Error for DB closed, which was used but undefined in tools.js