### PR TITLE
Throw on invalid setState object and allow undefined val if another prop exists consistently

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -935,8 +935,8 @@ function Adapter(options) {
         let acl = {user: user};
         if (user === SYSTEM_ADMIN_USER) {
             acl.groups = [SYSTEM_ADMIN_GROUP];
-            for (const c in commandsPermissions) {
-                if (!Object.prototype.hasOwnProperty.call(commandsPermissions, c) || !commandsPermissions[c].type) {
+            for (const c of Object.keys(commandsPermissions)) {
+                if (!commandsPermissions[c].type) {
                     continue;
                 }
                 acl[commandsPermissions[c].type] = acl[commandsPermissions[c].type] || {};
@@ -1004,14 +1004,12 @@ function Adapter(options) {
                                 } else {
                                     acl[type] = acl[type] || {};
                                 }
-                                for (const op in gAcl[type]) {
-                                    if (Object.prototype.hasOwnProperty.call(gAcl[type], op)) {
-                                        // fix error
-                                        if (type === 'user') {
-                                            acl.users[op] = acl.users[op] || gAcl.user[op];
-                                        } else {
-                                            acl[type][op] = acl[type][op] || gAcl[type][op];
-                                        }
+                                for (const op of Object.keys(gAcl[type])) {
+                                    // fix error
+                                    if (type === 'user') {
+                                        acl.users[op] = acl.users[op] || gAcl.user[op];
+                                    } else {
+                                        acl[type][op] = acl[type][op] || gAcl[type][op];
                                     }
                                 }
                             }
@@ -5786,10 +5784,7 @@ function Adapter(options) {
                 try {
                     validateSetStateObjectArgument(state);
                 } catch (e) {
-                    // return tools.maybeCallbackWithError(callback, e);
-                    // TODO Decline this action in js-controller 3.1 and reactivate tests in testAdapterHelpers
-                    logger.warn(`${this.namespaceLog} State value to set is invalid for ${id}: ${e.message}`);
-                    logger.warn(`${this.namespaceLog} This value will not be set in future versions. Please report this to the developer.`);
+                    return tools.maybeCallbackWithError(callback, e);
                 }
             } else {
                 // wrap non-object values in a state object
@@ -5968,10 +5963,7 @@ function Adapter(options) {
                 try {
                     validateSetStateObjectArgument(state);
                 } catch (e) {
-                    // return tools.maybeCallbackWithError(callback, e);
-                    // TODO Decline this action in js-controller 3.1 and reactivate tests in testAdapterHelpers
-                    logger.warn(`${this.namespaceLog} State value to set is invalid for ${id}: ${e.message}`);
-                    logger.warn(`${this.namespaceLog} This value will not be set in future versions. Please report this to the developer.`);
+                    return tools.maybeCallbackWithError(callback, e);
                 }
             } else {
                 // wrap non-object values in a state object
@@ -6070,10 +6062,7 @@ function Adapter(options) {
                 try {
                     validateSetStateObjectArgument(state);
                 } catch (e) {
-                    // return tools.maybeCallbackWithError(callback, e);
-                    // TODO Decline this action in js-controller 3.1 and reactivate tests in testAdapterHelpers
-                    logger.warn(`${this.namespaceLog} State value to set is invalid for ${id}: ${e.message}`);
-                    logger.warn(`${this.namespaceLog} This value will not be set in future versions. Please report this to the developer.`);
+                    return tools.maybeCallbackWithError(callback, e);
                 }
             } else {
                 // wrap non-object values in a state object
@@ -6272,10 +6261,7 @@ function Adapter(options) {
                 try {
                     validateSetStateObjectArgument(state);
                 } catch (e) {
-                    // return tools.maybeCallbackWithError(callback, e);
-                    // TODO Decline this action in js-controller 3.1 and reactivate tests in testAdapterHelpers
-                    logger.warn(`${this.namespaceLog} State value to set is invalid for ${id}: ${e.message}`);
-                    logger.warn(`${this.namespaceLog} This value will not be set in future versions. Please report this to the developer.`);
+                    return tools.maybeCallbackWithError(callback, e);
                 }
             } else {
                 // wrap non-object values in a state object
@@ -8090,10 +8076,8 @@ function Adapter(options) {
 
                     if (adapterConfig.common.loglevel && !this.overwriteLogLevel) {
                         // set configured in DB log level
-                        for (const trans in logger.transports) {
-                            if (Object.prototype.hasOwnProperty.call(logger.transports, trans)) {
-                                logger.transports[trans].level = adapterConfig.common.loglevel;
-                            }
+                        for (const trans of Object.keys(logger.transports)) {
+                            logger.transports[trans].level = adapterConfig.common.loglevel;
                         }
                         config.log.level = adapterConfig.common.loglevel;
                     }

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -5970,7 +5970,7 @@ function Adapter(options) {
                 state = {val: state};
             }
 
-            if (state.val === undefined) {
+            if (state.val === undefined && !Object.keys(state).length) {
                 // undefined is not allowed as state.val -> return
                 return tools.maybeCallbackWithError(callback, 'undefined is not a valid state value');
             }
@@ -6069,7 +6069,7 @@ function Adapter(options) {
                 state = {val: state};
             }
 
-            if (state.val === undefined) {
+            if (state.val === undefined && !Object.keys(state).length) {
                 // undefined is not allowed as state.val -> return
                 return tools.maybeCallbackWithError(callback, 'undefined is not a valid state value');
             }
@@ -6268,7 +6268,7 @@ function Adapter(options) {
                 state = {val: state};
             }
 
-            if (state.val === undefined) {
+            if (state.val === undefined && !Object.keys(state).length) {
                 // undefined is not allowed as state.val -> return
                 return tools.maybeCallbackWithError(callback, 'undefined is not a valid state value');
             }

--- a/test/lib/testAdapterHelpers.js
+++ b/test/lib/testAdapterHelpers.js
@@ -392,7 +392,7 @@ function register(it, expect, context) {
     for (const method of ['setState', 'setStateChanged', 'setForeignState', 'setForeignStateChanged']) {
         describe(`${context.name} ${context.adapterShortName} adapter: ${method} validates the state object`, () => {
             it('at least one property has to exist', function (done) {
-                this.timeout(2000);
+                this.timeout(1000);
                 const callback = spy();
                 context.adapter[method]('testid', {val: undefined}, callback);
 

--- a/test/lib/testAdapterHelpers.js
+++ b/test/lib/testAdapterHelpers.js
@@ -135,7 +135,7 @@ function register(it, expect, context) {
     // formatValue
     it(context.name + ' ' + context.adapterShortName + ' adapter: Check formatValue', function (done) {
         this.timeout(1000);
-        let testValue, testValue2;
+        let testValue;
 
         // Test with number
         testValue = context.adapter.formatValue(1000,'.,');
@@ -155,7 +155,7 @@ function register(it, expect, context) {
 
         // Test with an empty format pattern
         testValue = context.adapter.formatValue('1000', ''); //1.000,00
-        testValue2 = context.adapter.formatValue('1000', (context.adapter.isFloatComma === undefined) ? '.,' : ((context.adapter.isFloatComma) ? '.,' : ',.')); //1.000,00
+        const testValue2 = context.adapter.formatValue('1000', (context.adapter.isFloatComma === undefined) ? '.,' : ((context.adapter.isFloatComma) ? '.,' : ',.')); //1.000,00
         expect(testValue).to.equal(testValue2);
 
         testValue = context.adapter.formatValue(undefined, '.,');
@@ -180,7 +180,7 @@ function register(it, expect, context) {
     it(context.name + ' ' + context.adapterShortName + ' adapter: Check formatDate', function (done) {
         this.timeout(1000);
         const testDate = new Date(0);
-        let testStringDate, testStringDate2;
+        let testStringDate;
 
         expect(context.adapter.formatDate(new Date())).to.be.a('string');
 
@@ -388,18 +388,17 @@ function register(it, expect, context) {
         expect(decrypted).to.equal('topSecret');
     });
 
-    /*
-    // Todo: reactivate this tests with 3.2 when setState validation will refuse to set state
     // setState object validation
     for (const method of ['setState', 'setStateChanged', 'setForeignState', 'setForeignStateChanged']) {
         describe(`${context.name} ${context.adapterShortName} adapter: ${method} validates the state object`, () => {
-            it('requires the val property to exist', function (done) {
-                this.timeout(1000);
+            it('at least one property has to exist', function (done) {
+                this.timeout(2000);
                 const callback = spy();
-                context.adapter[method]('testid', {ack: true}, callback);
+                context.adapter[method]('testid', {val: undefined}, callback);
+
                 setImmediate(() => {
                     expect(callback).to.have.been.calledOnce;
-                    expect(callback.firstCall.args[0]).to.match(/required/);
+                    expect(callback.firstCall.args[0].message.includes('At least one property is expected!')).to.be.true;
                     done();
                 });
             });
@@ -410,7 +409,7 @@ function register(it, expect, context) {
                 context.adapter[method]('testid', {val: 1, foo: 'bar'}, callback);
                 setImmediate(() => {
                     expect(callback).to.have.been.calledOnce;
-                    expect(callback.firstCall.args[0]).to.match(/forbidden/);
+                    expect(callback.firstCall.args[0].message).to.match(/forbidden/);
                     done();
                 });
             });
@@ -421,8 +420,8 @@ function register(it, expect, context) {
                 context.adapter[method]('testid', {val: 1, ack: 'true'}, callback);
                 setImmediate(() => {
                     expect(callback).to.have.been.calledOnce;
-                    expect(callback.firstCall.args[0]).to.match(/wrong type/);
-                    expect(callback.firstCall.args[0].includes('should be "boolean"')).to.be.true;
+                    expect(callback.firstCall.args[0].message).to.match(/wrong type/);
+                    expect(callback.firstCall.args[0].message.includes('should be "boolean"')).to.be.true;
                     done();
                 });
             });
@@ -433,8 +432,8 @@ function register(it, expect, context) {
                 context.adapter[method]('testid', {val: 1, ts: true}, callback);
                 setImmediate(() => {
                     expect(callback).to.have.been.calledOnce;
-                    expect(callback.firstCall.args[0]).to.match(/wrong type/);
-                    expect(callback.firstCall.args[0].includes('should be "number"')).to.be.true;
+                    expect(callback.firstCall.args[0].message).to.match(/wrong type/);
+                    expect(callback.firstCall.args[0].message.includes('should be "number"')).to.be.true;
                     done();
                 });
             });
@@ -445,8 +444,8 @@ function register(it, expect, context) {
                 context.adapter[method]('testid', {val: 1, q: true}, callback);
                 setImmediate(() => {
                     expect(callback).to.have.been.calledOnce;
-                    expect(callback.firstCall.args[0]).to.match(/wrong type/);
-                    expect(callback.firstCall.args[0].includes('should be "number"')).to.be.true;
+                    expect(callback.firstCall.args[0].message).to.match(/wrong type/);
+                    expect(callback.firstCall.args[0].message.includes('should be "number"')).to.be.true;
                     done();
                 });
             });
@@ -457,8 +456,8 @@ function register(it, expect, context) {
                 context.adapter[method]('testid', {val: 1, expire: true}, callback);
                 setImmediate(() => {
                     expect(callback).to.have.been.calledOnce;
-                    expect(callback.firstCall.args[0]).to.match(/wrong type/);
-                    expect(callback.firstCall.args[0].includes('should be "number"')).to.be.true;
+                    expect(callback.firstCall.args[0].message).to.match(/wrong type/);
+                    expect(callback.firstCall.args[0].message.includes('should be "number"')).to.be.true;
                     done();
                 });
             });
@@ -469,8 +468,8 @@ function register(it, expect, context) {
                 context.adapter[method]('testid', {val: 1, from: 2}, callback);
                 setImmediate(() => {
                     expect(callback).to.have.been.calledOnce;
-                    expect(callback.firstCall.args[0]).to.match(/wrong type/);
-                    expect(callback.firstCall.args[0].includes('should be "string"')).to.be.true;
+                    expect(callback.firstCall.args[0].message).to.match(/wrong type/);
+                    expect(callback.firstCall.args[0].message.includes('should be "string"')).to.be.true;
                     done();
                 });
             });
@@ -481,14 +480,13 @@ function register(it, expect, context) {
                 context.adapter[method]('testid', {val: 1, c: []}, callback);
                 setImmediate(() => {
                     expect(callback).to.have.been.calledOnce;
-                    expect(callback.firstCall.args[0]).to.match(/wrong type/);
-                    expect(callback.firstCall.args[0].includes('should be "string"')).to.be.true;
+                    expect(callback.firstCall.args[0].message).to.match(/wrong type/);
+                    expect(callback.firstCall.args[0].message.includes('should be "string"')).to.be.true;
                     done();
                 });
             });
         });
     }
-     */
 }
 
 module.exports.register = register;

--- a/test/lib/testAdapterHelpers.js
+++ b/test/lib/testAdapterHelpers.js
@@ -485,6 +485,15 @@ function register(it, expect, context) {
                     done();
                 });
             });
+
+            it('is okay to have undefined val if another property exists', function (done) {
+                this.timeout(1000);
+                // cannot use the sync spies here, so only evaluate the err
+                context.adapter[method]('testid', {ack: true}, err => {
+                    expect(err).to.be.not.ok;
+                    done();
+                });
+            });
         });
     }
 }


### PR DESCRIPTION
- we throw if setObjectArg is invalid
- closes #772
- we allow undefined val if another property exists, as already allowed by setState and discussed previously (test case added for this)