### PR TITLE
Fix user

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -1754,7 +1754,7 @@ function Adapter(options) {
 
                     typeof options.objectChange === 'function' && setImmediate(options.objectChange, id, obj);
                     // emit 'objectChange' event instantly
-                    setImmediate(this.emit, 'objectChange', id, obj);
+                    setImmediate(() => this.emit('objectChange', id, obj));
                 }
             }
         });
@@ -4934,12 +4934,16 @@ function Adapter(options) {
      */
     const updateUsernameCache = async () => {
         // make sure cache is cleared
-        this.usernames = {};
         try {
             // get all users
             const obj = await this.getObjectListAsync({startkey: 'system.user.', endkey: 'system.user.\u9999'});
+            this.usernames = {};
             for (const row of obj.rows) {
-                this.usernames[row.value.common.name] = {id: row.id};
+                if (row.value.common && typeof row.value.common.name === 'string') {
+                    this.usernames[row.value.common.name] = {id: row.id};
+                } else {
+                    logger.warn(`${this.namespaceLog} Invalid username for ${row.id}`);
+                }
             }
         } catch (e) {
             throw new Error(`Could not update user cache: ${e.message}`);

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -1511,6 +1511,10 @@ function Adapter(options) {
                     clearTimeout(initializeTimeout);
                     initializeTimeout = null;
                 }
+
+                // subscribe to user changes
+                adapterObjects.subscribe('system.user.*');
+
                 // Read dateformat if using of formatDate is announced
                 if (options.useFormatDate) {
                     this.getForeignObject('system.config', (err, data) => {
@@ -1661,6 +1665,12 @@ function Adapter(options) {
                         }
                     }
                 }
+
+                // Clear cache if got the message about change (Will work for admin and javascript)
+                if (id.match(/^system\.user\./) || id.match(/^system\.group\./)) {
+                    this.users = {};
+                    this.groups = {};
+                }
             },
             changeUser: (id, obj) => { // User level object changes
                 if (obj === 'null' || obj === '') {
@@ -1691,9 +1701,9 @@ function Adapter(options) {
                         }
                     }
 
-                    typeof options.objectChange === 'function' && setImmediate(() => options.objectChange(id, obj));
+                    typeof options.objectChange === 'function' && setImmediate(options.objectChange, id, obj);
                     // emit 'objectChange' event instantly
-                    setImmediate(() => this.emit('objectChange', id, obj));
+                    setImmediate(this.emit, 'objectChange', id, obj);
                 }
             }
         });
