### PR TITLE
only scale aliases if target or source is represented by unit %

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,6 +459,13 @@ The following fields are allowed in the alias structure:
 * `alias.read` can optionally contain a read script (will be evaluated) to calculate the alias value when the target state changes
 * `alias.write` can optionally contain a write script (will be evaluated) to calculate the target value if the alias value is changed
 
+Note, that alias states will be automatically scaled if the following conditions match:
+
+* target and source state are of type `number`
+* either the alias state or (not both) the source state are of unit `%`
+* no `read` or `write` function is defined
+* the state which is not of unit `%` has a valid `min` and `max` property
+
 To set the alias properties without a JavaScript or in adapter code you can also use the cli commands like:
 
 ```

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -6990,7 +6990,8 @@ function Adapter(options) {
                     pattern,
                     type:  aliasObj.common.type,
                     max:   aliasObj.common.max,
-                    min:   aliasObj.common.min
+                    min:   aliasObj.common.min,
+                    unit: aliasObj.common.unit
                 };
 
                 this.aliases[sourceId].targets.push(targetEntry);
@@ -7006,6 +7007,7 @@ function Adapter(options) {
                                     this.aliases[sourceObj._id].source.min  = sourceObj.common.min;
                                     this.aliases[sourceObj._id].source.max  = sourceObj.common.max;
                                     this.aliases[sourceObj._id].source.type = sourceObj.common.type;
+                                    this.aliases[sourceObj._id].source.unit = sourceObj.common.unit;
                                 }
                             }
                             return tools.maybeCallbackWithError(callback, err);

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -2006,7 +2006,7 @@ function formatAliasValue(sourceObj, targetObj, state, logger, logNamespace) {
         }
     }
 
-    // auto-scaling, only if val not null
+    // auto-scaling, only if val not null and unit for target or source is %
     if (((targetObj && targetObj.alias && !targetObj.alias.read) || (sourceObj && sourceObj.alias && !sourceObj.alias.write)) && state.val !== null) {
         if (targetObj &&
             targetObj.type === 'number' &&
@@ -2014,7 +2014,8 @@ function formatAliasValue(sourceObj, targetObj, state, logger, logNamespace) {
             targetObj.min !== undefined &&
             sourceObj &&
             sourceObj.max !== undefined &&
-            sourceObj.min !== undefined) {
+            sourceObj.min !== undefined &&
+            (targetObj.unit === '%' || sourceObj.unit === '%')) {
             const val = (state.val - sourceObj.min) / (sourceObj.max - sourceObj.min);
             state.val = (targetObj.max - targetObj.min) * val + targetObj.min;
         }

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -2006,18 +2006,16 @@ function formatAliasValue(sourceObj, targetObj, state, logger, logNamespace) {
         }
     }
 
-    // auto-scaling, only if val not null and unit for target or source is %
+    // auto-scaling, only if val not null and unit for target (x)or source is %
     if (((targetObj && targetObj.alias && !targetObj.alias.read) || (sourceObj && sourceObj.alias && !sourceObj.alias.write)) && state.val !== null) {
-        if (targetObj &&
-            targetObj.type === 'number' &&
-            targetObj.max !== undefined &&
-            targetObj.min !== undefined &&
-            sourceObj &&
-            sourceObj.max !== undefined &&
-            sourceObj.min !== undefined &&
-            (targetObj.unit === '%' || sourceObj.unit === '%')) {
-            const val = (state.val - sourceObj.min) / (sourceObj.max - sourceObj.min);
-            state.val = (targetObj.max - targetObj.min) * val + targetObj.min;
+        if (targetObj && targetObj.type === 'number' && targetObj.unit === '%' &&
+            sourceObj && sourceObj.min !== undefined && sourceObj.max !== undefined) {
+            // scale target between 0 and 100 % based on sources min/max
+            state.val = (state.val - sourceObj.min) / (sourceObj.max - sourceObj.min) * 100;
+        } else if (sourceObj && sourceObj.unit === '%' && targetObj && targetObj.type === 'number' &&
+            targetObj.min !== undefined && targetObj.max !== undefined) {
+            // scale target based on its min/max by its source (assuming source is meant to be 0 - 100 %)
+            state.val = ((targetObj.max - targetObj.min) * state.val / 100) + targetObj.min;
         }
     }
 

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -2008,12 +2008,12 @@ function formatAliasValue(sourceObj, targetObj, state, logger, logNamespace) {
 
     // auto-scaling, only if val not null and unit for target (x)or source is %
     if (((targetObj && targetObj.alias && !targetObj.alias.read) || (sourceObj && sourceObj.alias && !sourceObj.alias.write)) && state.val !== null) {
-        if (targetObj && targetObj.type === 'number' && targetObj.unit === '%' &&
-            sourceObj && sourceObj.min !== undefined && sourceObj.max !== undefined) {
+        if (targetObj && targetObj.type === 'number' && targetObj.unit === '%' && sourceObj &&
+            sourceObj.type === 'number' && sourceObj.unit !== '%' && sourceObj.min !== undefined && sourceObj.max !== undefined) {
             // scale target between 0 and 100 % based on sources min/max
             state.val = (state.val - sourceObj.min) / (sourceObj.max - sourceObj.min) * 100;
-        } else if (sourceObj && sourceObj.unit === '%' && targetObj && targetObj.type === 'number' &&
-            targetObj.min !== undefined && targetObj.max !== undefined) {
+        } else if (sourceObj && sourceObj.type === 'number' && sourceObj.unit === '%' && targetObj &&
+            targetObj.unit !== '%' && targetObj.type === 'number' && targetObj.min !== undefined && targetObj.max !== undefined) {
             // scale target based on its min/max by its source (assuming source is meant to be 0 - 100 %)
             state.val = ((targetObj.max - targetObj.min) * state.val / 100) + targetObj.min;
         }

--- a/main.js
+++ b/main.js
@@ -339,10 +339,7 @@ function createStates(onConnect) {
 
                         // delete too old callbacks IDs
                         const now = Date.now();
-                        for (const _id in callbacks) {
-                            if (!Object.prototype.hasOwnProperty.call(callbacks, _id)) {
-                                continue;
-                            }
+                        for (const _id of Object.keys(callbacks)) {
                             if (now - callbacks[_id].time > 3600000) {
                                 delete callbacks[_id];
                             }
@@ -418,10 +415,7 @@ function createStates(onConnect) {
                 let currentLevel = config.log.level;
                 if (state.val && state.val !== currentLevel && ['silly','debug', 'info', 'warn', 'error'].includes(state.val)) {
                     config.log.level = state.val;
-                    for (const transport in logger.transports) {
-                        if (!Object.prototype.hasOwnProperty.call(logger.transports, transport)) {
-                            continue;
-                        }
+                    for (const transport of Object.keys(logger.transports)) {
                         if (logger.transports[transport].level === currentLevel) {
                             logger.transports[transport].level = state.val;
                         }
@@ -842,24 +836,16 @@ function cleanAutoSubscribe(instance, autoInstance, callback) {
         }
         let modified = false;
         // look for all subscribes from this instance
-        for (const pattern in subs) {
-            if (!Object.prototype.hasOwnProperty.call(subs, pattern)) {
-                continue;
-            }
-            for (const id in subs[pattern]) {
-                if (Object.prototype.hasOwnProperty.call(subs[pattern], id) && id === instance) {
+        for (const pattern of Object.keys(subs)) {
+            for (const id of Object.keys(subs[pattern])) {
+                if (id === instance) {
                     modified = true;
                     delete subs[pattern][id];
                 }
             }
-            let found = false;
-            for (const f in subs[pattern]) {
-                if (Object.prototype.hasOwnProperty.call(subs[pattern], f)) {
-                    found = true;
-                    break;
-                }
-            }
-            if (!found) {
+
+            // check if array is now empty
+            if (!Object.keys(subs[pattern].length)) {
                 modified = true;
                 delete subs[pattern];
             }
@@ -2218,8 +2204,8 @@ async function processMessage(msg) {
                     data.Uptime = Math.round((Date.now() - uptimeStart) / 1000);
                     // add information about running instances
                     let count = 0;
-                    for (const id in procs) {
-                        if (Object.prototype.hasOwnProperty.call(procs, id) && procs[id].process) {
+                    for (const id of Object.keys(procs)) {
+                        if (procs[id].process) {
                             count++;
                         }
                     }
@@ -2374,8 +2360,8 @@ async function processMessage(msg) {
                 });
 
                 // Get list of all active adapters and send them message with command checkLogging
-                for (const _id in procs) {
-                    if (Object.prototype.hasOwnProperty.call(procs, _id) && procs[_id].process) {
+                for (const _id of Object.keys(procs)) {
+                    if (procs[_id].process) {
                         outputCount++;
                         states.setState(_id + '.checkLogging', {val: true, ack: false, from: hostObjectPrefix});
                     }
@@ -2526,8 +2512,8 @@ function getInstances() {
             let count = 0;
 
             // first mark all instances as disabled to detect disabled once
-            for (const id in procs) {
-                if (Object.prototype.hasOwnProperty.call(procs, id) && procs[id].config && procs[id].config.common && procs[id].config.common.enabled) {
+            for (const id of Object.keys(procs)) {
+                if (procs[id].config && procs[id].config.common && procs[id].config.common.enabled) {
                     procs[id].config.common.enabled = false;
                 }
             }
@@ -2657,11 +2643,7 @@ function initInstances() {
     let id;
 
     // Start first admin
-    for (id in procs) {
-        if (!Object.prototype.hasOwnProperty.call(procs, id)) {
-            continue;
-        }
-
+    for (id of Object.keys(procs)) {
         if (procs[id].config.common.enabled && (procs[id].config.common.mode !== 'extension' || !procs[id].config.native.webInstance)) {
             if (id.startsWith('system.adapter.admin')) {
                 // do not process if still running. It will be started when old one will be finished
@@ -2684,11 +2666,7 @@ function initInstances() {
         }
     }
 
-    for (id in procs) {
-        if (!Object.prototype.hasOwnProperty.call(procs, id)) {
-            continue;
-        }
-
+    for (id of Object.keys(procs)) {
         if (procs[id].config.common.enabled && (procs[id].config.common.mode !== 'extension' || !procs[id].config.native.webInstance)) {
             if (!id.startsWith('system.adapter.admin')) {
                 // do not process if still running. It will be started when old one will be finished
@@ -2783,11 +2761,7 @@ function checkVersions(id, deps, globalDeps) {
 
             // check local dependencies: required adapter must be installed on the same host
             try {
-                for (const dep in deps) {
-                    if (!Object.prototype.hasOwnProperty.call(deps, dep)) {
-                        continue;
-                    }
-
+                for (const dep of Object.keys(deps)) {
                     if (!checkVersion(id, dep, deps[dep], instances)) {
                         return reject(new Error());
                     }
@@ -2800,11 +2774,7 @@ function checkVersions(id, deps, globalDeps) {
 
             // check global dependencies: required adapter must be NOT installed on the same host
             try {
-                for (const gDep in globalDeps) {
-                    if (!Object.prototype.hasOwnProperty.call(globalDeps, gDep)) {
-                        continue;
-                    }
-
+                for (const gDep of Object.keys(globalDeps)) {
                     if (!checkVersion(id, gDep, globalDeps[gDep], globInstances)) {
                         return reject(new Error());
                     }
@@ -2826,20 +2796,12 @@ function storePids() {
         storeTimer = setTimeout(() => {
             storeTimer = null;
             const pids = [];
-            for (const id in procs) {
-                if (!Object.prototype.hasOwnProperty.call(procs, id)) {
-                    continue;
-                }
-
+            for (const id of Object.keys(procs)) {
                 if (procs[id].process && procs[id].process.pid && !procs[id].startedAsCompactGroup) {
                     pids.push(procs[id].process.pid);
                 }
             }
-            for (const id in compactProcs) {
-                if (!Object.prototype.hasOwnProperty.call(compactProcs, id)) {
-                    continue;
-                }
-
+            for (const id of Object.keys(compactProcs)) {
                 if (compactProcs[id].process && compactProcs[id].process.pid) {
                     pids.push(compactProcs[id].process.pid);
                 }
@@ -3327,19 +3289,13 @@ function startInstance(id, wakeUp) {
 
                                 if (isStopping) {
                                     logger.silly(`${hostLogPrefix} Check Stopping ${id}`);
-                                    for (const i in procs) {
-                                        if (!Object.prototype.hasOwnProperty.call(procs, i)) {
-                                            continue;
-                                        }
+                                    for (const i of Object.keys(procs)) {
                                         if (procs[i].process) {
                                             logger.silly(`${hostLogPrefix} ${procs[i].config.common.name} still running`);
                                             return;
                                         }
                                     }
-                                    for (const i in compactProcs) {
-                                        if (!Object.prototype.hasOwnProperty.call(compactProcs, i)) {
-                                            continue;
-                                        }
+                                    for (const i of Object.keys(compactProcs)) {
                                         if (compactProcs[i].process) {
                                             logger.silly(`${hostLogPrefix} Compact group ${i} still running`);
                                             return;
@@ -3630,19 +3586,13 @@ function startInstance(id, wakeUp) {
 
                                         if (isStopping) {
                                             logger.silly(hostLogPrefix + ' Check after group exit ' + currentCompactGroup);
-                                            for (const i in procs) {
-                                                if (!Object.prototype.hasOwnProperty.call(procs, i)) {
-                                                    continue;
-                                                }
+                                            for (const i of Object.keys(procs)) {
                                                 if (procs[i].process) {
                                                     logger.silly(hostLogPrefix + ' ' + procs[i].config.common.name + ' still running');
                                                     return;
                                                 }
                                             }
-                                            for (const i in compactProcs) {
-                                                if (!Object.prototype.hasOwnProperty.call(compactProcs, i)) {
-                                                    continue;
-                                                }
+                                            for (const i of Object.keys(compactProcs)) {
                                                 if (compactProcs[i].process) {
                                                     logger.silly(hostLogPrefix + ' Compact group ' + i + ' still running (compact)');
                                                     return;
@@ -4084,19 +4034,13 @@ function stopInstances(forceStop, callback) {
             callback = null;
         }
 
-        for (const id in procs) {
-            if (!Object.prototype.hasOwnProperty.call(procs, id)) {
-                continue;
-            }
+        for (const id of Object.keys(procs)) {
             stopInstance(id, forceStop); // sends kill signal via sigKill state or a kill after timeouts or if forced
         }
         if (forceStop || isDaemon) {
             // send instances SIGTERM, only needed if running in background (isDaemon)
             // or slave lost connection to master
-            for (const id in compactProcs) {
-                if (!Object.prototype.hasOwnProperty.call(compactProcs, id)) {
-                    continue;
-                }
+            for (const id of Object.keys(compactProcs)) {
                 if (compactProcs[id].process) {
                     compactProcs[id].process.kill();
                 } // TODO better?
@@ -4169,20 +4113,14 @@ function stop(force, callback) {
         states.setState(hostObjectPrefix + '.alive', {val: false, ack: true, from: hostObjectPrefix}, () => {
             logger.info(hostLogPrefix + ' ' + (wasForced ? 'force terminating' : 'terminated'));
             if (wasForced) {
-                for (const i in procs) {
-                    if (!Object.prototype.hasOwnProperty.call(procs, i)) {
-                        continue;
-                    }
+                for (const i of Object.keys(procs)) {
                     if (procs[i].process) {
                         if (procs[i].config && procs[i].config.common && procs[i].config.common.name) {
                             logger.info(hostLogPrefix + ' Adapter ' + procs[i].config.common.name + ' still running');
                         }
                     }
                 }
-                for (const i in compactProcs) {
-                    if (!Object.prototype.hasOwnProperty.call(compactProcs, i)) {
-                        continue;
-                    }
+                for (const i of Object.keys(compactProcs)) {
                     if (compactProcs[i].process) {
                         logger.info(hostLogPrefix + ' Compact group controller ' + i + ' still running');
                     }


### PR DESCRIPTION
- fixes #1021
- we should discuss this before merging

For me it makes sense as described in #1021 to scale if source or target is of `unit: '%'` and `min` and `max` of both are defined of course. On the other hand, some may argue to just set a read function to only `read: 'val'` and `write: 'val'` if no auto-scaling is in any direction is desired. 
