### PR TITLE
replace outdated encryption mechanism of multihost

### DIFF
--- a/lib/setup/setupMultihost.js
+++ b/lib/setup/setupMultihost.js
@@ -170,10 +170,8 @@ function Multihost(options) {
                             callback('Secret phrases are not equal!');
                         } else {
                             objects.getObject('system.config', function (err, obj) {
-                                tools.encryptPhrase(obj.native.secret, password.password, function (encoded) {
-                                    config.multihostService.password = encoded;
-                                    showMHState(config, changed, callback);
-                                });
+                                config.multihostService.password = tools.encrypt(obj.native.secret, password.password);
+                                showMHState(config, changed, callback);
                             });
                         }
                     } else {

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -152,25 +152,7 @@ function upToDate(repoVersion, installedVersion) {
     return semver.gte(installedVersion, repoVersion);
 }
 
-function encryptPhrase(password, phrase, callback) {
-    // encrypt secret
-    crypto = crypto || require('crypto');
-    const cipher = crypto.createCipher('aes192', password);
-
-    let encrypted = '';
-    cipher.on('readable', () => {
-        const data = cipher.read();
-        if (data) {
-            encrypted += data.toString('hex');
-        }
-    });
-
-    cipher.on('end', () => callback(encrypted));
-
-    cipher.write(phrase);
-    cipher.end();
-}
-
+// TODO: this is only here for backward compatibility, if MULTIHOST password was still setup with old decryption
 function decryptPhrase(password, data, callback) {
     crypto = crypto || require('crypto');
     const decipher = crypto.createDecipher('aes192', password);
@@ -2697,7 +2679,6 @@ module.exports = {
     appName: getAppName(),
     createUuid,
     decryptPhrase,
-    encryptPhrase,
     execAsync,
     findIPs,
     generateDefaultCertificates,

--- a/main.js
+++ b/main.js
@@ -194,8 +194,14 @@ function startMultihost(__config) {
         if (_config.multihostService.secure) {
             objects.getObject('system.config', (err, obj) => {
                 if (obj && obj.native && obj.native.secret) {
-                    tools.decryptPhrase(obj.native.secret, _config.multihostService.password, secret =>
-                        _startMultihost(_config, secret));
+                    if (!_config.multihostService.password.startsWith(`$/aes-192-cbc:`)) {
+                        // if old encryption was used, we need to decrypt in old fashion
+                        tools.decryptPhrase(obj.native.secret, _config.multihostService.password, secret =>
+                            _startMultihost(_config, secret));
+                    } else {
+                        const secret = tools.decrypt(obj.native.secret, _config.multihostService.password);
+                        _startMultihost(_config, secret);
+                    }
                 } else {
                     logger.error(`${hostLogPrefix} Cannot start multihost discovery server: no system.config found (err:${err})`);
                 }


### PR DESCRIPTION
decryptPhrase and encryptPhrase are more or less weaker versions of encrypt/decrypt and `crypto.createDecipher` is deprecated because its too weak, thus we replace them completely. We still need decryptPhrase for backward compatibility, if a multihost was setup with old mechanism

to get completely rid of the warning the user has to do `setup multihost` once again, to get a password created with the new encrpytion