### PR TITLE
use instanceObjects from system.adapter.. object instead from iopack

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -1441,8 +1441,8 @@ function Adapter(options) {
             });
         }
 
-        if (this.ioPack.instanceObjects) {
-            this.ioPack.instanceObjects.forEach(async obj => {
+        if (instanceObj && instanceObj.instanceObjects) {
+            instanceObj.instanceObjects.forEach(async obj => {
                 if (!obj._id.startsWith(this.namespace)) {
                     // instanceObjects are normally defined without namespace prefix
                     obj._id = (obj._id === '') ? this.namespace : this.namespace + '.' + obj._id;

--- a/lib/setup/setupInstall.js
+++ b/lib/setup/setupInstall.js
@@ -1140,7 +1140,7 @@ function Install(options) {
                             adapterConf = fs.readJSONSync(`${adapterDir}/io-package.json`);
                         } catch (e) {
                             console.error(`host.${hostname} error: reading io-package.json ${e}`);
-                            processExit(EXIT_CODES.INVALID_IO_PACKAGE_JSON);
+                            return void processExit(EXIT_CODES.INVALID_IO_PACKAGE_JSON);
                         }
 
                         adapterConf.instanceObjects = adapterConf.instanceObjects || [];


### PR DESCRIPTION
- closes #769
- only other occurrences of instanceObjs are in `setupUpload` and `setupInstall` in these both files, it is intended to read from io-pack, and update the `system.adapter..` object from with the provided information. 