### PR TITLE
Add missing parameter `digest` to crypto calls

### DIFF
--- a/lib/password.js
+++ b/lib/password.js
@@ -59,7 +59,7 @@ const password = pw => {
                     callback(null, `pbkdf2$${iterations}$${key.toString('hex')}$${salt}`);
                 });
             } else {
-                crypto.pbkdf2(pw, salt, iterations, 64, (err, key) => {
+                crypto.pbkdf2(pw, salt, iterations, 64, 'sha1', (err, key) => {
                     if (err) {
                         return callback(err);
                     }


### PR DESCRIPTION

The default (as per the Node.js 4.x docs) used to be 'sha1'

Fixes: #853