### PR TITLE
Add Plugin CLI commands to enable/disable plugins

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -46,6 +46,6 @@
         "no-trailing-spaces": "error"
     },
     "parserOptions": {
-        "ecmaVersion": 2018
+        "ecmaVersion": 2019
     }
 }

--- a/lib/cli/cliPlugin.js
+++ b/lib/cli/cliPlugin.js
@@ -257,7 +257,7 @@ module.exports = class CLIPlugin extends CLICommand {
                     // If the state could not be read or had no value, fall back to the configuration
                     const enabled = pluginEnabled(
                         pluginName,
-                        systemConfig,
+                        await objects.getObjectAsync('system.config'),
                         instance
                     );
                     CLI.success.pluginStatus(
@@ -318,7 +318,7 @@ function pluginExists(pluginName, systemConfig, adapter) {
  */
 function pluginEnabled(pluginName, systemConfig, adapter) {
     // 1. check if diagnostics were disabled in ioBroker
-    if (systemConfig && systemConfig.diag === 'none') {
+    if (systemConfig && systemConfig.common && systemConfig.common.diag === 'none') {
         return false;
     }
 

--- a/lib/cli/cliPlugin.js
+++ b/lib/cli/cliPlugin.js
@@ -1,0 +1,346 @@
+'use strict';
+const CLI = require('./messages.js');
+const CLICommand = require('./cliCommand.js');
+const { getObjectFrom } = require('./cliTools');
+const tools = require('../tools.js');
+const fs = require('fs');
+const path = require('path');
+
+const controllerIoPackPath = path.join(__dirname, '../../io-package.json');
+
+/** Command iobroker plugin <enable/disable/status> <pluginname> [--host this/hostname] ... */
+module.exports = class CLIPlugin extends CLICommand {
+    /** @param {import('./cliCommand').CLICommandOptions} options */
+    constructor(options) {
+        super(options);
+    }
+
+    /**
+     * Executes a command
+     * @param {any[]} args
+     */
+    execute(args) {
+        const { callback, showHelp } = this.options;
+        const command = args[0];
+
+        switch (command) {
+            case 'on':
+            case 'enable':
+                return this.set(args, true);
+            case 'off':
+            case 'disable':
+                return this.set(args, false);
+            case 'status':
+                return this.status(args);
+            default:
+                CLI.error.unknownCommand('plugin', command);
+                showHelp();
+                return void callback(3);
+        }
+    }
+
+    /**
+     * Enables or disables the given plugin
+     * @param {any[]} args
+     * @param {boolean} enabled
+     */
+    set(args, enabled) {
+        const { callback, dbConnect } = this.options;
+        /** @type {string} */
+        const pluginName = args[1];
+        if (!pluginName) {
+            CLI.error.requiredArgumentMissing(
+                'pluginName',
+                'plugin enable <pluginname>'
+            );
+            return void callback(34);
+        }
+
+        /** @type {string | undefined} */
+        let hostname;
+        /** @type {string | undefined} */
+        let instance;
+
+        if (this.options.adapter || this.options.instance) {
+            instance = this.options.adapter || this.options.instance;
+            // default to instance 0
+            if (!/\.\d+$/.test(instance)) {
+                instance += '.0';
+            }
+        } else {
+            // Use host if no adapter was specified and fallback to the current one
+            hostname = this.options.host;
+            if (!hostname || hostname === 'this') {
+                hostname = tools.getHostName();
+            }
+        }
+
+        dbConnect(
+            async (objects, states, _isOffline, _dbType, systemConfig) => {
+                try {
+                    // Check if the host or instance exists
+                    /** @type {string} */ let objectNamespace;
+                    if (hostname) {
+                        objectNamespace = `system.host.${hostname}`;
+                        const hostObject = await objects.getObject(
+                            objectNamespace
+                        );
+                        if (!hostObject) {
+                            CLI.error.hostDoesNotExist(hostname);
+                            return void callback(30);
+                        }
+                    } else {
+                        objectNamespace = `system.adapter.${instance}`;
+                        const instanceObject = await objects.getObject(
+                            objectNamespace
+                        );
+                        if (!instanceObject) {
+                            CLI.error.invalidInstance(instance);
+                            return void callback(30);
+                        }
+                    }
+
+                    // Check if the plugin is defined
+                    if (!pluginExists(pluginName, systemConfig, instance)) {
+                        CLI.error.pluginNotDefined(
+                            pluginName,
+                            hostname,
+                            instance
+                        );
+                        return void callback(30);
+                    }
+
+                    // Create the plugin state if it does not exist
+                    const pluginsFolderId = `${objectNamespace}.plugins`;
+                    if (!(await objects.getObjectAsync(pluginsFolderId))) {
+                        await objects.setObject(pluginsFolderId, {
+                            type: 'folder',
+                            common: {
+                                name: `${
+                                    hostname ? 'host' : 'instance'
+                                }: plugin states`
+                            },
+                            native: {}
+                        });
+                    }
+                    const pluginFolderId = `${objectNamespace}.plugins.${pluginName}`;
+                    if (!(await objects.getObjectAsync(pluginFolderId))) {
+                        await objects.setObject(pluginFolderId, {
+                            type: 'folder',
+                            common: {
+                                name: `${pluginName}: plugin states`
+                            },
+                            native: {}
+                        });
+                    }
+                    const pluginEnabledId = `${pluginFolderId}.enabled`;
+                    if (!(await objects.getObjectAsync(pluginEnabledId))) {
+                        await objects.setObject(pluginEnabledId, {
+                            type: 'state',
+                            common: {
+                                name: 'Plugin enabled',
+                                type: 'boolean',
+                                read: true,
+                                write: true,
+                                role: 'value'
+                            },
+                            native: {}
+                        });
+                    }
+
+                    // Update the state
+                    await states.setStateAsync(pluginEnabledId, {
+                        val: enabled,
+                        from: getObjectFrom()
+                    });
+
+                    // Notify the user that we are done
+                    CLI.success.pluginEnabledOrDisabled(
+                        pluginName,
+                        hostname,
+                        instance,
+                        enabled
+                    );
+                    return void callback();
+                } catch (err) {
+                    CLI.error.unknown(err);
+                    return void callback(1);
+                }
+            }
+        );
+    }
+
+    /**
+     * Prints the status of the given plugin
+     * @param {any[]} args
+     */
+    status(args) {
+        const { callback, dbConnect } = this.options;
+        /** @type {string} */
+        const pluginName = args[1];
+        if (!pluginName) {
+            CLI.error.requiredArgumentMissing(
+                'pluginName',
+                'plugin status <pluginname>'
+            );
+            return void callback(34);
+        }
+
+        /** @type {string | undefined} */
+        let hostname;
+        /** @type {string | undefined} */
+        let instance;
+
+        if (this.options.adapter || this.options.instance) {
+            instance = this.options.adapter || this.options.instance;
+            // default to instance 0
+            if (!/\.\d+$/.test(instance)) {
+                instance += '.0';
+            }
+        } else {
+            // Use host if no adapter was specified and fallback to the current one
+            hostname = this.options.host;
+            if (!hostname || hostname === 'this') {
+                hostname = tools.getHostName();
+            }
+        }
+
+        dbConnect(
+            async (objects, states, _isOffline, _dbType, systemConfig) => {
+                try {
+                    // Check if the host or instance exists
+                    /** @type {string} */ let objectNamespace;
+                    if (hostname) {
+                        objectNamespace = `system.host.${hostname}`;
+                        const hostObject = await objects.getObject(
+                            objectNamespace
+                        );
+                        if (!hostObject) {
+                            CLI.error.hostDoesNotExist(hostname);
+                            return void callback(30);
+                        }
+                    } else {
+                        objectNamespace = `system.adapter.${instance}`;
+                        const instanceObject = await objects.getObject(
+                            objectNamespace
+                        );
+                        if (!instanceObject) {
+                            CLI.error.invalidInstance(instance);
+                            return void callback(30);
+                        }
+                    }
+
+                    // Check if the plugin is defined
+                    if (!pluginExists(pluginName, systemConfig, instance)) {
+                        CLI.error.pluginNotDefined(
+                            pluginName,
+                            hostname,
+                            instance
+                        );
+                        return void callback(30);
+                    }
+
+                    const pluginEnabledId = `${objectNamespace}.plugins.${pluginName}.enabled`;
+
+                    // Read the state
+                    try {
+                        const enabled = await states.getState(pluginEnabledId)
+                            .val;
+                        if (typeof enabled === 'boolean') {
+                            CLI.success.pluginStatus(pluginName, enabled);
+                            return void callback();
+                        }
+                    } catch {
+                        /* ignore */
+                    }
+
+                    // If the state could not be read or had no value, fall back to the configuration
+                    const enabled = pluginEnabled(
+                        pluginName,
+                        systemConfig,
+                        instance
+                    );
+                    CLI.success.pluginStatus(
+                        pluginName,
+                        hostname,
+                        instance,
+                        enabled
+                    );
+                    return void callback();
+                } catch (err) {
+                    CLI.error.unknown(err);
+                    return void callback(1);
+                }
+            }
+        );
+    }
+};
+
+/**
+ * Checks if a plugin exists and can be configured
+ * @param {string} pluginName
+ * @param {Record<string, any>} systemConfig
+ * @param {string} [adapter] (optional) - If passed, the adapter configuration will be searched for defined plugins instead of js-controller
+ */
+function pluginExists(pluginName, systemConfig, adapter) {
+    // 1. check if the plugin is defined in io-package.json
+    // TODO: replace this with fs-extra methods #799
+    try {
+        const ioPackPath = adapter
+            ? path.join(tools.getAdapterDir(adapter), 'io-package.json')
+            : controllerIoPackPath;
+        const ioPack = JSON.parse(fs.readFileSync(ioPackPath, 'utf8'));
+        if (
+            ioPack &&
+            ioPack.common &&
+            ioPack.common.plugins &&
+            pluginName in ioPack.common.plugins
+        ) {
+            return true;
+        }
+    } catch {
+        /* ignore */
+    }
+
+    // 2. check if the plugin is defined in iobroker.json
+    return (
+        systemConfig &&
+        systemConfig.plugins &&
+        pluginName in systemConfig.plugins
+    );
+}
+
+/**
+ * Checks if a plugin exists and can be configured
+ * @param {string} pluginName
+ * @param {Record<string, any>} systemConfig
+ * @param {string} [adapter] (optional) - If passed, the adapter configuration will be searched for defined plugins instead of js-controller
+ */
+function pluginEnabled(pluginName, systemConfig, adapter) {
+    // 1. check if diagnostics were disabled in ioBroker
+    if (systemConfig && systemConfig.diag === 'none') {
+        return false;
+    }
+
+    // 2. check if the plugin is disabled in io-package.json
+    // TODO: replace this with fs-extra methods #799
+    try {
+        const ioPackPath = adapter
+            ? path.join(tools.getAdapterDir(adapter), 'io-package.json')
+            : controllerIoPackPath;
+        const ioPack = JSON.parse(fs.readFileSync(ioPackPath, 'utf8'));
+        if (
+            ioPack &&
+            ioPack.common &&
+            ioPack.common.plugins &&
+            pluginName in ioPack.common.plugins
+        ) {
+            return ioPack.common.plugins[pluginName].enabled !== false;
+        }
+    } catch {
+        /* ignore */
+    }
+
+    // default: enabled
+    return true;
+}

--- a/lib/cli/cliPlugin.js
+++ b/lib/cli/cliPlugin.js
@@ -76,7 +76,7 @@ module.exports = class CLIPlugin extends CLICommand {
         }
 
         dbConnect(
-            async (objects, states, _isOffline, _dbType, systemConfig) => {
+            async (objects, states, _isOffline, _dbType, iobrokerJson) => {
                 try {
                     // Check if the host or instance exists
                     /** @type {string} */ let objectNamespace;
@@ -101,7 +101,7 @@ module.exports = class CLIPlugin extends CLICommand {
                     }
 
                     // Check if the plugin is defined
-                    if (!pluginExists(pluginName, systemConfig, instance)) {
+                    if (!pluginExists(pluginName, iobrokerJson, instance)) {
                         CLI.error.pluginNotDefined(
                             pluginName,
                             hostname,
@@ -206,7 +206,7 @@ module.exports = class CLIPlugin extends CLICommand {
         }
 
         dbConnect(
-            async (objects, states, _isOffline, _dbType, systemConfig) => {
+            async (objects, states, _isOffline, _dbType, iobrokerJson) => {
                 try {
                     // Check if the host or instance exists
                     /** @type {string} */ let objectNamespace;
@@ -231,7 +231,7 @@ module.exports = class CLIPlugin extends CLICommand {
                     }
 
                     // Check if the plugin is defined
-                    if (!pluginExists(pluginName, systemConfig, instance)) {
+                    if (!pluginExists(pluginName, iobrokerJson, instance)) {
                         CLI.error.pluginNotDefined(
                             pluginName,
                             hostname,
@@ -257,8 +257,9 @@ module.exports = class CLIPlugin extends CLICommand {
                     // If the state could not be read or had no value, fall back to the configuration
                     const enabled = pluginEnabled(
                         pluginName,
+                        instance,
                         await objects.getObjectAsync('system.config'),
-                        instance
+                        iobrokerJson
                     );
                     CLI.success.pluginStatus(
                         pluginName,
@@ -279,10 +280,10 @@ module.exports = class CLIPlugin extends CLICommand {
 /**
  * Checks if a plugin exists and can be configured
  * @param {string} pluginName
- * @param {Record<string, any>} systemConfig
+ * @param {Record<string, any>} iobrokerJson The contents of iobroker.json
  * @param {string} [adapter] (optional) - If passed, the adapter configuration will be searched for defined plugins instead of js-controller
  */
-function pluginExists(pluginName, systemConfig, adapter) {
+function pluginExists(pluginName, iobrokerJson, adapter) {
     // 1. check if the plugin is defined in io-package.json
     // TODO: replace this with fs-extra methods #799
     try {
@@ -304,21 +305,26 @@ function pluginExists(pluginName, systemConfig, adapter) {
 
     // 2. check if the plugin is defined in iobroker.json
     return (
-        systemConfig &&
-        systemConfig.plugins &&
-        pluginName in systemConfig.plugins
+        iobrokerJson &&
+        iobrokerJson.plugins &&
+        pluginName in iobrokerJson.plugins
     );
 }
 
 /**
  * Checks if a plugin exists and can be configured
  * @param {string} pluginName
- * @param {Record<string, any>} systemConfig
- * @param {string} [adapter] (optional) - If passed, the adapter configuration will be searched for defined plugins instead of js-controller
+ * @param {string | undefined} adapter If defined, the adapter configuration will be searched for defined plugins instead of js-controller
+ * @param {Record<string, any>} systemConfig The system.config object
+ * @param {Record<string, any>} iobrokerJson The contents of iobroker.json
  */
-function pluginEnabled(pluginName, systemConfig, adapter) {
-    // 1. check if diagnostics were disabled in ioBroker
-    if (systemConfig && systemConfig.common && systemConfig.common.diag === 'none') {
+function pluginEnabled(pluginName, adapter, systemConfig, iobrokerJson) {
+    // 1. check if diagnostics are disabled in ioBroker
+    if (
+        systemConfig &&
+        systemConfig.common &&
+        systemConfig.common.diag === 'none'
+    ) {
         return false;
     }
 
@@ -333,12 +339,23 @@ function pluginEnabled(pluginName, systemConfig, adapter) {
             ioPack &&
             ioPack.common &&
             ioPack.common.plugins &&
-            pluginName in ioPack.common.plugins
+            pluginName in ioPack.common.plugins &&
+            ioPack.common.plugins[pluginName].enabled === false
         ) {
-            return ioPack.common.plugins[pluginName].enabled !== false;
+            return false;
         }
     } catch {
         /* ignore */
+    }
+
+    // 3. check if the plugin is disabled in iobroker.json
+    if (
+        iobrokerJson &&
+        iobrokerJson.plugins &&
+        pluginName in iobrokerJson.plugins &&
+        iobrokerJson.plugins[pluginName].enabled === false
+    ) {
+        return false;
     }
 
     // default: enabled

--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -16,6 +16,6 @@ module.exports = {
         cert:    require('./cliCert.js'),
         compact: require('./cliCompact.js'),
         debug:    require('./cliDebug.js'),
-        plugin: require('./cliPLugin.js')
+        plugin: require('./cliPlugin.js')
     }
 };

--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -15,6 +15,7 @@ module.exports = {
         host:    require('./cliHost.js'),
         cert:    require('./cliCert.js'),
         compact: require('./cliCompact.js'),
-        debug:    require('./cliDebug.js')
+        debug:    require('./cliDebug.js'),
+        plugin: require('./cliPLugin.js')
     }
 };

--- a/lib/cli/messages.js
+++ b/lib/cli/messages.js
@@ -62,6 +62,8 @@ const errorMessages = Object.freeze({
     hostAlreadyExists: hostname => `A host with the name "${hostname}" already exists!`,
     hostDoesNotExist: hostname => `The host "${hostname}" does not exist!`,
 
+    pluginNotDefined: (pluginName, host, instance) => `The plugin "${pluginName}" does not exist for ${host ? `host "${host}"` : `instance "${instance}"`}!`,
+
     cert: certName => `Certificate "${certName}" not found or error parsing certificate information.`
 });
 
@@ -93,7 +95,10 @@ const successMessages = Object.freeze({
         /** @type {string} */ from,
         /** @type {string} */ to
     ) => `The host for instance "${instance}" was changed from "${from}" to "${to}".`,
-    hostDeleted: hostname => `The host "${hostname}" was deleted.`
+    hostDeleted: hostname => `The host "${hostname}" was deleted.`,
+
+    pluginEnabledOrDisabled: (pluginName, host, instance, status) => `The plugin "${pluginName}" was successfully ${status ? 'enabled' : 'disabled'} for ${host ? `host "${host}"` : `instance "${instance}"`}.`,
+    pluginStatus: (pluginName, host, instance, status) => `The plugin "${pluginName}" is ${status ? 'enabled' : 'disabled'} for ${host ? `host "${host}"` : `instance "${instance}"`}.`
 });
 
 const warnings = Object.freeze({

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -132,9 +132,9 @@ function initYargs() {
                 tools.appName + ' plugin enable <pluginname> [--host <hostname>] - enables a plugin for the specified host. If no host is specified, the current one is used \n' +
                 tools.appName + ' plugin disable <pluginname> [--host <hostname>] - disables a plugin for the specified host. If no host is specified, the current one is used \n' +
                 tools.appName + ' plugin status <pluginname> [--host <hostname>] - checks if a plugin is enabled for the specified host. If no host is specified, the current one is used \n' +
-                tools.appName + ' plugin enable <pluginname> --instance <adapter>.<nr> - enables a plugin for the specified adapter instance \n' +
-                tools.appName + ' plugin disable <pluginname> --instance <adapter>.<nr> - disables a plugin for the specified adapter instance \n' +
-                tools.appName + ' plugin status <pluginname> --instance <adapter>.<nr> - checks if a plugin is enabled for the specified adapter instance \n' +
+                tools.appName + ' plugin enable <pluginname> --instance <adapter>[.<nr>] - enables a plugin for the specified adapter instance (defaults to instance 0) \n' +
+                tools.appName + ' plugin disable <pluginname> --instance <adapter>[.<nr>] - disables a plugin for the specified adapter instance (defaults to instance 0) \n' +
+                tools.appName + ' plugin status <pluginname> --instance <adapter>[.<nr>] - checks if a plugin is enabled for the specified adapter instance (defaults to instance 0) \n' +
                 tools.appName + ' version [adapter] - show version of js-controller or specified adapter\n' +
                 tools.appName + ' [adapter] -v - show version of js-controller or specified adapter\n')
     //.default('objects',   '127.0.0.1')

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -129,6 +129,12 @@ function initYargs() {
                 tools.appName + ' compact <adapter>.<instance> group <group-id> - define compact group of a specific adapter\n' +
                 tools.appName + ' compact <adapter>.<instance> <disable|off> - enable or disable compact mode for specified adapter instance\n' +
                 tools.appName + ' compact <adapter>.<instance> <enable|on> [group-id] - enable or disable compact mode for specified adapter instance and set comapct group optionally\n' +
+                tools.appName + ' plugin enable <pluginname> [--host <hostname>] - enables a plugin for the specified host. If no host is specified, the current one is used \n' +
+                tools.appName + ' plugin disable <pluginname> [--host <hostname>] - disables a plugin for the specified host. If no host is specified, the current one is used \n' +
+                tools.appName + ' plugin status <pluginname> [--host <hostname>] - checks if a plugin is enabled for the specified host. If no host is specified, the current one is used \n' +
+                tools.appName + ' plugin enable <pluginname> --instance <adapter>.<nr> - enables a plugin for the specified adapter instance \n' +
+                tools.appName + ' plugin disable <pluginname> --instance <adapter>.<nr> - disables a plugin for the specified adapter instance \n' +
+                tools.appName + ' plugin status <pluginname> --instance <adapter>.<nr> - checks if a plugin is enabled for the specified adapter instance \n' +
                 tools.appName + ' version [adapter] - show version of js-controller or specified adapter\n' +
                 tools.appName + ' [adapter] -v - show version of js-controller or specified adapter\n')
     //.default('objects',   '127.0.0.1')
@@ -2018,6 +2024,12 @@ function processCommand(command, args, params, callback) {
         case 'compact': {
             const compactCommand = new cli.command.compact(commandOptions);
             compactCommand.execute(args);
+            break;
+        }
+
+        case 'plugin': {
+            const pluginCommand = new cli.command.plugin(commandOptions);
+            pluginCommand.execute(args);
             break;
         }
 

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -1050,8 +1050,13 @@ function sendDiagInfo(obj, callback) {
 function getAdapterDir(adapter) {
     const appName = module.exports.appName;
 
-    if (adapter.substring(0, appName.length + 1) === appName + '.') {
+    // snip off 'iobroker.'
+    if (adapter.startsWith(appName + '.')) {
         adapter = adapter.substring(appName.length + 1);
+    }
+    // snip off instance id
+    if (/\.\d+$/.test(adapter)) {
+        adapter = adapter.substr(0, adapter.lastIndexOf('.'));
     }
 
     const possibilities = [


### PR DESCRIPTION
fixes: #869 

This PR adds the following CLI commands to enable, disable and show the enabled status of plugins:
```
iobroker plugin enable <pluginname> [--host <hostname>]
iobroker plugin disable <pluginname> [--host <hostname>]
iobroker plugin status <pluginname> [--host <hostname>]
iobroker plugin enable <pluginname> --instance <adapter>.<nr>
iobroker plugin disable <pluginname> --instance <adapter>.<nr>
iobroker plugin status <pluginname> --instance <adapter>.<nr>
```

Plugins can be configured per host or per adapter instance. If no argument is given, the current host is used. If no adapter instance number is given, instance 0 is used.

I tried to stay consistent with the older CLI commands, so all commands have the form `<namespace> <command> <commmandArg> [--<args>]`