### PR TITLE
👮🏻‍♂️ Code police was here 🚓

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+	"typescript.tsdk": "node_modules\\typescript\\lib"
+}

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -82,7 +82,7 @@ gulp.task('renameFiles', done => {
     done();
 });
 
-gulp.task('replaceName', _done => {
+gulp.task('replaceName', () => {
     const patterns = [
         {
             match:       /iobroker/gi,

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -531,7 +531,7 @@ function Adapter(options) {
      * @alias getPort
      * @memberof Adapter
      * @param {number} port port number to start the search for free port
-     * @param {string} host optional hostname for the port search
+     * @param {string} [host] optional hostname for the port search
      * @param {function} callback return result
      *        <pre><code>function (port) {}</code></pre>
      */
@@ -598,7 +598,7 @@ function Adapter(options) {
      * @memberof Adapter
      * @param {string} user user name as text
      * @param {string} pw password as text
-     * @param {object} options optional user context
+     * @param {object} [options] optional user context
      * @param {function} callback return result
      *        <pre><code>
      *            function (result) {
@@ -643,8 +643,8 @@ function Adapter(options) {
      * @memberof Adapter
      * @param {string} user user name as text
      * @param {string} pw password as text
-     * @param {object} options optional user context
-     * @param {function} callback return result
+     * @param {object} [options] optional user context
+     * @param {function} [callback] return result
      *        <pre><code>
      *            function (err) {
      *              if (err) adapter.log.error('Cannot set password: ' + err);
@@ -691,7 +691,7 @@ function Adapter(options) {
      * @memberof Adapter
      * @param {string} user user name as text
      * @param {string} group group name
-     * @param {object} options optional user context
+     * @param {object} [options] optional user context
      * @param {function} callback return result
      *        <pre><code>
      *            function (result) {
@@ -786,8 +786,8 @@ function Adapter(options) {
      *            getUserPermissions: {type: 'object',    operation: 'read'}
      *         };
      *        </code></pre>
-     * @param {object} options optional user context
-     * @param {function} callback return result
+     * @param {object} [options] optional user context
+     * @param {function} [callback] return result
      *        <pre><code>
      *            function (acl) {
      *              // Access control object for admin looks like:
@@ -979,9 +979,9 @@ function Adapter(options) {
      *
      * @alias getCertificates
      * @memberof Adapter
-     * @param {string} publicName public certificate name
-     * @param {string} privateName private certificate name
-     * @param {string} chainedName optional chained certificate name
+     * @param {string} [publicName] public certificate name
+     * @param {string} [privateName] private certificate name
+     * @param {string} [chainedName] optional chained certificate name
      * @param {function} callback return result
      *        <pre><code>
      *            function (err, certs) {
@@ -1102,8 +1102,8 @@ function Adapter(options) {
      *
      * It returns promise if no callback is provided.
      * @param {string} attribute - attribute name in native configuration part
-     * @param {function} callback - optional callback
-     * @returns {object} promise if no callback provided
+     * @param {function} [callback] - optional callback
+     * @returns {Promise<any>} promise if no callback provided
      *
      */
     this.getEncryptedConfig = (attribute, callback) => {
@@ -1780,8 +1780,8 @@ function Adapter(options) {
          * @memberof Adapter
          * @param {string} id object ID, that must be overwritten or created.
          * @param {object} obj new object
-         * @param {object} options optional user context
-         * @param {function} callback return result
+         * @param {object} [options] optional user context
+         * @param {function} [callback] return result
          *        <pre><code>
          *            function (err, obj) {
          *              // obj is {id: id}
@@ -1979,8 +1979,8 @@ function Adapter(options) {
          * @memberof Adapter
          * @param {string} id object ID, that must be extended
          * @param {object} obj part that must be extended
-         * @param {object} options optional user context
-         * @param {function} callback return result
+         * @param {object} [options] optional user context
+         * @param {function} [callback] return result
          *        <pre><code>
          *            function (err, obj) {
          *                if (err) adapter.log.error(err);
@@ -2122,8 +2122,8 @@ function Adapter(options) {
          * @memberof Adapter
          * @param {string} id object ID, that must be overwritten or created.
          * @param {object} obj new object
-         * @param {object} options optional user context
-         * @param {function} callback return result
+         * @param {object} [options] optional user context
+         * @param {function} [callback] return result
          *        <pre><code>
          *            function (err, obj) {
          *              // obj is {id: id}
@@ -2197,8 +2197,8 @@ function Adapter(options) {
          * @memberof Adapter
          * @param {string} id object ID, that must be extended
          * @param {object} obj part that must be extended
-         * @param {object} options optional user context
-         * @param {function} callback return result
+         * @param {object} [options] optional user context
+         * @param {function} [callback] return result
          *        <pre><code>
          *            function (err, obj) {
          *                // obj is {"id": id}
@@ -2325,7 +2325,7 @@ function Adapter(options) {
          * @alias getObject
          * @memberof Adapter
          * @param {string} id exactly object ID (without namespace)
-         * @param {object} options optional user context
+         * @param {object} [options] optional user context
          * @param {function} callback return result
          *        <pre><code>
          *            function (err, obj) {
@@ -2477,7 +2477,7 @@ function Adapter(options) {
          * @alias getEnum
          * @memberof Adapter
          * @param {string} _enum enum name, e.g. 'rooms', 'function' or '' (all enums)
-         * @param {object} options optional user context
+         * @param {object} [options] optional user context
          * @param {function} callback return result
          *        <pre><code>
          *            function (err, enums, requestEnum) {
@@ -2534,7 +2534,7 @@ function Adapter(options) {
          * @alias getEnums
          * @memberof Adapter
          * @param {string|array} _enumList enum name or names, e.g. ['rooms', 'function']
-         * @param {object} options optional user context
+         * @param {object} [options] optional user context
          * @param {function} callback return result
          *        <pre><code>
          *            function (err, enums) {
@@ -2676,7 +2676,7 @@ function Adapter(options) {
          * @param {string} pattern object ID/wildchars
          * @param {string} type type of object: 'state', 'channel' or 'device'. Default - 'state'
          * @param {string|string[]} enums object ID, that must be overwritten or created.
-         * @param {object} options optional user context
+         * @param {object} [options] optional user context
          * @param {function} callback return result
          *        <pre><code>
          *            function (err, obj) {
@@ -2827,8 +2827,8 @@ function Adapter(options) {
          * @alias getForeignObject
          * @memberof Adapter
          * @param {string} id exactly object ID (with namespace)
-         * @param {object} options optional user context
-         * @param {function} [callback] return result
+         * @param {object} [options] optional user context
+         * @param {function} callback return result
          *        <pre><code>
          *            function (err, obj) {
          *              if (err) adapter.log.error('Cannot get object: ' + err);
@@ -2882,8 +2882,8 @@ function Adapter(options) {
          * @alias delObject
          * @memberof Adapter
          * @param {string} id exactly object ID (without namespace)
-         * @param {object} options optional user context. E.g. recursive option could be true
-         * @param {function} callback return result
+         * @param {object} [options] optional user context. E.g. recursive option could be true
+         * @param {function} [callback] return result
          *        <pre><code>
          *            function (err) {
          *              if (err) adapter.log.error('Cannot delete object: ' + err);
@@ -2943,8 +2943,8 @@ function Adapter(options) {
          * @alias delForeignObject
          * @memberof Adapter
          * @param {string} id exactly object ID (with namespace)
-         * @param {object} options optional user context or {recursive:true} to delete all underlying objects
-         * @param {function} callback return result
+         * @param {object} [options] optional user context or {recursive:true} to delete all underlying objects
+         * @param {function} [callback] return result
          *        <pre><code>
          *            function (err) {
          *              if (err) adapter.log.error('Cannot delete object: ' + err);
@@ -3057,8 +3057,8 @@ function Adapter(options) {
          * @alias unsubscribeObjects
          * @memberof Adapter
          * @param {string} pattern pattern like 'channel.*' or '*' (all objects) - without namespaces
-         * @param {object} options optional user context
-         * @param {function} callback optional returns result
+         * @param {object} [options] optional user context
+         * @param {function} [callback] optional returns result
          *        <pre><code>
          *            function (err) {
          *              if (err) adapter.log.error('Cannot unsubscribe object: ' + err);
@@ -3093,8 +3093,8 @@ function Adapter(options) {
          * @alias subscribeForeignObjects
          * @memberof Adapter
          * @param {string} pattern pattern like 'channel.*' or '*' (all objects) - without namespaces. You can use array of patterns
-         * @param {object} options optional user context
-         * @param {function} callback optional returns result
+         * @param {object} [options] optional user context
+         * @param {function} [callback] optional returns result
          *        <pre><code>
          *            function (err) {
          *              if (err) adapter.log.error('Cannot subscribe object: ' + err);
@@ -3124,8 +3124,8 @@ function Adapter(options) {
          * @alias unsubscribeForeignObjects
          * @memberof Adapter
          * @param {string} pattern pattern like 'channel.*' or '*' (all objects) - without namespaces
-         * @param {object} options optional user context
-         * @param {function} callback optional returns result
+         * @param {object} [options] optional user context
+         * @param {function} [callback] optional returns result
          *        <pre><code>
          *            function (err) {
          *              if (err) adapter.log.error('Cannot unsubscribe object: ' + err);
@@ -3162,8 +3162,8 @@ function Adapter(options) {
          * @memberof Adapter
          * @param {string} id object ID, that must be overwritten or created.
          * @param {object} obj new object
-         * @param {object} options optional user context
-         * @param {function} callback return result
+         * @param {object} [options] optional user context
+         * @param {function} [callback] return result
          *        <pre><code>
          *            function (err, obj) {
          *              // obj is {id: id}
@@ -3227,8 +3227,8 @@ function Adapter(options) {
          * @memberof Adapter
          * @param {string} id object ID, that must be overwritten or created.
          * @param {object} obj new object
-         * @param {object} options optional user context
-         * @param {function} callback return result
+         * @param {object} [options] optional user context
+         * @param {function} [callback] return result
          *        <pre><code>
          *            function (err, obj) {
          *              // obj is {id: id}
@@ -3400,6 +3400,7 @@ function Adapter(options) {
                 roleOrCommon = undefined;
             }
 
+            /** @type {ioBroker.StateCommon} */
             let common = {};
             if (typeof roleOrCommon === 'string') {
                 common = {
@@ -3530,8 +3531,8 @@ function Adapter(options) {
          * @alias deleteDevice
          * @memberof Adapter
          * @param {string} deviceName is the part of ID like: adapter.instance.<deviceName>
-         * @param {object} options optional user context
-         * @param {function} callback return result
+         * @param {object} [options] optional user context
+         * @param {function} [callback] return result
          *        <pre><code>
          *            function (err, obj) {
          *              // obj is {id: id}
@@ -4519,8 +4520,8 @@ function Adapter(options) {
          * @param {string} _adapter adapter name. If adapter name is null, so the name (not instance) of current adapter will be taken.
          * @param {string} filename path to file without adapter name. E.g. If you want to read "/vis.0/main/views.json", here must be "/main/views.json" and _adapter must be equal to "vis.0".
          * @param {object} data data as UTF8 string or buffer depends on the file extension.
-         * @param {object} options optional user context
-         * @param {function} callback return result
+         * @param {object} [options] optional user context
+         * @param {function} [callback] return result
          *        <pre><code>
          *            function (err) {
          *
@@ -4614,7 +4615,7 @@ function Adapter(options) {
                     case 'YY':
                     case 'JJ':
                     case 'ГГ':
-                        v = /** @type {Date} */dateObj.getFullYear();
+                        v = /** @type {Date} */(dateObj).getFullYear();
                         if (s.length === 2) {
                             v %= 100;
                         }
@@ -5406,7 +5407,7 @@ function Adapter(options) {
          * @param {string} instanceName name of the instance where the message must be send to. E.g. "pushover.0" or "system.adapter.pushover.0".
          * @param {string} command command name, like "send", "browse", "list". Command is depend on target adapter implementation.
          * @param {object} message object that will be given as argument for request
-         * @param {function} callback optional return result
+         * @param {function} [callback] optional return result
          *        <pre><code>
          *            function (result) {
          *              // result is target adapter specific and can vary from adapter to adapter
@@ -5507,10 +5508,10 @@ function Adapter(options) {
          *
          * @alias sendToHost
          * @memberof Adapter
-         * @param {string} hostName name of the host where the message must be send to. E.g. "myPC" or "system.host.myPC". If argument is empty, the message will be sent to all hosts.
+         * @param {any} hostName name of the host where the message must be send to. E.g. "myPC" or "system.host.myPC". If argument is empty, the message will be sent to all hosts.
          * @param {string} command command name. One of: "cmdExec", "getRepository", "getInstalled", "getVersion", "getDiagData", "getLocationOnDisk", "getDevList", "getLogs", "delLogs", "readDirAsZip", "writeDirAsZip", "readObjectsAsZip", "writeObjectsAsZip", "checkLogging". Commands can be checked in controller.js (function processMessage)
          * @param {object} message object that will be given as argument for request
-         * @param {function} callback optional return result
+         * @param {function} [callback] optional return result
          *        <pre><code>
          *            function (result) {
          *              // result is target adapter specific and can vary from command to command
@@ -5673,8 +5674,8 @@ function Adapter(options) {
          *          lc:     timestampMS       // default - automatic calculation
          *      }
          *  </code></pre>
-         * @param {boolean} ack optional is command(false) or status(true)
-         * @param {object} options optional user context
+         * @param {boolean} [ack] optional is command(false) or status(true)
+         * @param {object} [options] optional user context
          * @param {function} [callback] optional return error and id
          *        <pre><code>
          *            function (err, id) {
@@ -5837,9 +5838,9 @@ function Adapter(options) {
          * @memberof Adapter
          * @param {string} id object ID of the state.
          * @param {object|string|number|boolean} state simple value or object with attribues.
-         * @param {boolean} ack optional is command(false) or status(true)
-         * @param {object} options optional user context
-         * @param {function} callback optional return error, id and notChanged
+         * @param {boolean} [ack] optional is command(false) or status(true)
+         * @param {object} [options] optional user context
+         * @param {function} [callback] optional return error, id and notChanged
          *        <pre><code>
          *            function (err, id, notChanged) {
          *              if (err) adapter.log.error('Cannot set value for "' + id + '": ' + err);
@@ -5947,9 +5948,9 @@ function Adapter(options) {
          *          lc:     timestampMS       // default - automatic calculation
          *      }
          *  </code></pre>
-         * @param {boolean} ack optional is command(false) or status(true)
-         * @param {object} options optional user context
-         * @param {function} callback optional return error and id
+         * @param {boolean} [ack] optional is command(false) or status(true)
+         * @param {object} [options] optional user context
+         * @param {function} [callback] optional return error and id
          *        <pre><code>
          *            function (err, id) {
          *              if (err) adapter.log.error('Cannot set value for "' + id + '": ' + err);
@@ -6133,9 +6134,9 @@ function Adapter(options) {
          *          lc:     timestampMS       // default - automatic calculation
          *      }
          *  </code></pre>
-         * @param {boolean} ack optional is command(false) or status(true)
-         * @param {object} options optional user context
-         * @param {function} callback optional return error and id
+         * @param {boolean} [ack] optional is command(false) or status(true)
+         * @param {object} [options] optional user context
+         * @param {function} [callback] optional return error and id
          *        <pre><code>
          *            function (err, id) {
          *              if (err) adapter.log.error('Cannot set value for "' + id + '": ' + err);
@@ -6616,8 +6617,8 @@ function Adapter(options) {
          * @alias delState
          * @memberof Adapter
          * @param {string} id exactly object ID (without namespace)
-         * @param {object} options optional user context
-         * @param {function} callback return result
+         * @param {object} [options] optional user context
+         * @param {function} [callback] return result
          *        <pre><code>
          *            function (err) {
          *              if (err) adapter.log.error('Cannot delete object: ' + err);
@@ -6650,8 +6651,8 @@ function Adapter(options) {
          * @alias delForeignState
          * @memberof Adapter
          * @param {string} id long string for ID like "adapterName.0.stateID".
-         * @param {object} options optional argument to describe the user context
-         * @param {function} callback return result function (err) {}
+         * @param {object} [options] optional argument to describe the user context
+         * @param {function} [callback] return result function (err) {}
          */
         this.delForeignState = (id, options, callback) => {
             if (typeof options === 'function') {
@@ -6807,7 +6808,7 @@ function Adapter(options) {
          *
          * @alias getForeignStates
          * @memberof Adapter
-         * @param {string} pattern string in form 'adapter.0.*' or like this. It can be array of IDs too.
+         * @param {string | string[]} pattern string in form 'adapter.0.*' or like this. It can be array of IDs too.
          * @param {object} options optional argument to describe the user context
          * @param {function} callback return result function (err, states) {}, where states is an object like {"ID1": {"val": 1, "ack": true}, "ID2": {"val": 2, "ack": false}, ...}
          */
@@ -6884,7 +6885,7 @@ function Adapter(options) {
                     // filter out
                     let regEx;
                     // process patterns like "*.someValue". The patterns "someValue.*" will be processed by getObjectView
-                    if (pattern && pattern !== '*' && pattern[pattern.length - 1] !== '*') {
+                    if (typeof pattern === 'string' && pattern !== '*' && pattern[pattern.length - 1] !== '*') {
                         regEx = new RegExp(tools.pattern2RegEx(pattern));
                     }
                     for (let i = 0; i < res.rows.length; i++) {
@@ -6985,9 +6986,9 @@ function Adapter(options) {
          *
          * @alias subscribeForeignStates
          * @memberof Adapter
-         * @param {string} pattern string in form 'adapter.0.*' or like this. It can be array of IDs too.
-         * @param {object} options optional argument to describe the user context
-         * @param {function} callback return result function (err) {}
+         * @param {string | string[]} pattern string in form 'adapter.0.*' or like this. It can be array of IDs too.
+         * @param {object} [options] optional argument to describe the user context
+         * @param {function} [callback] return result function (err) {}
          */
         this.subscribeForeignStates = (pattern, options, callback) => {
             pattern = pattern || '*';
@@ -7014,7 +7015,7 @@ function Adapter(options) {
 
                 // compare if this pattern for one of auto-subscribe adapters
                 for (let s = 0; s < this.autoSubscribe.length; s++) {
-                    if (pattern === '*' || pattern.substring(0, this.autoSubscribe[s].length + 1) === this.autoSubscribe[s] + '.') {
+                    if (typeof pattern === 'string' && (pattern === '*' || pattern.substring(0, this.autoSubscribe[s].length + 1) === this.autoSubscribe[s] + '.')) {
                         // put this pattern into adapter list
                         adapterStates.getState('system.adapter.' + this.autoSubscribe[s] + '.subscribes', (err, state) => {
                             state = {};
@@ -7178,9 +7179,9 @@ function Adapter(options) {
          *
          * @alias unsubscribeForeignStates
          * @memberof Adapter
-         * @param {string} pattern string in form 'adapter.0.*'. Must be the same as subscribe.
-         * @param {object} options optional argument to describe the user context
-         * @param {function} callback return result function (err) {}
+         * @param {string | string[] | RegExp} pattern string in form 'adapter.0.*'. Must be the same as subscribe.
+         * @param {object} [options] optional argument to describe the user context
+         * @param {function} [callback] return result function (err) {}
          */
         this.unsubscribeForeignStates = (pattern, options, callback) => {
             pattern = pattern || '*';
@@ -7195,7 +7196,7 @@ function Adapter(options) {
                 options = null;
             }
 
-            if (this.autoSubscribe) {
+            if (this.autoSubscribe && typeof pattern === 'string') {
                 for (let s = 0; s < this.autoSubscribe.length; s++) {
                     if (pattern === '*' || pattern.substring(0, this.autoSubscribe[s].length + 1) === this.autoSubscribe[s] + '.') {
                         // remove this pattern from adapter list
@@ -7263,7 +7264,7 @@ function Adapter(options) {
             }
 
             // if pattern known, remove it from alias patterns to not subscribe to further matching aliases
-            for (const i in this.aliasPatterns) {
+            for (let i = 0; i < this.aliasPatterns.length; i++) {
                 if (this.aliasPatterns[i] === aliasPattern) {
                     this.aliasPatterns.splice(i, 1);
                     break;
@@ -7305,8 +7306,8 @@ function Adapter(options) {
          * @alias subscribeStates
          * @memberof Adapter
          * @param {string} pattern string in form 'adapter.0.*' or like this. Only string allowed
-         * @param {object} options optional argument to describe the user context
-         * @param {function} callback return result function (err) {}
+         * @param {object} [options] optional argument to describe the user context
+         * @param {function} [callback]
          */
         this.subscribeStates = (pattern, options, callback) => {
             // Todo check rights for options
@@ -7346,8 +7347,8 @@ function Adapter(options) {
          * @alias unsubscribeStates
          * @memberof Adapter
          * @param {string} pattern string in form 'adapter.0.*'. Must be the same as subscribe.
-         * @param {object} options optional argument to describe the user context
-         * @param {function} callback return result function (err) {}
+         * @param {object} [options] optional argument to describe the user context
+         * @param {function} [callback]
          */
         this.unsubscribeStates = (pattern, options, callback) => {
             // Todo check rights for options
@@ -7478,8 +7479,8 @@ function Adapter(options) {
          *
          * @param {string} id of state
          * @param {Buffer} binary data
-         * @param {object} options optional
-         * @param {function} callback
+         * @param {object} [options] optional
+         * @param {function} [callback]
          *
          */
         this.setBinaryState = (id, binary, options, callback) => {
@@ -7519,13 +7520,20 @@ function Adapter(options) {
          * @memberof Adapter
          * @param {string} id of state
          * @param {Buffer} binary data
-         * @param {object} options optional
+         * @param {object} [options] optional
          * @return promise
          *
          */
         this.setBinaryStateAsync = tools.promisify(this.setBinaryState, this);
 
         // Read binary block from redis, e.g. image
+        /**
+         * Read a binary block from redis, e.g. an image
+         *
+         * @param {string} id The state ID
+         * @param {object} options optional
+         * @param {function} callback
+         */
         this.getBinaryState = (id, options, callback) => {
             if (typeof options === 'function') {
                 callback = options;
@@ -7572,8 +7580,8 @@ function Adapter(options) {
          * @memberof Adapter
          *
          * @param {string} id
-         * @param {object} options optional
-         * @param {function} callback optional
+         * @param {object} [options]
+         * @param {function} [callback]
          *
          */
         this.delBinaryState = (id, options, callback) => {
@@ -7613,7 +7621,7 @@ function Adapter(options) {
          * @alias delBinaryStateAsync
          * @memberof Adapter
          * @param {string} id
-         * @param {object} options optional
+         * @param {object} [options]
          * @return promise
          *
          */

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -6885,7 +6885,7 @@ function Adapter(options) {
                     // filter out
                     let regEx;
                     // process patterns like "*.someValue". The patterns "someValue.*" will be processed by getObjectView
-                    if (typeof pattern === 'string' && pattern !== '*' && pattern[pattern.length - 1] !== '*') {
+                    if (pattern !== '*' && pattern[pattern.length - 1] !== '*') {
                         regEx = new RegExp(tools.pattern2RegEx(pattern));
                     }
                     for (let i = 0; i < res.rows.length; i++) {
@@ -7264,12 +7264,7 @@ function Adapter(options) {
             }
 
             // if pattern known, remove it from alias patterns to not subscribe to further matching aliases
-            for (let i = 0; i < this.aliasPatterns.length; i++) {
-                if (this.aliasPatterns[i] === aliasPattern) {
-                    this.aliasPatterns.splice(i, 1);
-                    break;
-                }
-            }
+            this.aliasPatterns = this.aliasPatterns.filter(pattern => pattern !== aliasPattern);
 
             if (aliasPattern) {
                 Object.keys(this.aliases).forEach(sourceId => {

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -33,7 +33,7 @@ const {PluginHandler}   = require('@iobroker/plugin-base');
 
 const password          = require('./password');
 
-const FORBIDDEN_CHARS   = /[\]\[*,;'"`<>\\?]/g;
+const FORBIDDEN_CHARS   = /[\][*,;'"`<>\\?]/g;
 const DEFAULT_SECRET    = 'Zgfr56gFe87jJOM';
 const ALIAS_STARTS_WITH = 'alias.';
 

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -156,11 +156,11 @@ function Adapter(options) {
         config.states = config.states || {type: 'file'};
         config.objects = config.objects || {type: 'file'};
     } else {
-        throw 'Cannot find ' + getConfigFileName();
+        throw new Error(`Cannot find ${getConfigFileName()}`);
     }
 
     if (!options || (!config && !options.config)) {
-        throw 'Configuration not set!';
+        throw new Error('Configuration not set!');
     }
 
     let schedule;
@@ -250,7 +250,7 @@ function Adapter(options) {
     }
 
     if (!options.name) {
-        throw 'No name of adapter!';
+        throw new Error('No name of adapter!');
     }
 
     this._getObjectsByArray = (keys, objects, options, cb, _index, _result, _errors) => {
@@ -412,7 +412,7 @@ function Adapter(options) {
         if (config.states.type === 'file' || config.states.type === 'redis') {
             States = require('./states/statesInRedis');
         } else {
-            throw 'Unknown objects type: ' + config.states.type;
+            throw new Error(`Unknown objects type: ${config.states.type}`);
         }
     } else {
         States  = require('./states');
@@ -427,7 +427,7 @@ function Adapter(options) {
                 Objects = require('iobroker.objects-redis');
             }
         } else {
-            throw 'Unknown objects type: ' + config.objects.type;
+            throw new Error(`Unknown objects type: ${config.objects.type}`);
         }
     } else {
         Objects = require('./objects');
@@ -537,7 +537,7 @@ function Adapter(options) {
      */
     this.getPort = (port, host, callback) => {
         if (!port) {
-            throw 'adapterGetPort: no port';
+            throw new Error('adapterGetPort: no port');
         }
 
         if (typeof host === 'function') {
@@ -613,7 +613,7 @@ function Adapter(options) {
         }
 
         if (!callback) {
-            throw 'checkPassword: no callback';
+            throw new Error('checkPassword: no callback');
         }
 
         user = (user || '').toString().replace(this.FORBIDDEN_CHARS, '_').replace(/\s/g, '_').replace(/\./g, '_').toLowerCase();
@@ -3335,7 +3335,7 @@ function Adapter(options) {
                 options = null;
             }
             if (!channelName) {
-                throw 'Try to create channel without name!';
+                throw new Error('Cannot create a channel without a name!');
             }
 
             if (typeof _native === 'function') {
@@ -3386,7 +3386,7 @@ function Adapter(options) {
                 options = null;
             }
             if (!stateName) {
-                throw 'Empty name is not allowed!';
+                throw new Error('Cannot create a state without a name!');
             }
 
             if (typeof _native === 'function') {

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -1498,6 +1498,7 @@ function Adapter(options) {
             }
         }, (config.objects.connectTimeout || 2000) * 3); // Because we do not connect only anymore, give it a bit more time
 
+        // eslint-disable-next-line no-unused-vars
         const objectsInst = new Objects({
             namespace: this.namespaceLog,
             connection: config.objects,
@@ -5137,6 +5138,7 @@ function Adapter(options) {
         }, config.states.connectTimeout || 2000);
 
         // Internal object, but some special adapters want to access it anyway.
+        // eslint-disable-next-line no-unused-vars
         const _states = new States({
             namespace:  this.namespaceLog,
             connection: config.states,

--- a/lib/cli/cliObjects.js
+++ b/lib/cli/cliObjects.js
@@ -271,11 +271,11 @@ module.exports = class CLIObjects extends CLICommand {
 
     /**
      * Collects all object for specific path
-     * @param objects {object} class
-     * @param params {object} parameters for getObjectView
-     * @param callback {function} return like function(array)
-     * @param _types {array} types (internal)
-     * @param _result {array} temporary result (internal)
+     * @param {object} objects class
+     * @param {object} params parameters for getObjectView
+     * @param {(result: object[]) => void} callback
+     * @param {string[]} _types types (internal)
+     * @param {object[]} _result temporary result (internal)
      */
     _collectObjects(objects, params, callback, _types, _result) {
         _types = _types || ['state', 'channel', 'device', 'enum', 'instance', 'host', 'adapter', 'meta', 'config', 'group', 'user', 'info', 'script'];
@@ -292,15 +292,15 @@ module.exports = class CLIObjects extends CLICommand {
 
     /**
      * Delete all object from list sequentially
-     * @param objects {object} class
-     * @param ids {array} IDs
-     * @param callback {function} function() {}
+     * @param {object} objects class
+     * @param {string[]} ids IDs
+     * @param {() => void} callback
      */
     _deleteObjects(objects, ids, callback) {
         if (!ids || !ids.length) {
             callback && callback();
         } else {
-            const id = ids.pop;
+            const id = ids.pop();
             objects.delObject(id, () => {
                 tools.removeIdFromAllEnums(objects, id).then(() => setImmediate(this._deleteObjects, objects, ids, callback))
                     .catch(e => {
@@ -343,7 +343,7 @@ module.exports = class CLIObjects extends CLICommand {
                             input:  process.stdin,
                             output: process.stdout
                         });
-                        rl.question(result.count + ' object(s) will be deleted. Are you sure? [y/N]: ', answer => {
+                        rl.question(result.length + ' object(s) will be deleted. Are you sure? [y/N]: ', answer => {
                             rl.close();
                             if (answer === 'y' || answer === 'yes' || answer === 'j' || answer === 'ja' || answer === 'да' || answer === 'д') {
                                 this._deleteObjects(objects, ids, callback);

--- a/lib/cli/cliStates.js
+++ b/lib/cli/cliStates.js
@@ -112,8 +112,8 @@ module.exports = class CLIStates extends CLICommand {
      */
     set_(args) {
         const {callback, dbConnect, showHelp} = this.options;
-        /** @type {[string, any, any]} */
-        let [id, val, ack] = args.slice(1);
+        // eslint-disable-next-line prefer-const
+        let [id, val, ack] = /** @type {[string, any, any]} */ (args.slice(1));
         const force = args.includes('--force') || args.includes('-f');
 
         if (val === undefined) {

--- a/lib/letsencryptStore.js
+++ b/lib/letsencryptStore.js
@@ -35,6 +35,7 @@ function fs_writeFileAsync(fileName, data, encoding) {
     });
 }
 
+// eslint-disable-next-line no-unused-vars
 function fs_statAsync(fileName, options) {
     return new Promise((resolve, reject) => {
         try {
@@ -753,7 +754,7 @@ module.exports.create = function (configs) {
             // Configs
             _checkHelperAsync: args =>
                 pyconf.readFileAsync(args.renewalPath)
-                    .catch(err => pyconf.readFileAsync(path.join(__dirname, 'renewal.conf.tpl'))),
+                    .catch(_err => pyconf.readFileAsync(path.join(__dirname, 'renewal.conf.tpl'))),
             // Configs
             getAsync: args => store.configs._checkHelperAsync(args)
                 .then(pyobj => {

--- a/lib/multihostClient.js
+++ b/lib/multihostClient.js
@@ -14,6 +14,7 @@ let crypto = null;
 const port   = 50005;
 const MULTICAST_ADDR = '239.255.255.250';
 
+/** @class */
 function MHClient(_hostname, _logger, _config, _info) {
     let id = 1;
     let server;
@@ -99,11 +100,10 @@ function MHClient(_hostname, _logger, _config, _info) {
         });
 
         server.on('message', function (msg, rinfo) {
-            msg = msg.toString();
             try {
-                msg = JSON.parse(msg);
+                const message = JSON.parse(msg.toString());
                 if (onMessage) {
-                    if (onMessage(server, msg, rinfo)) {
+                    if (onMessage(server, message, rinfo)) {
                         stopServer();
                         onFinished = null;
                     }

--- a/lib/objects.js
+++ b/lib/objects.js
@@ -19,5 +19,5 @@ if (config.objects.type === 'file' || config.objects.type === 'redis') {
         }
     }
 } else {
-    throw 'Unknown objects type: ' + config.objects.type;
+    throw new Error(`Unknown objects type: ${config.objects.type}`);
 }

--- a/lib/objects/objectsInMemFileDB.js
+++ b/lib/objects/objectsInMemFileDB.js
@@ -1093,8 +1093,7 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
             if (changed) {
                 if (fs.existsSync(path.join(this.objectsDir, id))) {
                     fs.writeFileSync(path.join(this.objectsDir, id, '_data.json'), JSON.stringify(this.fileOptions[id]));
-                }
-                else {
+                } else {
                     delete this.fileOptions[id];
                 }
             }

--- a/lib/objects/objectsInMemServerRedis.js
+++ b/lib/objects/objectsInMemServerRedis.js
@@ -394,9 +394,8 @@ class ObjectsInMemoryServer extends ObjectsInMemoryFileDB {
                         response.push(JSON.stringify(obj));
                     });
                     handler.sendArray(responseId, response);
-                }
-                // Handle request for File data
-                else {
+                } else {
+                    // Handle request for File data
                     handler.sendError(responseId, new Error('MGET-UNSUPPORTED for file data'));
                 }
             } else {
@@ -453,9 +452,8 @@ class ObjectsInMemoryServer extends ObjectsInMemoryFileDB {
                     }
                     obj.stats = stats;
                     handler.sendBulk(responseId, JSON.stringify(obj));
-                }
-                // Handle request for File data
-                else {
+                } else {
+                    // Handle request for File data
                     this.readFile(id, name, (err, data, _mimeType) => {
                         if (err || data === undefined || data === null) {
                             handler.sendNull(responseId);
@@ -512,9 +510,8 @@ class ObjectsInMemoryServer extends ObjectsInMemoryFileDB {
                         return;
                     }
                     handler.sendString(responseId, 'OK');
-                }
-                // Handle request to write the file
-                else {
+                } else {
+                    // Handle request to write the file
                     this.writeFile(id, name, data[1], err => {
                         if (err) {
                             handler.sendError(responseId, new Error('ERROR writeFile id=' + id + ': ' + err));
@@ -541,9 +538,8 @@ class ObjectsInMemoryServer extends ObjectsInMemoryFileDB {
                 // Handle request for Meta data for files
                 if (oldDetails.isMeta) {
                     handler.sendString(responseId, 'OK');
-                }
-                // Handle request for File data
-                else {
+                } else {
+                    // Handle request for File data
                     this.rename(oldDetails.id, oldDetails.name, newDetails.name, err => {
                         if (err) {
                             handler.sendNull(responseId);
@@ -574,9 +570,8 @@ class ObjectsInMemoryServer extends ObjectsInMemoryFileDB {
                 // will be removed when data are deleted
                 if (isMeta) {
                     handler.sendString(responseId, 'OK');
-                }
-                // Handle request to remove the file
-                else {
+                } else {
+                    // Handle request to remove the file
                     this.unlink(id, name, err => {
                         if (err) {
                             handler.sendError(responseId, new Error('ERROR unlink id=' + id + ': ' + err));

--- a/lib/objects/objectsInMemServerRedis.js
+++ b/lib/objects/objectsInMemServerRedis.js
@@ -88,7 +88,7 @@ class ObjectsInMemoryServer extends ObjectsInMemoryFileDB {
     /**
      * Separate Namespace from ID and return both
      * @param idWithNamespace ID or Array of IDs containing a redis namespace and the real ID
-     * @returns {{namespace: (string); id: (string|string[]); name?: string; isMeta?: boolean}} Object with namespace and the
+     * @returns {{namespace: (string); id: string; name?: string; isMeta?: boolean}} Object with namespace and the
      *                                                      ID/Array of IDs without the namespace
      * @private
      */

--- a/lib/objects/objectsInMemServerRedis.js
+++ b/lib/objects/objectsInMemServerRedis.js
@@ -82,7 +82,7 @@ class ObjectsInMemoryServer extends ObjectsInMemoryFileDB {
         }
     }
 
-    addPreserveSettings(settings) {
+    addPreserveSettings(_settings) {
         // when Redis is used this is done by objectsInRedis already
     }
     /**

--- a/lib/objects/objectsUtils.js
+++ b/lib/objects/objectsUtils.js
@@ -17,7 +17,7 @@ const deepClone   = require('deep-clone');
 
 const regUser     = /^system\.user\./;
 const regGroup    = /^system\.group\./;
-const regCheckId  = /[*?\[\]]|\$%\$/;
+const regCheckId  = /[*?[\]]|\$%\$/;
 
 const SYSTEM_ADMIN_USER  = 'system.user.admin';
 const SYSTEM_ADMIN_GROUP = 'system.group.administrator';

--- a/lib/objects/objectsUtils.js
+++ b/lib/objects/objectsUtils.js
@@ -145,7 +145,7 @@ WMStrm.prototype._write = function (chunk, enc, cb) {
         memStore[this.key] = Buffer.concat([memStore[this.key], buffer]);
     }
     if (!cb) {
-        throw 'Callback is empty';
+        throw new Error('Callback is empty');
     }
     cb();
 };

--- a/lib/preinstallCheck.js
+++ b/lib/preinstallCheck.js
@@ -23,7 +23,7 @@ function checkNpmVersion() {
 
             let timer = setTimeout(() => {
                 timer = null;
-                reject('Timeout');
+                reject(new Error('Timeout'));
             }, 10000);
 
             child_process.exec('npm -v', {encoding: 'utf8', env: newEnv, windowsHide: true}, (error, stdout, _stderr) => {

--- a/lib/preinstallCheck.js
+++ b/lib/preinstallCheck.js
@@ -166,14 +166,14 @@ function eq(v1, v2) {
     return v1.build === v2.build;
 }
 
-/**
- * Checks if v1 != v2
- * @param {Version | string} v1
- * @param {Version | string} v2
- */
-function ne(v1, v2) {
-    return !eq(v1, v2);
-}
+// /**
+//  * Checks if v1 != v2
+//  * @param {Version | string} v1
+//  * @param {Version | string} v2
+//  */
+// function ne(v1, v2) {
+//     return !eq(v1, v2);
+// }
 
 /**
  * Checks if v1 >= v2
@@ -184,11 +184,11 @@ function gte(v1, v2) {
     return gt(v1, v2) || eq(v1, v2);
 }
 
-/**
- * Checks if v1 <= v2
- * @param {Version | string} v1
- * @param {Version | string} v2
- */
-function lte(v1, v2) {
-    return lt(v1, v2) || eq(v1, v2);
-}
+// /**
+//  * Checks if v1 <= v2
+//  * @param {Version | string} v1
+//  * @param {Version | string} v2
+//  */
+// function lte(v1, v2) {
+//     return lt(v1, v2) || eq(v1, v2);
+// }

--- a/lib/redisHandler.js
+++ b/lib/redisHandler.js
@@ -1,5 +1,5 @@
 const Resp = require('respjs');
-const EventEmitter = require('events');
+const { EventEmitter } = require('events');
 
 /**
  * Class to handle a redis connection and provide events to react on for
@@ -135,9 +135,8 @@ class RedisHandler extends EventEmitter {
                 if (this.writeQueue.length && this.writeQueue[idx].data === false) {
                     break;
                 }
-            }
-            // we have not found the response on the current index, try next one
-            else {
+            } else {
+                // we have not found the response on the current index, try next one
                 idx++;
             }
         }

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -2389,7 +2389,7 @@ function checkSystemOffline(onlyCheck, callback) {
                 });
                 callback && callback(true);
             });
-        } , err => {
+        }).catch(() => {
             callback && callback(true);
         });
     }, 500);
@@ -2447,6 +2447,7 @@ function dbConnect(onlyCheck, params, callback) {
                 }
                 // Just open in memory DB itself
                 Objects = require('./objects/objectsInMemServerRedis');
+                // eslint-disable-next-line no-unused-vars
                 const _inst = new Objects({
                     connection: config.objects,
                     logger: {

--- a/lib/setup/setupBackup.js
+++ b/lib/setup/setupBackup.js
@@ -26,19 +26,19 @@ class BackupRestore {
         options = options || {};
 
         if (!options.states) {
-            throw 'Invalid arguments: states is missing';
+            throw new Error('Invalid arguments: states is missing');
         }
         if (!options.objects) {
-            throw 'Invalid arguments: objects is missing';
+            throw new Error('Invalid arguments: objects is missing');
         }
         if (!options.processExit) {
-            throw 'Invalid arguments: processExit is missing';
+            throw new Error('Invalid arguments: processExit is missing');
         }
         if (!options.cleanDatabase) {
-            throw 'Invalid arguments: cleanDatabase is missing';
+            throw new Error('Invalid arguments: cleanDatabase is missing');
         }
         if (!options.restartController) {
-            throw 'Invalid arguments: restartController is missing';
+            throw new Error('Invalid arguments: restartController is missing');
         }
 
         this.objects = options.objects;
@@ -851,10 +851,10 @@ class BackupRestore {
         }
 
         if (!this.cleanDatabase) {
-            throw 'Invalid arguments: cleanDatabase is missing';
+            throw new Error('Invalid arguments: cleanDatabase is missing');
         }
         if (!this.restartController) {
-            throw 'Invalid arguments: restartController is missing';
+            throw new Error('Invalid arguments: restartController is missing');
         }
 
         // If number

--- a/lib/setup/setupBackup.js
+++ b/lib/setup/setupBackup.js
@@ -695,7 +695,7 @@ class BackupRestore {
         return new Promise((resolve, reject) => {
             const backupJSON = require(`${tmpDir}/backup/backup.json`);
             if (!backupJSON.objects || !backupJSON.objects.length) {
-                reject('Backup does not contain valid objects');
+                reject(new Error('Backup does not contain valid objects'));
             }
 
             this._checkDirectory(`${tmpDir}/backup/files`)
@@ -824,7 +824,7 @@ class BackupRestore {
                             }
                             resolve();
                         } catch (e) {
-                            reject(`host.${hostname} ${filePath} is not a valid json file`);
+                            reject(new Error(`host.${hostname} ${filePath} is not a valid json file`));
                         }
                     }
                 }

--- a/lib/setup/setupInstall.js
+++ b/lib/setup/setupInstall.js
@@ -234,7 +234,7 @@ function Install(options) {
                 return typeof callback === 'function' && callback(_callback =>
                     typeof _callback === 'function' && _callback(), packetName);
             }
-            name = packetName.replace(/[\/ $&*\\]/g, '_');
+            name = packetName.replace(/[/ $&*\\]/g, '_');
         } else {
             url = packetName;
             if (url.indexOf('http://') === -1 && url.indexOf('https://') === -1 && url.indexOf('file://') === -1) {
@@ -1731,7 +1731,7 @@ function Install(options) {
                 if (url.endsWith('/')) {
                     url = url.substring(0, url.length -1);
                 }
-                const githubParts = url.match(/^https:\/\/github\.com\/([^\/]+\/[^\/]+)\/?.*$/);
+                const githubParts = url.match(/^https:\/\/github\.com\/([^/]+\/[^/]+)\/?.*$/);
                 if (githubParts && githubParts[1]) {
                     request.get({
                         url: 'http://api.github.com/repos/' + githubParts[1] + '/commits/master',

--- a/lib/setup/setupInstall.js
+++ b/lib/setup/setupInstall.js
@@ -35,19 +35,19 @@ function Install(options) {
     options = options || {};
 
     if (!options.states)        {
-        throw 'Invalid arguments: states is missing';
+        throw new Error('Invalid arguments: states is missing');
     }
     if (!options.objects)       {
-        throw 'Invalid arguments: objects is missing';
+        throw new Error('Invalid arguments: objects is missing');
     }
     if (!options.processExit)   {
-        throw 'Invalid arguments: processExit is missing';
+        throw new Error('Invalid arguments: processExit is missing');
     }
     if (!options.installNpm)    {
-        throw 'Invalid arguments: installNpm is missing';
+        throw new Error('Invalid arguments: installNpm is missing');
     }
     if (!options.getRepository) {
-        throw 'Invalid arguments: getRepository is missing';
+        throw new Error('Invalid arguments: getRepository is missing');
     }
 
     const objects            = options.objects;

--- a/lib/setup/setupInstall.js
+++ b/lib/setup/setupInstall.js
@@ -737,8 +737,7 @@ function Install(options) {
         let engineVersion;
         try {
             // read directly from disk and not via require to allow "on the fly" updates of adapters.
-            let p = fs.readFileSync(adapterDir + '/package.json');
-            p = JSON.parse(p.toString());
+            const p = JSON.parse(fs.readFileSync(adapterDir + '/package.json', 'utf8'));
             engineVersion = p && p.engines && p.engines.node;
         } catch (e) {
             console.error('host.' + hostname + ': Cannot read and parse "' + adapterDir + '/package.json"');
@@ -1545,8 +1544,9 @@ function Install(options) {
             {id: `vis`, name: `widgets/${adapter}`},
             {id: `vis`, name: `widgets/${adapter}.html`},
             {id: adapter},
-            {id: `${adapter}.admin`}
-        ].concat(metaFilesToDelete);
+            {id: `${adapter}.admin`},
+            ...metaFilesToDelete.map(id => ({id}))
+        ];
 
         for (const file of filesToDelete) {
             const id = typeof file === 'object' ? file.id : file;

--- a/lib/setup/setupInstall.js
+++ b/lib/setup/setupInstall.js
@@ -766,7 +766,7 @@ function Install(options) {
                             upload.uploadAdapter(_adapter, true, true, () =>
                                 upload.uploadAdapter(_adapter, false, true, () =>
                                     callInstallOfAdapter(_adapter, adapterConf, () =>
-                                        that.uploadStaticObjects(adapter, err =>
+                                        that.uploadStaticObjects(adapter, _err =>
                                             upload.upgradeAdapterObjects(adapter, () =>
                                                 callback(adapter))))));
                         }
@@ -775,7 +775,7 @@ function Install(options) {
                     upload.uploadAdapter(adapter, true, true, () =>
                         upload.uploadAdapter(adapter, false, true, () =>
                             callInstallOfAdapter(adapter, adapterConf, () =>
-                                that.uploadStaticObjects(adapter, err =>
+                                that.uploadStaticObjects(adapter, _err =>
                                     upload.upgradeAdapterObjects(adapter, () =>
                                         callback(adapter))))));
                 }

--- a/lib/setup/setupLicense.js
+++ b/lib/setup/setupLicense.js
@@ -28,14 +28,14 @@ function License(options) {
         // try to encode license
         const license = jwt.decode(file);
         if (!license) {
-            return Promise.reject('License cannot be decoded');
+            return Promise.reject(new Error('License cannot be decoded'));
         }
         if (!license.name) {
-            return Promise.reject('Name not found in the license');
+            return Promise.reject(new Error('Name not found in the license'));
         }
         const adapter = license.name.split('.')[1];
         if (!adapter) {
-            return Promise.reject(`Invalid license name ${license.name}`);
+            return Promise.reject(new Error(`Invalid license name ${license.name}`));
         }
         // read all instances of this adapter
         return objects.getObjectListAsync({

--- a/lib/setup/setupList.js
+++ b/lib/setup/setupList.js
@@ -16,13 +16,13 @@ function List(options) {
     options = options || {};
 
     if (!options.states)      {
-        throw 'Invalid Modified arguments: states is missing';
+        throw new Error('Invalid Modified arguments: states is missing');
     }
     if (!options.objects)     {
-        throw 'Invalid arguments: objects is missing';
+        throw new Error('Invalid arguments: objects is missing');
     }
     if (!options.processExit) {
-        throw 'Invalid arguments: processExit is missing';
+        throw new Error('Invalid arguments: processExit is missing');
     }
 
     const tools             = require('../tools');

--- a/lib/setup/setupRepo.js
+++ b/lib/setup/setupRepo.js
@@ -32,10 +32,10 @@ function Repo(options) {
     options = options || {};
 
     if (!options.objects) {
-        throw 'Invalid arguments: objects is missing';
+        throw new Error('Invalid arguments: objects is missing');
     }
     if (!options.states) {
-        throw 'Invalid arguments: states is missing';
+        throw new Error('Invalid arguments: states is missing');
     }
 
     const objects = options.objects;

--- a/lib/setup/setupSetup.js
+++ b/lib/setup/setupSetup.js
@@ -48,7 +48,7 @@ function Setup(options) {
                 if (dirpath[i] !== '..') {
                     fs.mkdirSync(rootpath);
                 } else {
-                    throw 'Cannot create ' + rootpath + dirpath.join('/');
+                    throw new Error(`Cannot create ${rootpath}${dirpath.join('/')}`);
                 }
             }
         }

--- a/lib/setup/setupUpgrade.js
+++ b/lib/setup/setupUpgrade.js
@@ -17,16 +17,16 @@ function Upgrade(options) {
     options = options || {};
 
     if (!options.processExit)       {
-        throw 'Invalid arguments: processExit is missing';
+        throw new Error('Invalid arguments: processExit is missing');
     }
     if (!options.installNpm)        {
-        throw 'Invalid arguments: installNpm is missing';
+        throw new Error('Invalid arguments: installNpm is missing');
     }
     if (!options.restartController) {
-        throw 'Invalid arguments: restartController is missing';
+        throw new Error('Invalid arguments: restartController is missing');
     }
     if (!options.getRepository)     {
-        throw 'Invalid arguments: getRepository is missing';
+        throw new Error('Invalid arguments: getRepository is missing');
     }
 
     const processExit       = options.processExit;

--- a/lib/setup/setupUpload.js
+++ b/lib/setup/setupUpload.js
@@ -20,10 +20,10 @@ function Upload(options) {
     options = options || {};
 
     if (!options.states)      {
-        throw 'Invalid arguments: states is missing';
+        throw new Error('Invalid arguments: states is missing');
     }
     if (!options.objects)     {
-        throw 'Invalid arguments: objects is missing';
+        throw new Error('Invalid arguments: objects is missing');
     }
 
     const states      = options.states;

--- a/lib/setup/setupUsers.js
+++ b/lib/setup/setupUsers.js
@@ -18,10 +18,10 @@ function Users(options) {
     options   = options || {};
 
     if (!options.objects)     {
-        throw 'Invalid arguments: objects is missing';
+        throw new Error('Invalid arguments: objects is missing');
     }
     if (!options.processExit) {
-        throw 'Invalid arguments: processExit is missing';
+        throw new Error('Invalid arguments: processExit is missing');
     }
 
     const objects     = options.objects;

--- a/lib/setup/setupVendor.js
+++ b/lib/setup/setupVendor.js
@@ -51,11 +51,11 @@ function Vendor(options) {
                 data = JSON.parse(fs.readFileSync(file).toString('utf8'));
             } catch (e) {
                 logger.error(`cannot read or parse "${file}": ${e.toString()}`);
-                return Promise.reject(`cannot read or parse "${file}": ${e.toString()}`);
+                return Promise.reject(new Error(`cannot read or parse "${file}": ${e.toString()}`));
             }
         } else {
             logger.error(`"${file}" does not exist`);
-            return Promise.reject(`"${file}" does not exist`);
+            return Promise.reject(new Error(`"${file}" does not exist`));
         }
 
         const promises = [];

--- a/lib/setup/setupVisDebug.js
+++ b/lib/setup/setupVisDebug.js
@@ -24,10 +24,10 @@ function VisDebug(options) {
     options = options || {};
 
     if (!options.objects)           {
-        throw 'Invalid arguments: objects is missing';
+        throw new Error('Invalid arguments: objects is missing');
     }
     if (!options.processExit)       {
-        throw 'Invalid arguments: processExit is missing';
+        throw new Error('Invalid arguments: processExit is missing');
     }
 
     const objects           = options.objects;
@@ -81,7 +81,7 @@ function VisDebug(options) {
             }
 
             if (!adapterDir) {
-                throw `Adapter not found. Tried: ${adapterNames2Try.join(', ')}`;
+                throw new Error(`Adapter not found. Tried: ${adapterNames2Try.join(', ')}`);
             }
         }
 

--- a/lib/setup/setupVisDebug.js
+++ b/lib/setup/setupVisDebug.js
@@ -157,7 +157,7 @@ FALLBACK:
             count++;
             objects.writeFile('vis', 'cache.manifest', file)
                 .catch(e => console.error(`Cannot save ${visDir}/www/cache.manifest: ${e}`))
-                .then(() => !--count && processExit())
+                .then(() => !--count && processExit());
         }
 
         let file = fs.readFileSync(tools.getConfigFileName(), 'utf8');

--- a/lib/states.js
+++ b/lib/states.js
@@ -9,5 +9,5 @@ if (!config.states) {
 if (config.states.type === 'file' || config.states.type === 'redis') {
     module.exports = require('./states/statesInRedis');
 } else {
-    throw 'Unknown objects type: ' + config.objects.type;
+    throw new Error(`Unknown objects type: ${config.objects.type}`);
 }

--- a/lib/states/statesInMemServerRedis.js
+++ b/lib/states/statesInMemServerRedis.js
@@ -76,7 +76,7 @@ class StatesInMemoryServer extends StatesInMemoryFileDB {
     /**
      * Separate Namespace from ID and return both
      * @param idWithNamespace ID or Array of IDs containing a redis namespace and the real ID
-     * @returns {{namespace: (string), id: (string | string[])}} Object with namespace and the
+     * @returns {{namespace: (string), id: string}} Object with namespace and the
      *                                                      ID/Array of IDs without the namespace
      * @private
      */

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -335,6 +335,7 @@ function uuid(givenMac, callback) {
         u = mac.substring(0, 8) + '-' + mac.substring(8, 12) + '-' + mac.substring(12, 16) + '-' + mac.substring(16, 20) + '-' + mac.substring(20);
     } else {
         // Returns a RFC4122 compliant v4 UUID https://gist.github.com/LeverOne/1308368 (DO WTF YOU WANT TO PUBLIC LICENSE)
+        /** @type {any} */
         let a;
         let b;
         b = a = '';
@@ -1573,6 +1574,7 @@ function sliceArgs(argsObj, startIndex) {
 function promisify(fn, context, returnArgNames) {
     return function () {
         const args = sliceArgs(arguments);
+        // @ts-ignore we cannot know the type of `this`
         context = context || this;
         return new Promise((resolve, reject) => {
             fn.apply(context, args.concat([
@@ -1622,6 +1624,7 @@ function promisify(fn, context, returnArgNames) {
 function promisifyNoError(fn, context, returnArgNames) {
     return function () {
         const args = sliceArgs(arguments);
+        // @ts-ignore we cannot know the type of `this`
         context = context || this;
         return new Promise((resolve, _reject) => {
             fn.apply(context, args.concat([
@@ -1850,6 +1853,7 @@ function decrypt(key, value) {
 /**
  * Tests whether the given variable is a real object and not an Array
  * @param {any} it The variable to test
+ * @returns {it is Record<string, any>}
  */
 function isObject(it) {
     // This is necessary because:
@@ -2050,7 +2054,7 @@ function parseDependencies(dependencies) {
  * If attributes of obj.common are not provided, no error is thrown. obj.type has to be there and has to be valid.
  *
  * @param {object} obj an object which will be validated
- * @param {boolean} extend optional if true checks will allow more optional cases for extendObject calls
+ * @param {boolean} [extend] (optional) if true checks will allow more optional cases for extendObject calls
  * @throws Error if a property has the wrong type or obj.type is non existing
  */
 function validateGeneralObjectProperties(obj, extend) {

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -1075,7 +1075,7 @@ function getAdapterDir(adapter) {
     if (!adapterPath) {
         return null; // inactive
     } else {
-        const parts = path.normalize(adapterPath).split(/[\\\/]/g);
+        const parts = path.normalize(adapterPath).split(/[\\/]/g);
         parts.pop();
         return parts.join('/');
     }

--- a/lib/uploadFiles.js
+++ b/lib/uploadFiles.js
@@ -31,6 +31,7 @@ let dir;
 let prefix;
 
 let db;
+// eslint-disable-next-line no-unused-vars
 const _inst = new Objects({
     logger: {
         silly: function (_msg) { },

--- a/lib/www/js/visUtils.js
+++ b/lib/www/js/visUtils.js
@@ -111,7 +111,7 @@ function extractBinding(format) {
                         }
                     }
                 } else {
-                    const parse = parts[u].match(/([\w\s\/+*-]+)(\(.+\))?/);
+                    const parse = parts[u].match(/([\w\s/+*-]+)(\(.+\))?/);
                     let param;
                     if (parse && parse[1]) {
                         parse[1] = parse[1].trim();

--- a/lib/www/js/visUtils.js
+++ b/lib/www/js/visUtils.js
@@ -183,9 +183,8 @@ function extractBinding(format) {
                                     operations.push({op: parse[1], arg: parse[2]});
                                 }
                             }
-                        } else
-                        // operators without parameter
-                        {
+                        } else {
+                            // operators without parameter
                             operations = operations || [];
                             operations.push({op: parse[1]});
                         }

--- a/main.js
+++ b/main.js
@@ -1595,8 +1595,7 @@ function setMeta() {
     objects.getObjectView('system', 'state', {startkey: hostObjectPrefix + '.', endkey: hostObjectPrefix + '.\u9999', include_docs: true}, (err, doc) => {
         if (err) {
             logger && logger.error(hostLogPrefix + ' Could not collect ' + hostObjectPrefix + ' states to check for obsolete states: ' + err);
-        }
-        else if (doc.rows) {
+        } else if (doc.rows) {
             // identify existing states for deletion, because they are not in the new tasks-list
             let thishostStates = doc.rows;
             if (!compactGroupController) {
@@ -3343,7 +3342,9 @@ function startInstance(id, wakeUp) {
 
                 // Some parts of the Adapter start logic are async, so "the finalization" is put into this method
                 const handleAdapterProcessStart = () => {
-                    if (!procs[id]) return;
+                    if (!procs[id]) {
+                        return;
+                    }
                     if (!procs[id].process) { // We were not able or should not start as compact mode
                         try {
                             procs[id].process = cp.fork(fileNameFull, args, {

--- a/main.js
+++ b/main.js
@@ -274,6 +274,7 @@ function handleDisconnect() {
 }
 
 function createStates(onConnect) {
+    // eslint-disable-next-line no-unused-vars
     const _inst = new States({
         namespace: hostLogPrefix,
         connection: config.states,
@@ -513,6 +514,7 @@ function initializeController() {
 
 // create "objects" object
 function createObjects(onConnect) {
+    // eslint-disable-next-line no-unused-vars
     const _inst = new Objects({
         namespace:  hostLogPrefix,
         connection: config.objects,
@@ -3039,7 +3041,7 @@ function startInstance(id, wakeUp) {
     // Check if all required adapters installed and have valid version
     if (instance.common.dependencies || instance.common.globalDependencies) {
         return checkVersions(id, instance.common.dependencies, instance.common.globalDependencies)
-            .then(ok => {
+            .then(() => {
                 delete instance.common.dependencies;
                 delete instance.common.globalDependencies;
                 startInstance(id, wakeUp);

--- a/main.js
+++ b/main.js
@@ -2345,7 +2345,7 @@ function processMessage(msg) {
                 if (fs.existsSync(configFile)) {
                     try {
                         let config = fs.readFileSync(configFile).toString('utf8');
-                        let stat = fs.lstatSync(configFile);
+                        const stat = fs.lstatSync(configFile);
                         config = JSON.parse(config);
                         sendTo(msg.from, msg.command, {config, isActive: uptimeStart > stat.mtimeMs}, msg.callback);
                     } catch (e) {

--- a/main.js
+++ b/main.js
@@ -592,7 +592,7 @@ function createObjects(onConnect) {
                                     if (procs[id].restartTimer) {
                                         clearTimeout(procs[id].restartTimer);
                                     }
-                                    const restartTimeout = (procs[id].config.common.stopTimeout || 500) + 2500
+                                    const restartTimeout = (procs[id].config.common.stopTimeout || 500) + 2500;
                                     procs[id].restartTimer = setTimeout(_id => startInstance(_id), restartTimeout, id);
                                 }
                             } else {
@@ -637,7 +637,7 @@ function createObjects(onConnect) {
                         (procs[id].config.common.mode !== 'extension' || !procs[id].config.native.webInstance)
                     ) {
                         // We should give is a slight delay to allow an pot. former existing process on other host to exit
-                        const restartTimeout = (procs[id].config.common.stopTimeout || 500) + 2500
+                        const restartTimeout = (procs[id].config.common.stopTimeout || 500) + 2500;
                         procs[id].restartTimer = setTimeout(_id => startInstance(_id), restartTimeout, id);
                     }
                 }

--- a/main.js
+++ b/main.js
@@ -2295,13 +2295,13 @@ function processMessage(msg) {
             })();
             break;
 
-        case 'updateMultihost':
+        case 'updateMultihost': {
             const result = startMultihost();
             if (msg.callback) {
                 sendTo(msg.from, msg.command, {result: result}, msg.callback);
             }
             break;
-
+        }
         case 'getInterfaces':
             if (msg.callback && msg.from) {
                 sendTo(msg.from, msg.command, {result: os.networkInterfaces()}, msg.callback);
@@ -2363,7 +2363,7 @@ function processMessage(msg) {
             }
             break;
 
-        case 'writeBaseSettings':
+        case 'writeBaseSettings': {
             let error;
             if (msg.message) {
                 const configFile = tools.getConfigFileName();
@@ -2414,6 +2414,7 @@ function processMessage(msg) {
             }
 
             break;
+        }
     }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6857,6 +6857,12 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
     },
+    "typescript": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
+      "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
+      "dev": true
+    },
     "uc.micro": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",

--- a/package.json
+++ b/package.json
@@ -1,115 +1,118 @@
 {
-    "name": "iobroker.js-controller",
-    "version": "3.0.21",
-    "engines": {
-        "node": ">=10.0.0"
-    },
-    "optionalDependencies": {
-        "diskusage": "^1.1.3",
-        "greenlock": "^2.8.8",
-        "le-challenge-fs": "^2.0.9",
-        "le-sni-auto": "^2.1.9",
-        "le-acme-core": "^2.1.4",
-        "winston-syslog": "^2.4.0"
-    },
-    "bin": {
-        "iobroker": "./iobroker.js"
-    },
-    "dependencies": {
-        "@iobroker/plugin-base": "^1.1.1",
-        "@iobroker/plugin-sentry": "^1.0.2",
-        "chokidar": "^3.4.0",
-        "daemonize2": "^0.4.2",
-        "debug": "^4.1.1",
-        "decache": "^4.5.1",
-        "deep-clone": "^3.0.3",
-        "event-stream": "^4.0.1",
-        "iobroker.objects-redis": "^3.3.6",
-        "ioredis": "^4.16.3",
-        "jsonwebtoken": "^8.5.1",
-        "jszip": "^3.4.0",
-        "loadavg-windows": "^1.1.1",
-        "mime": "^2.4.4",
-        "mkdirp": "^1.0.4",
-        "ncp": "^2.0.0",
-        "node-forge": "^0.9.1",
-        "node-schedule": "^1.3.2",
-        "node.extend": "^2.0.2",
-        "pidusage": "^2.0.18",
-        "prompt": "^1.0.0",
-        "readline-sync": "^1.4.10",
-        "request": "^2.88.2",
-        "respjs": "^4.2.0",
-        "semver": "^7.3.2",
-        "tar": "^6.0.2",
-        "winston": "^3.2.1",
-        "winston-daily-rotate-file": "^4.4.2",
-        "yargs": "^15.3.1"
-    },
-    "devDependencies": {
-        "@types/event-stream": "^3.3.34",
-        "@types/iobroker": "^3.0.6",
-        "@types/mocha": "^7.0.2",
-        "@types/node": "^13.13.4",
-        "@types/yargs": "^15.0.4",
-        "chai": "^4.2.0",
-        "chai-as-promised": "^7.1.1",
-        "eslint": "^6.8.0",
-        "gulp": "^4.0.2",
-        "gulp-jsdoc3": "^3.0.0",
-        "gulp-replace": "^1.0.0",
-        "istanbul": "^0.4.5",
-        "mocha": "^7.1.2",
-        "sinon": "^9.0.2",
-        "sinon-chai": "^3.5.0"
-    },
-    "homepage": "http://www.iobroker.com",
-    "description": "Updated by reinstall.js on 2018-06-11T15:19:56.688Z",
-    "keywords": [
-        "ioBroker",
-        "Smarthome",
-        "Home Automation",
-        "Smart Metering",
-        "Homematic",
-        "Hue",
-        "KNX",
-        "Z-Wave",
-        "ZigBee",
-        "Bidcos",
-        "TV",
-        "Sonos",
-        "AV Receiver"
-    ],
-    "bugs": {
-        "url": "https://github.com/ioBroker/ioBroker.js-controller/issues"
-    },
-    "licenses": [
-        {
-            "type": "MIT",
-            "url": "https://github.com/ioBroker/ioBroker.js-controller/blob/master/LICENSE"
-        }
-    ],
-    "author": "bluefox <dogafox@gmail.com>",
-    "contributors": [
-        "bluefox <dogafox@gmail.com>",
-        "hobbyquaker <hq@ccu.io>"
-    ],
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/ioBroker/ioBroker.js-controller"
-    },
-    "scripts": {
-        "preinstall": "node lib/preinstallCheck.js",
-        "install": "node iobroker.js setup first",
-        "start": "node iobroker.js start",
-        "stop": "node iobroker.js stop",
-        "restart": "node iobroker.js restart",
-        "prepublishOnly": "node lib/scripts/scripts.js --prepublish",
-        "test": "node node_modules/mocha/bin/mocha test --exit",
-        "test-redis-socket": "node node_modules/mocha/bin/mocha test/redis-socket/ --exit",
-        "test-redis-sentinel": "node node_modules/mocha/bin/mocha test/redis-sentinel/ --exit",
-        "coverage": "node node_modules/istanbul/lib/cli.js cover --config istanbul.yml node_modules/mocha/bin/_mocha ./test -- --ui bdd -R spec"
-    },
-    "main": "main.js",
-    "license": "MIT"
+  "name": "iobroker.js-controller",
+  "version": "3.0.21",
+  "engines": {
+    "node": ">=10.0.0"
+  },
+  "optionalDependencies": {
+    "diskusage": "^1.1.3",
+    "greenlock": "^2.8.8",
+    "le-challenge-fs": "^2.0.9",
+    "le-sni-auto": "^2.1.9",
+    "le-acme-core": "^2.1.4",
+    "winston-syslog": "^2.4.0"
+  },
+  "bin": {
+    "iobroker": "./iobroker.js"
+  },
+  "dependencies": {
+    "@iobroker/plugin-base": "^1.1.1",
+    "@iobroker/plugin-sentry": "^1.0.2",
+    "chokidar": "^3.4.0",
+    "daemonize2": "^0.4.2",
+    "debug": "^4.1.1",
+    "decache": "^4.5.1",
+    "deep-clone": "^3.0.3",
+    "event-stream": "^4.0.1",
+    "iobroker.objects-redis": "^3.3.6",
+    "ioredis": "^4.16.3",
+    "jsonwebtoken": "^8.5.1",
+    "jszip": "^3.4.0",
+    "loadavg-windows": "^1.1.1",
+    "mime": "^2.4.4",
+    "mkdirp": "^1.0.4",
+    "ncp": "^2.0.0",
+    "node-forge": "^0.9.1",
+    "node-schedule": "^1.3.2",
+    "node.extend": "^2.0.2",
+    "pidusage": "^2.0.18",
+    "prompt": "^1.0.0",
+    "readline-sync": "^1.4.10",
+    "request": "^2.88.2",
+    "respjs": "^4.2.0",
+    "semver": "^7.3.2",
+    "tar": "^6.0.2",
+    "winston": "^3.2.1",
+    "winston-daily-rotate-file": "^4.4.2",
+    "yargs": "^15.3.1"
+  },
+  "devDependencies": {
+    "@types/event-stream": "^3.3.34",
+    "@types/iobroker": "^3.0.6",
+    "@types/mocha": "^7.0.2",
+    "@types/node": "^13.13.4",
+    "@types/yargs": "^15.0.4",
+    "chai": "^4.2.0",
+    "chai-as-promised": "^7.1.1",
+    "eslint": "^6.8.0",
+    "gulp": "^4.0.2",
+    "gulp-jsdoc3": "^3.0.0",
+    "gulp-replace": "^1.0.0",
+    "istanbul": "^0.4.5",
+    "mocha": "^7.1.2",
+    "sinon": "^9.0.2",
+    "sinon-chai": "^3.5.0",
+    "typescript": "^3.8.3"
+  },
+  "homepage": "http://www.iobroker.com",
+  "description": "Updated by reinstall.js on 2018-06-11T15:19:56.688Z",
+  "keywords": [
+    "ioBroker",
+    "Smarthome",
+    "Home Automation",
+    "Smart Metering",
+    "Homematic",
+    "Hue",
+    "KNX",
+    "Z-Wave",
+    "ZigBee",
+    "Bidcos",
+    "TV",
+    "Sonos",
+    "AV Receiver"
+  ],
+  "bugs": {
+    "url": "https://github.com/ioBroker/ioBroker.js-controller/issues"
+  },
+  "licenses": [
+    {
+      "type": "MIT",
+      "url": "https://github.com/ioBroker/ioBroker.js-controller/blob/master/LICENSE"
+    }
+  ],
+  "author": "bluefox <dogafox@gmail.com>",
+  "contributors": [
+    "bluefox <dogafox@gmail.com>",
+    "hobbyquaker <hq@ccu.io>"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ioBroker/ioBroker.js-controller"
+  },
+  "scripts": {
+    "preinstall": "node lib/preinstallCheck.js",
+    "install": "node iobroker.js setup first",
+    "start": "node iobroker.js start",
+    "stop": "node iobroker.js stop",
+    "restart": "node iobroker.js restart",
+    "prepublishOnly": "node lib/scripts/scripts.js --prepublish",
+    "test": "node node_modules/mocha/bin/mocha test --exit",
+    "test-redis-socket": "node node_modules/mocha/bin/mocha test/redis-socket/ --exit",
+    "test-redis-sentinel": "node node_modules/mocha/bin/mocha test/redis-sentinel/ --exit",
+    "coverage": "node node_modules/istanbul/lib/cli.js cover --config istanbul.yml node_modules/mocha/bin/_mocha ./test -- --ui bdd -R spec",
+    "lint": "eslint *.js lib",
+    "check": "tsc"
+  },
+  "main": "main.js",
+  "license": "MIT"
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,59 +1,61 @@
 {
 	"compilerOptions": {
-	  /* Basic Options */
-	  "target": "es2015",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', or 'ESNEXT'. */
-	  "module": "commonjs",                     /* Specify module code generation: 'none', commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
-	  "lib": ["es6"],                             /* Specify library files to be included in the compilation:  */
-	  "allowJs": true,                       /* Allow javascript files to be compiled. */
-	  "checkJs": true,                       /* Report errors in .js files. */
-	  // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
-	  // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
-	  // "sourceMap": true,                     /* Generates corresponding '.map' file. */
-	  // "outFile": "./",                       /* Concatenate and emit output to single file. */
-	  // "outDir": "./",                        /* Redirect output structure to the directory. */
-	  // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
-	  // "removeComments": true,                /* Do not emit comments to output. */
-	  "noEmit": true,                        /* Do not emit outputs. */
-	  // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
-	  // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
-	  // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
-  
-	  /* Strict Type-Checking Options */
-	  "strict": false,                            /* Enable all strict type-checking options. */
-	  "noImplicitAny": false,                 /* Raise error on expressions and declarations with an implied 'any' type. */
-	  // "strictNullChecks": true,              /* Enable strict null checks. */
-	  "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
-	  // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
-  
-	  /* Additional Checks */
-	  // "noUnusedLocals": true,                /* Report errors on unused locals. */
-	  // "noUnusedParameters": true,            /* Report errors on unused parameters. */
-	  // "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
-	  // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
-  
-	  /* Module Resolution Options */
-	  // "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
-	  // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
-	  // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
-	  // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
-	  // "typeRoots": [],                       /* List of folders to include type definitions from. */
-	  // "types": [],                           /* Type declaration files to be included in compilation. */
-	  // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
-	  // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
-  
-	  /* Source Map Options */
-	  // "sourceRoot": "./",                    /* Specify the location where debugger should locate TypeScript files instead of source locations. */
-	  // "mapRoot": "./",                       /* Specify the location where debugger should locate map files instead of generated locations. */
-	  // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
-	  // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
-  
-	  /* Experimental Options */
-	  // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
-	  // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
-	  "resolveJsonModule": true
+		/* Basic Options */
+		"target": "es2015",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', or 'ESNEXT'. */
+		"module": "commonjs",                     /* Specify module code generation: 'none', commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
+		"lib": ["es6"],                             /* Specify library files to be included in the compilation:  */
+		"allowJs": true,                       /* Allow javascript files to be compiled. */
+		"checkJs": true,                       /* Report errors in .js files. */
+		// "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
+		// "declaration": true,                   /* Generates corresponding '.d.ts' file. */
+		// "sourceMap": true,                     /* Generates corresponding '.map' file. */
+		// "outFile": "./",                       /* Concatenate and emit output to single file. */
+		// "outDir": "./",                        /* Redirect output structure to the directory. */
+		// "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+		// "removeComments": true,                /* Do not emit comments to output. */
+		"noEmit": true,                        /* Do not emit outputs. */
+		// "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
+		// "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
+		// "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
+
+		/* Strict Type-Checking Options */
+		"strict": false,                            /* Enable all strict type-checking options. */
+		"noImplicitAny": false,                 /* Raise error on expressions and declarations with an implied 'any' type. */
+		// "strictNullChecks": true,              /* Enable strict null checks. */
+		"noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
+		// "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
+
+		"skipLibCheck": true,
+
+		/* Additional Checks */
+		// "noUnusedLocals": true,                /* Report errors on unused locals. */
+		// "noUnusedParameters": true,            /* Report errors on unused parameters. */
+		// "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
+		// "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
+
+		/* Module Resolution Options */
+		// "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+		// "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
+		// "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+		// "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
+		// "typeRoots": [],                       /* List of folders to include type definitions from. */
+		// "types": [],                           /* Type declaration files to be included in compilation. */
+		// "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
+		// "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
+
+		/* Source Map Options */
+		// "sourceRoot": "./",                    /* Specify the location where debugger should locate TypeScript files instead of source locations. */
+		// "mapRoot": "./",                       /* Specify the location where debugger should locate map files instead of generated locations. */
+		// "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
+		// "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
+
+		/* Experimental Options */
+		// "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
+		// "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+		"resolveJsonModule": true
 	},
 	"include": [
-	  "iobroker.js",
-	  "lib/**/*.js"
+		"iobroker.js",
+		"lib/**/*.js"
 	]
-  }
+}


### PR DESCRIPTION
Jokes aside, I wanted to cut down on the visual noise to find out what's actually wrong in #794 and what was there before. 

This PR contains fixes for most ESLint rules we have defined. Also, it replaces all `throw 'string'` and `[Promise.]reject('string')` to use Error objects instead.
There are a bunch of issues left with `hasOwnProperty` I'm not in the mood to fix and some minor things ESLint doesn't like.

I left the package manager alone, because #824 changes all of that anyways.
For review, look at each commit separately.