### PR TITLE
Use Unicode properties to define which characters are allowed instead of blacklisting

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -35,7 +35,7 @@ const controllerVersion = require('../package.json').version;
 
 const password          = require('./password');
 
-const FORBIDDEN_CHARS   = /[\][*,;'"`<>\\?]/g;
+const { FORBIDDEN_CHARS } = tools;
 const DEFAULT_SECRET    = 'Zgfr56gFe87jJOM';
 const ALIAS_STARTS_WITH = 'alias.';
 

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -22,11 +22,17 @@ const VENDOR_FILE = '/etc/iob-vendor.json';
 
 // Here we define all characters that are forbidden in IDs. Since we want to allow multiple
 // unicode character classes, we do that by OR-ing the character classes and negating the result.
-// (Ll = lowercase letters, Lu = uppercase letters, Nd = numbers),
 // Also, we can easily whitelist characters this way.
-
-/** Allowed characters are lowercase letters, uppercase letters, numbers, "_", "-" and ".". This regex matches all other characters. */
-const FORBIDDEN_CHARS   = /[^\p{Ll}\p{Lu}\p{Nd}._-]+/gu;
+//
+// We allow:
+// · Ll = lowercase letters
+// · Lu = uppercase letters
+// · Nd = numbers
+// · ".", "_", "-" (common in IDs)
+// · "/" (required for designs)
+//
+/** All characters that may not appear in an object ID */
+const FORBIDDEN_CHARS   = /[^._/\-\p{Ll}\p{Lu}\p{Nd}]+/gu;
 
 /**
  * recursively copy values from old object to new one

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -20,6 +20,14 @@ let diskusage;
 const randomID = Math.round(Math.random() * 10000000000000);  // Used for creation of User-Agent
 const VENDOR_FILE = '/etc/iob-vendor.json';
 
+// Here we define all characters that are forbidden in IDs. Since we want to allow multiple
+// unicode character classes, we do that by OR-ing the character classes and negating the result.
+// (Ll = lowercase letters, Lu = uppercase letters, Nd = numbers),
+// Also, we can easily whitelist characters this way.
+
+/** Allowed characters are lowercase letters, uppercase letters, numbers, "_", "-" and ".". This regex matches all other characters. */
+const FORBIDDEN_CHARS   = /[^\p{Ll}\p{Lu}\p{Nd}._-]+/gu;
+
 /**
  * recursively copy values from old object to new one
  *
@@ -2600,6 +2608,7 @@ module.exports = {
     measureEventLoopLag,
     formatAliasValue,
     pipeLinewise,
+    FORBIDDEN_CHARS,
     ERRORS: {
         ERROR_NOT_FOUND: 'Not exists',
         ERROR_EMPTY_OBJECT: 'null object',

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -30,10 +30,10 @@ const VENDOR_FILE = '/etc/iob-vendor.json';
 // · Nd = numbers
 // · ".", "_", "-" (common in IDs)
 // · "/" (required for designs)
-// · " !#$%&()+=@^{}|~" (for legacy reasons)
+// · " :!#$%&()+=@^{}|~" (for legacy reasons)
 //
 /** All characters that may not appear in an object ID. */
-const FORBIDDEN_CHARS = /[^._\-/ !#$%&()+=@^{}|~\p{Ll}\p{Lu}\p{Nd}]+/gu;
+const FORBIDDEN_CHARS = /[^._\-/ :!#$%&()+=@^{}|~\p{Ll}\p{Lu}\p{Nd}]+/gu;
 
 /**
  * recursively copy values from old object to new one

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -30,9 +30,10 @@ const VENDOR_FILE = '/etc/iob-vendor.json';
 // · Nd = numbers
 // · ".", "_", "-" (common in IDs)
 // · "/" (required for designs)
+// · " !#$%&()+=@^{}|~" (for legacy reasons)
 //
-/** All characters that may not appear in an object ID */
-const FORBIDDEN_CHARS   = /[^._/\-\p{Ll}\p{Lu}\p{Nd}]+/gu;
+/** All characters that may not appear in an object ID. */
+const FORBIDDEN_CHARS = /[^._\-/ !#$%&()+=@^{}|~\p{Ll}\p{Lu}\p{Nd}]+/gu;
 
 /**
  * recursively copy values from old object to new one

--- a/test/lib/testAdapterHelpers.js
+++ b/test/lib/testAdapterHelpers.js
@@ -386,7 +386,6 @@ function register(it, expect, context) {
         const decrypted = context.adapter.decrypt(encrypted);
         // check that correctly decrypted
         expect(decrypted).to.equal('topSecret');
-        return Promise.resolve();
     });
 
     /*

--- a/test/testTools.js
+++ b/test/testTools.js
@@ -6,7 +6,7 @@ const { FORBIDDEN_CHARS } = require('../lib/tools');
 describe('test tools.js helpers', () => {
     it('FORBIDDEN_CHARS', () => {
         const tests = [
-            { input: 'abc^def.0.1.foo-bar_', expected: 'abc_def.0.1.foo-bar_' },
+            { input: 'abc?def.0.1.foo-bar_', expected: 'abc_def.0.1.foo-bar_' },
             { input: 'ݑ', expected: '_' }, // Arabic Letter Beh with Dot Below and Three Dots Above (is an "other letter")
             { input: 'ⴃ', expected: 'ⴃ' }, // Georgian Small Letter Don (is a lowercase letter)
             { input: 'Ϣ', expected: 'Ϣ' }, // Coptic Capital Letter Shei (is a uppercase letter)

--- a/test/testTools.js
+++ b/test/testTools.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const { expect } = require('chai');
+const { FORBIDDEN_CHARS } = require('../lib/tools');
+
+describe('test tools.js helpers', () => {
+    it('FORBIDDEN_CHARS', () => {
+        const tests = [
+            { input: 'abc^def.0.1.foo-bar_', expected: 'abc_def.0.1.foo-bar_' },
+            { input: 'ݑ', expected: '_' }, // Arabic Letter Beh with Dot Below and Three Dots Above (is an "other letter")
+            { input: 'ⴃ', expected: 'ⴃ' }, // Georgian Small Letter Don (is a lowercase letter)
+            { input: 'Ϣ', expected: 'Ϣ' }, // Coptic Capital Letter Shei (is a uppercase letter)
+            { input: 'ok﹏﹏ok', expected: 'ok_ok' }, // multiple disallowed characters are replaced with one "_"
+            { input: 'Th1s-IS_0.k4y', expected: 'Th1s-IS_0.k4y' }
+        ];
+        for (const { input, expected } of tests) {
+            expect(input.replace(FORBIDDEN_CHARS, '_')).to.equal(expected);
+        }
+    });
+});


### PR DESCRIPTION
With this PR, we now whitelist characters that are allowed in IDs instead of blacklisting them.
For now, I've allowed lowercase letters, uppercase letters, numbers, "_", "-" and ".". We can discuss if there is more that should be allowed, like `:~#@|!§$&()={}/+`, which was not explicitly forbidden before.

fixes: #982 