### PR TITLE
setupInstall name needs to be of type string for path

### DIFF
--- a/lib/setup/setupInstall.js
+++ b/lib/setup/setupInstall.js
@@ -241,10 +241,10 @@ function Install(options) {
                 console.error('host.' + hostname + ' Unknown packetName ' + packetName);
                 processExit(EXIT_CODES.UNKNOWN_PACKET_NAME);
             }
-            name = Math.floor(Math.random() * 0xFFFFFFE);
+            name = Math.floor(Math.random() * 0xFFFFFFE).toString();
         }
 
-        const ncp = require('ncp').ncp;
+        const { ncp }  = require('ncp');
         ncp.limit =  16;
 
         console.log('host.' + hostname + ' download ' + url);


### PR DESCRIPTION
Accidentally i caused ran into the following error:

```
downloaded /opt/iobroker/node_modules/iobroker.js-controller/lib/../tmp/64185067.zip
host.moritz-ThinkPad-E470 unzip /opt/iobroker/node_modules/iobroker.js-controller/tmp/64185067.zip
internal/validators.js:125
    throw new ERR_INVALID_ARG_TYPE(name, 'string', value);
    ^

TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received type number
    at validateString (internal/validators.js:125:11)
    at Object.join (path.js:1147:7)
    at tools.getFile.tmpFile (/opt/iobroker/node_modules/iobroker.js-controller/lib/setup/setupInstall.js:257:40)
    at WriteStream.request.on.pipe.on (/opt/iobroker/node_modules/iobroker.js-controller/lib/tools.js:456:17)
    at WriteStream.emit (events.js:198:13)
    at lazyFs.close (internal/fs/streams.js:207:14)
    at FSReqWrap.args [as oncomplete] (fs.js:140:20)
```

Now we are using `path` instead of rare string concatenation and path doesn't like args of type `number`. 

https://github.com/ioBroker/ioBroker.js-controller/blob/3edc464c005e284e7961de25818ae9fa2e75ff6b/lib/setup/setupInstall.js#L257