### PR TITLE
Handle existing, but undefined properties in validateSetStateObjectArgument

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -5641,8 +5641,8 @@ function Adapter(options) {
          * @param {Record<string, any>} obj
          */
         function validateSetStateObjectArgument(obj) {
-            // CHeck that we have at least one property at all, else invalid
-            if (Object.keys(obj).length === 0) {
+            // Check that we have at least one existing non-undefined property at all, else invalid
+            if (!Object.keys(obj).some(key => obj[key] !== undefined)) {
                 throw new Error(`The state contains no properties! At least one property is expected!`);
             }
 
@@ -5682,8 +5682,8 @@ function Adapter(options) {
                 if (type === 'any') {
                     continue;
                 }
-                // don't flag optional properties when they don't exist
-                if (!(key in obj)) {
+                // don't flag optional properties when they don't exist or are undefined
+                if (!(key in obj) || obj[key] === undefined) {
                     continue;
                 }
                 if (type !== typeof obj[key]) {


### PR DESCRIPTION
Fixes this (`q is undefined`):
![grafik](https://user-images.githubusercontent.com/17641229/94202359-d25ff700-febd-11ea-80a9-79c7254c9c49.png)