@@ -2831,7 +2841,7 @@ function Adapter(options) {
          * @alias getForeignObject
          * @memberof Adapter
          * @param {string} id exactly object ID (with namespace)
-         * @param {object} options optional user context
+         * @param {object} [options] optional user context
          * @param {ioBroker.GetObjectCallback} callback return result
          *        <pre><code>
          *            function (err, obj) {
@@ -5173,7 +5183,7 @@ function Adapter(options) {
         const _states = new States({
             namespace:  this.namespaceLog,
             connection: config.states,
-            connected: statesInstance => {
+            connected: async statesInstance => {
                 adapterStates = statesInstance;
                 logger.debug(this.namespaceLog + ' statesDB connected');
                 this.statesConnectedTime = Date.now();
@@ -5185,30 +5195,34 @@ function Adapter(options) {
 
                 if (!config.isInstall) {
                     // Subscribe for process exit signal
-                    adapterStates.subscribe('system.adapter.' + this.namespace + '.sigKill');
+                    adapterStates.subscribe(`system.adapter.${this.namespace}.sigKill`);
 
                     // Subscribe for loglevel
-                    adapterStates.subscribe('system.adapter.' + this.namespace + '.logLevel');
+                    adapterStates.subscribe(`system.adapter.${this.namespace}.logLevel`);
                 }
                 if (options.subscribable) {
                     // subscribe on if other instance wants to have states of this adapter
-                    adapterStates.subscribe('system.adapter.' + this.namespace + '.subscribes');
+                    adapterStates.subscribe(`system.adapter.${this.namespace}.subscribes`);
 
                     // read actual autosubscribe requests
-                    adapterStates.getState('system.adapter.' + this.namespace + '.subscribes', (err, state) => {
-                        if (!state || !state.val) {
+                    let state;
+                    try {
+                        state = await adapterStates.getStateAsync(`system.adapter.${this.namespace}.subscribes`);
+                    } catch {
+                        // ignore
+                    }
+                    if (!state || !state.val) {
+                        this.patterns = {};
+                    } else {
+                        try {
+                            this.patterns = JSON.parse(state.val);
+                            Object.keys(this.patterns).forEach(p =>
+                                this.patterns[p].regex = tools.pattern2RegEx(p));
+                        } catch (e) {
                             this.patterns = {};
-                        } else {
-                            try {
-                                this.patterns = JSON.parse(state.val);
-                                Object.keys(this.patterns).forEach(p =>
-                                    this.patterns[p].regex = tools.pattern2RegEx(p));
-                            } catch (e) {
-                                this.patterns = {};
-                            }
                         }
-                        return tools.maybeCallback(cb);
-                    });
+                    }
+                    return tools.maybeCallback(cb);
                 } else {
                     return tools.maybeCallback(cb);
                 }
@@ -5288,12 +5302,6 @@ function Adapter(options) {
                     } else {
                         this.emit('subscribesChange', subs);
                     }
-                }
-
-                // Clear cache if accidentally got the message about change (Will work for admin and javascript)
-                if (id.match(/^system\.user\./) || id.match(/^system\.group\./)) {
-                    this.users = {};
-                    this.groups = {};
                 }
 
                 // If someone want to have log messages

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -635,12 +635,15 @@ function Adapter(options) {
                 } catch (e) {
                     this.log.error(e);
                 }
-                // user still not there, its no valid user -> credentials false
                 if (!this.usernames[user]) {
-                    return tools.maybeCallback(callback, false);
+                    // user still not there, its no valid user -> fallback to legacy check
+                    user = `system.user.${user.toString().replace(this.FORBIDDEN_CHARS, '_').replace(/\s/g, '_').replace(/\./g, '_').toLowerCase()}`;
+                } else {
+                    user = this.usernames[user].id;
                 }
+            } else {
+                user = this.usernames[user].id;
             }
-            user = this.usernames[user].id;
         }
 
         this.getForeignObject(user, options, (err, obj) => {
@@ -688,12 +691,15 @@ function Adapter(options) {
                 } catch (e) {
                     this.log.error(e);
                 }
-                // user still not there, its no valid user
                 if (!this.usernames[user]) {
-                    return tools.maybeCallbackWithError(callback, 'User does not exist');
+                    // user still not there, fallback to legacy check
+                    user = `system.user.${user.toString().replace(this.FORBIDDEN_CHARS, '_').replace(/\s/g, '_').replace(/\./g, '_').toLowerCase()}`;
+                } else {
+                    user = this.usernames[user].id;
                 }
+            } else {
+                user = this.usernames[user].id;
             }
-            user = this.usernames[user].id;
         }
 
         this.getForeignObject(user, options, (err, obj) => {
@@ -767,12 +773,16 @@ function Adapter(options) {
                 } catch (e) {
                     this.log.error(e);
                 }
-                // user still not there, its no valid user -> credentials false
+
                 if (!this.usernames[user]) {
-                    return tools.maybeCallback(callback, false);
+                    // user still not there, its no valid user -> fallback
+                    user = `system.user.${user.toString().replace(this.FORBIDDEN_CHARS, '_').replace(/\s/g, '_').replace(/\./g, '_').toLowerCase()}`;
+                } else {
+                    user = this.usernames[user].id;
                 }
+            } else {
+                user = this.usernames[user].id;
             }
-            user = this.usernames[user].id;
         }
 
         if (group && !regGroup.test(group)) {
@@ -911,13 +921,15 @@ function Adapter(options) {
                 } catch (e) {
                     this.log.error(e.message);
                 }
-                // user still not there, its no valid user
+                // user still not there, fallback
                 if (!this.usernames[user]) {
-                    logger.error(`${this.namespaceLog} User ${user} does not exist`);
-                    return tools.maybeCallback(callback, {});
+                    user = `system.user.${user.toString().replace(this.FORBIDDEN_CHARS, '_').replace(/\s/g, '_').replace(/\./g, '_').toLowerCase()}`;
+                } else {
+                    user = this.usernames[user].id;
                 }
+            } else {
+                user = this.usernames[user].id;
             }
-            user = this.usernames[user].id;
         }
 
         // read all groups

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -452,7 +452,9 @@ function Adapter(options) {
     this._namespaceRegExp = new RegExp('^' + (this.namespace + '.').replace(/\./g, '\\.')); // cache the regex object 'adapter.0.'
 
     /** The cache of users */
-    this.users           = {}; // cache of user groups
+    this.users           = {};
+    /** The cache of usernames */
+    this.usernames       = {};
     /** The cache of user groups */
     this.groups          = {};
     this.defaultHistory  = null;
@@ -610,11 +612,11 @@ function Adapter(options) {
      * @param {(port: number) => void} callback return result
      *        <pre><code>
      *            function (result) {
-     *              adapter.log.debug('User is valid');
+     *              if (result) adapter.log.debug('User is valid');
      *            }
      *        </code></pre>
      */
-    this.checkPassword = (user, pw, options, callback) => {
+    this.checkPassword = async (user, pw, options, callback) => {
         if (typeof options === 'function') {
             callback = options;
             options = null;
@@ -624,10 +626,21 @@ function Adapter(options) {
             throw new Error('checkPassword: no callback');
         }
 
-        user = (user || '').toString().replace(this.FORBIDDEN_CHARS, '_').replace(/\s/g, '_').replace(/\./g, '_').toLowerCase();
-
         if (user && !regUser.test(user)) {
-            user = 'system.user.' + user;
+            // its not yet a `system.user.xy` id, thus we assume it's a username
+            if (!this.usernames[user]) {
+                // we did not find the id of the username in our cache -> update cache
+                try {
+                    await updateUsernameCache();
+                } catch (e) {
+                    this.log.error(e);
+                }
+                // user still not there, its no valid user -> credentials false
+                if (!this.usernames[user]) {
+                    return tools.maybeCallback(callback, false);
+                }
+            }
+            user = this.usernames[user].id;
         }
 
         this.getForeignObject(user, options, (err, obj) => {
@@ -660,13 +673,27 @@ function Adapter(options) {
      *            }
      *        </code></pre>
      */
-    this.setPassword = (user, pw, options, callback) => {
+    this.setPassword = async (user, pw, options, callback) => {
         if (typeof options === 'function') {
             callback = options;
             options  = null;
         }
+
         if (user && !regUser.test(user)) {
-            user = 'system.user.' + user;
+            // its not yet a `system.user.xy` id, thus we assume it's a username
+            if (!this.usernames[user]) {
+                // we did not find the id of the username in our cache -> update cache
+                try {
+                    await updateUsernameCache();
+                } catch (e) {
+                    this.log.error(e);
+                }
+                // user still not there, its no valid user
+                if (!this.usernames[user]) {
+                    return tools.maybeCallbackWithError(callback, 'User does not exist');
+                }
+            }
+            user = this.usernames[user].id;
         }
 
         this.getForeignObject(user, options, (err, obj) => {
@@ -723,16 +750,31 @@ function Adapter(options) {
      *            }
      *        </code></pre>
      */
-    this.checkGroup = (user, group, options, callback) => {
-        user = (user || '').toLowerCase();
+    this.checkGroup = async (user, group, options, callback) => {
+        user = (user || '');
 
         if (typeof options === 'function') {
             callback = options;
             options  = null;
         }
+
         if (user && !regUser.test(user)) {
-            user = 'system.user.' + user;
+            // its not yet a `system.user.xy` id, thus we assume it's a username
+            if (!this.usernames[user]) {
+                // we did not find the id of the username in our cache -> update cache
+                try {
+                    await updateUsernameCache();
+                } catch (e) {
+                    this.log.error(e);
+                }
+                // user still not there, its no valid user -> credentials false
+                if (!this.usernames[user]) {
+                    return tools.maybeCallback(callback, false);
+                }
+            }
+            user = this.usernames[user].id;
         }
+
         if (group && !regGroup.test(group)) {
             group = 'system.group.' + group;
         }
@@ -852,17 +894,32 @@ function Adapter(options) {
      *            }
      *        </code></pre>
      */
-    this.calculatePermissions = (user, commandsPermissions, options, callback) => {
-        user = (user || '').toLowerCase();
+    this.calculatePermissions = async (user, commandsPermissions, options, callback) => {
+        user = (user || '');
 
         if (typeof options === 'function') {
             callback = options;
             options  = null;
         }
 
-        if (!regUser.test(user)) {
-            user = 'system.user.' + user;
+        if (user && !regUser.test(user)) {
+            // its not yet a `system.user.xy` id, thus we assume it's a username
+            if (!this.usernames[user]) {
+                // we did not find the id of the username in our cache -> update cache
+                try {
+                    await updateUsernameCache();
+                } catch (e) {
+                    this.log.error(e.message);
+                }
+                // user still not there, its no valid user
+                if (!this.usernames[user]) {
+                    logger.error(`${this.namespaceLog} User ${user} does not exist`);
+                    return tools.maybeCallback(callback, {});
+                }
+            }
+            user = this.usernames[user].id;
         }
+
         // read all groups
         let acl = {user: user};
         if (user === SYSTEM_ADMIN_USER) {
@@ -881,10 +938,7 @@ function Adapter(options) {
         this.getForeignObjects('*', 'group', null, options, (err, groups) => {
             // aggregate all groups permissions, where this user is
             if (groups) {
-                for (const g in groups) {
-                    if (!Object.prototype.hasOwnProperty.call(groups, g)) {
-                        continue;
-                    }
+                for (const g of Object.keys(groups)) {
                     if (groups[g] &&
                         groups[g].common &&
                         groups[g].common.members &&
@@ -932,11 +986,7 @@ function Adapter(options) {
 
                         const gAcl = groups[g].common.acl;
                         try {
-                            for (const type in gAcl) {
-                                if (!Object.prototype.hasOwnProperty.call(gAcl, type)) {
-                                    continue;
-                                }
-
+                            for (const type of Object.keys(gAcl)) {
                                 // fix bug. Some version have user instead of users.
                                 if (type === 'user') {
                                     acl.users = acl.users || {};
@@ -1670,6 +1720,7 @@ function Adapter(options) {
                 if (id.match(/^system\.user\./) || id.match(/^system\.group\./)) {
                     this.users = {};
                     this.groups = {};
+                    this.usernames = {};
                 }
             },
             changeUser: (id, obj) => { // User level object changes
@@ -1741,7 +1792,7 @@ function Adapter(options) {
          * Helper method for `set[Foreign]Object[NotExists]` that also sets the default value if one is configured
          * @param {string} id of the object
          * @param obj The object to set
-         * @param {unknown} [options]
+         * @param {object} [options]
          * @param callback
          */
         const setObjectWithDefaultValue = async (id, obj, options, callback) => {
@@ -4874,6 +4925,25 @@ function Adapter(options) {
                 });
             }
         });
+    };
+
+    /**
+     * This method update the cached values in this.usernames
+     *
+     * @returns {Promise<void>}
+     */
+    const updateUsernameCache = async () => {
+        // make sure cache is cleared
+        this.usernames = {};
+        try {
+            // get all users
+            const obj = await this.getObjectListAsync({startkey: 'system.user.', endkey: 'system.user.\u9999'});
+            for (const row of obj.rows) {
+                this.usernames[row.value.common.name] = {id: row.id};
+            }
+        } catch (e) {
+            throw new Error(`Could not update user cache: ${e.message}`);
+        }
     };
 
     const checkState = (obj, options, command) => {

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -4940,9 +4940,9 @@ function Adapter(options) {
             this.usernames = {};
             for (const row of obj.rows) {
                 if (row.value.common && typeof row.value.common.name === 'string') {
-                    this.usernames[row.value.common.name] = {id: row.id};
+                    this.usernames[row.value.common.name] = {id: row.id.replace(FORBIDDEN_CHARS, '_')};
                 } else {
-                    logger.warn(`${this.namespaceLog} Invalid username for ${row.id}`);
+                    logger.warn(`${this.namespaceLog} Invalid username for id "${row.id}"`);
                 }
             }
         } catch (e) {

--- a/lib/cli/cliHost.js
+++ b/lib/cli/cliHost.js
@@ -69,7 +69,7 @@ module.exports = class CLIHost extends CLICommand {
         /** @type {string} */
         const hostname = args[1];
         if (!hostname) {
-            CLI.error.requiredArgumentMissing('hostname', 'host remove newHostname');
+            CLI.error.requiredArgumentMissing('hostname', 'host remove hostname');
             return void callback(34);
         }
 
@@ -120,7 +120,7 @@ module.exports = class CLIHost extends CLICommand {
                 CLI.success.hostDeleted(hostname);
                 return void callback();
 
-            }catch (err) {
+            } catch (err) {
                 CLI.error.unknown(err);
                 return void callback(1);
             }

--- a/test/lib/testAdapterHelpers.js
+++ b/test/lib/testAdapterHelpers.js
@@ -68,7 +68,7 @@ function register(it, expect, context) {
         this.timeout(1000);
 
         //Expecting a callback
-        expect(context.adapter.checkPassword.bind('claus', '1234')).to.throw('checkPassword: no callback');
+        context.adapter.checkPassword('claus', '1234').should.be.rejectedWith('checkPassword: no callback');
 
         //User doesnt exists
         context.adapter.checkPassword('claus', '1234', function(res){


### PR DESCRIPTION
- introducing a username cache to retrive the real id by the username instead of guessing the id by the name
- fix clearing cache of `this.users` and `this.groups` due to the fact, that moved to object change handler from state change handler, they are only objects, so this has never worked correctly
- closes #952 
- Note: imho we should prevent identical usernames, at least in frontend, as this is currently possible, opinions?
![Bildschirmfoto von 2020-06-24 22-49-27](https://user-images.githubusercontent.com/25484431/85842646-5102a680-b7a0-11ea-80f8-527b3e23d37b.png)
  