### PR TITLE
Use yargs helper instead of building our own string output

### DIFF
--- a/lib/setup.js
+++ b/lib/setup.js
@@ -33,115 +33,95 @@ let yargs;
 
 function initYargs() {
     yargs = require('yargs')
-    // TODO: These commands should have an explanation
-        .usage('Commands:\n' +
-                tools.appName + ' setup [redis/--redis] [--objects <host>] [--states <host>] [--port <port>] [custom] [first/--first]\n' +
-                tools.appName + ' start - starts the js-controller\n' +
-                tools.appName + ' stop - stops the js-controller\n' +
-                tools.appName + ' start <adapter>[.instance] - starts a specified adapter instance\n' +
-                tools.appName + ' stop <adapter>.[instance] - stops a specified adapter instance\n' +
-                tools.appName + ' start all - starts js-controller and all adapters\n' +
-                tools.appName + ' restart - restarts the js-controller\n' +
-                tools.appName + ' restart <adapter>[.instance] - restarts a specified adapter\n' +
-                tools.appName + ' debug <adapter>[.instance] [--ip=<ip>] [--port=<port>] [--wait] - Starts a Node.js debugging session for the adapter\n' +
-                '    --wait stops the execution until the debugger is attached.\n' +
-                '    --ip and --port can be used to change the listen IP and port. Use IP 0.0.0.0 for remote debugging.\n' +
-                tools.appName + ' info - shows the host info\n' +
-                tools.appName + ' logs [adapter] [--watch] [--lines=1000]\n' +
-                tools.appName + ' add <adapter> [desiredNumber] [--enabled] [--host <host>] [--port <port>]\n' +
-                tools.appName + ' install <adapter> - installs a specified adapter\n' +
-                tools.appName + ' rebuild <adapter>|self [--install]\n' +
-                tools.appName + ' url <url> [<name>] - install adapter from specified url, e.g. GitHub\n' +
-                tools.appName + ' del <adapter> - remove adapter from system\n' +
-                tools.appName + ' del <adapter>.<instance> - remove adapter instance\n' +
-                tools.appName + ' update [repository url] [--updatable/--u] [--installed/--i] [--force/--f] - update repository and optionally filter installed/updateable adapters, use --force to bypass hash check\n' +
-                tools.appName + ' upgrade [repository url] [--y]\n' +
-                tools.appName + ' upgrade self [repository url] [--force] - upgrade js-controller and all adapters, optionally you can specify the repository url\n' +
-                tools.appName + ' upgrade <adapter> [repository url] [--y] - upgrade specified adapter, optionally you can specify the repository url\n' +
-                tools.appName + ' upload <pathToLocalFile> <pathIn' + tools.appName + '>\n' +
-                tools.appName + ' upload all - upload all adapter files to make them available for instances\n' +
-                tools.appName + ' upload <adapter> - upload specified adapter files to make them available for instances\n' +
-                tools.appName + ' object get <id> - get object specified by id\n' +
-                tools.appName + ' object set <id> <json-value> - set object with the given id by providing a new json object\n' +
-                tools.appName + ' object set <id> propertyname=<value or json-value> - update part of the object by providing a new value or partial object\n' +
-                tools.appName + ' object extend <id> <json-value> - extend object with the given id by providing a new json object\n' +
-                tools.appName + ' object del <id|pattern> [--yes]\n' +
-                tools.appName + ' object chmod <object-mode> [state-mode] <id>\n' +
-                tools.appName + ' object chown <user> <group> <id>\n' +
-                tools.appName + ' object list <id>\n' +
-                tools.appName + ' state get <id> - get state, specified by id\n' +
-                tools.appName + ' state getplain <id> [--pretty]\n' +
-                tools.appName + ' state getvalue <id>\n' +
-                tools.appName + ' state set <id> <value> [ack]\n' +
-                tools.appName + ' state del <id>\n' +
-                tools.appName + ' message <adapter>[.instance] <command> [<message>]\n' +
-                tools.appName + ' list <type> [filter]\n' +
-                tools.appName + ' chmod <mode> <file>\n' +
-                tools.appName + ' chown <user> <group> <file>\n' +
-                tools.appName + ' touch <file>\n' +
-                tools.appName + ' rm <file>\n' +
-                tools.appName + ' file read <' + tools.appName + '-path-to-read> [<filesystem-path-to-write>]\n' +
-                tools.appName + ' file write <filesystem-path-to-read> <' + tools.appName + '-path-to-write>\n' +
-                tools.appName + ' file rm <' + tools.appName + '-path-to-delete>\n' +
-                tools.appName + ' file sync\n' +
-                tools.appName + ' user add <user> [--ingroup group] [--password pass]\n' +
-                tools.appName + ' user del <user>\n' +
-                tools.appName + ' user passwd <user> [--password pass]\n' +
-                tools.appName + ' user enable <user>\n' +
-                tools.appName + ' user disable <user>\n' +
-                tools.appName + ' user get <user>\n' +
-                tools.appName + ' user check <user> [--password pass]\n' +
-                tools.appName + ' group add <group>\n' +
-                tools.appName + ' group del <group>\n' +
-                tools.appName + ' group list <group>\n' +
-                tools.appName + ' group enable <group>\n' +
-                tools.appName + ' group disable <group>\n' +
-                tools.appName + ' group get <group>\n' +
-                tools.appName + ' group adduser <group> <user>\n' +
-                tools.appName + ' group deluser <group> <user>\n' +
-                tools.appName + ' host this\n' +
-                tools.appName + ' host <hostname>\n' +
-                tools.appName + ' host set <hostname>\n' +
-                tools.appName + ' host remove <hostname>\n' +
-                tools.appName + ' set <adapter>.<instance> [--port port] [--ip address] [--ssl true|false]\n' +
-                tools.appName + ' license <license.file or license.text>\n' +
-                tools.appName + ' cert create\n' +
-                tools.appName + ' cert view [<certificate name>]\n' +
-                tools.appName + ' clean\n' +
-                tools.appName + ' backup\n' +
-                tools.appName + ' restore <backup name or path> - restore a specified backup\n' +
-                tools.appName + ' validate <backup name or path> - validate a specified backup\n' +
-                tools.appName + ' <command> --timeout 5000\n' +
-                tools.appName + ' status [all|<adapter>.<instance>]\n' +
-                tools.appName + ' repo [name]\n' +
-                tools.appName + ' repo add <name> <path or url>\n' +
-                tools.appName + ' repo set <name>\n' +
-                tools.appName + ' repo del <name>\n' +
-                tools.appName + ' uuid\n' +
-                tools.appName + ' unsetup\n' +
-                tools.appName + ' fix - execute the installation fixer script, this updates your ioBroker installation\n' +
-                tools.appName + ' multihost <enable|disable> [--secure true|false] [--persist]\n' +
-                tools.appName + ' multihost browse\n' +
-                tools.appName + ' multihost connect\n' +
-                tools.appName + ' compact status - show if compact mode is enabled in general\n' +
-                tools.appName + ' compact <enable|on|disable|off> - enable or disable compact mode in general\n' +
-                tools.appName + ' compact <adapter>.<instance> status - show if compact mode is enabled for a specific instance\n' +
-                tools.appName + ' compact <adapter>.<instance> group <group-id> - define compact group of a specific adapter\n' +
-                tools.appName + ' compact <adapter>.<instance> <disable|off> - enable or disable compact mode for specified adapter instance\n' +
-                tools.appName + ' compact <adapter>.<instance> <enable|on> [group-id] - enable or disable compact mode for specified adapter instance and set comapct group optionally\n' +
-                tools.appName + ' plugin enable <pluginname> [--host <hostname>] - enables a plugin for the specified host. If no host is specified, the current one is used \n' +
-                tools.appName + ' plugin disable <pluginname> [--host <hostname>] - disables a plugin for the specified host. If no host is specified, the current one is used \n' +
-                tools.appName + ' plugin status <pluginname> [--host <hostname>] - checks if a plugin is enabled for the specified host. If no host is specified, the current one is used \n' +
-                tools.appName + ' plugin enable <pluginname> --instance <adapter>[.<nr>] - enables a plugin for the specified adapter instance (defaults to instance 0) \n' +
-                tools.appName + ' plugin disable <pluginname> --instance <adapter>[.<nr>] - disables a plugin for the specified adapter instance (defaults to instance 0) \n' +
-                tools.appName + ' plugin status <pluginname> --instance <adapter>[.<nr>] - checks if a plugin is enabled for the specified adapter instance (defaults to instance 0) \n' +
-                tools.appName + ' version [adapter] - show version of js-controller or specified adapter\n' +
-                tools.appName + ' [adapter] -v - show version of js-controller or specified adapter\n')
-    //.default('objects',   '127.0.0.1')
-    //.default('states',   '127.0.0.1')
-    //.default('lang',    'en')
-        .wrap(null)
+        .scriptName(tools.appName)
+        .completion('_createCompletion', false)// can be created via iob _createCompletion >> ~/.bashrc
+        .command('setup', 'setup ioBroker', yargs => {
+            yargs
+                .option('redis', {
+                    describe: 'setup as redis'
+                })
+                .option('objects', {
+                    describe: 'objects <host>',
+                    default: '127.0.0.1'
+                })
+                .option('states', {
+                    describe: 'states <host>',
+                    default: '127.0.0.1'
+                })
+                .option('port <port>', {
+                    describe: 'port of redis',
+                    default: 6379
+                })
+                .option('custom', {
+                    describe: 'custom setup'
+                })
+                .option('first', {
+                    describe: 'initial setup'
+                })
+                .argv;
+        })
+        .command('start', 'starts the js-controller', yargs => {
+            yargs.argv;
+        })
+        .command('stop', 'stops the js-controller', yargs => {
+            yargs.argv;
+        })
+        .command('start <adapter>[.instance]', 'starts a specified adapter instance', yargs => {
+            yargs.argv;
+        })
+        .command('stop <adapter>[.instance]', 'stops a specified adapter instance', yargs => {
+            yargs.argv;
+        })
+        .command('start all', 'starts js-controller and all adapters', yargs => {
+            yargs.argv;
+        })
+        .command('restart', 'restarts js-controller', yargs => {
+            yargs.argv;
+        })
+        .command('restart <adapter>[.instance]', 'restarts a specified adapter instance', yargs => {
+            yargs.argv;
+        })
+        .command('debug <adapter>[.instance]', 'Starts a Node.js debugging session for the adapter instance', yargs => {
+            yargs
+                .option('ip', {
+                    describe: 'ip <ip>'
+                })
+                .option('port', {
+                    describe: 'port <port>'
+                })
+                .option('wait', {
+                    describe: 'wait'
+                })
+                .argv;
+        })
+        .command('info', 'shows the host info', yargs => {
+            yargs.argv;
+        })
+        .command('logs [adapter]', 'monitor log', yargs => {
+            yargs
+                .option('lines=1000', {
+                    describe: 'number of lines'
+                })
+                .option('watch', {
+                    describe: 'watch'
+                })
+                .argv;
+        })
+        .command('add <adapter> [desiredNumber]', 'add instance of adapter', yargs => {
+            yargs
+                .option('enabled', {
+                    describe: 'enable adapter'
+                })
+                .option('host', {
+                    describe: 'host <host>'
+                })
+                .option('port', {
+                    describe: 'port <port>'
+                })
+                .argv;
+        })
     ;
+
     return yargs;
 }
 
@@ -2636,6 +2616,7 @@ module.exports.execute = function () {
     // direct call
     const _yargs = initYargs();
     const command = _yargs.argv._[0];
+    console.log(_yargs.argv)
 
     const args = [];
     for (let a = 1; a < _yargs.argv._.length; a++) {

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -195,31 +195,72 @@ function initYargs() {
         .command(`file write <filesystem-path-to-read> <${tools.appName}-path-to-write>`, `read file from path and write it to ${tools.appName} path`,{})
         .command(`file rm <${tools.appName}-path-to-delete>`, 'remove file', {})
         .command('file sync', 'sync files', {})
-        .command('user add <user>', 'add new user',{
-            ingroup: {
-                describe: 'user group',
-                type: 'string'
-            },
-            password: {
-                describe: 'user password',
-                type: 'string'
-            }
-        })
-        .command('user del <user>', 'delete user', {})
-        .command('user passwd <user>', 'change user password', {
-            password: {
-                describe: 'user password',
-                type: 'string'
-            }
-        })
-        .command('user enable <user>', 'enable user', {})
-        .command('user disable <user>', 'disable user', {})
-        .command('user get <user>', 'get user', {})
-        .command('user check <user>', 'check user password', {
-            password: {
-                describe: 'user password',
-                type: 'string'
-            }
+        .command('user', 'user commands', yargs => {
+            yargs
+                .command('add <user>', 'add new user',yargs => {
+                    yargs.option('ingroup', {
+                        describe: 'user group',
+                        type: 'string'
+                    })
+                        .option('password', {
+                            describe: 'user password',
+                            type: 'string'
+                        })
+                        .positional('user', {
+                            describe: 'username',
+                            type: 'string'
+                        });
+                })
+                .command('del <user>', 'delete user', yargs => {
+                    yargs
+                        .positional('user', {
+                            describe: 'username',
+                            type: 'string'
+                        });
+                })
+                .command('passwd <user>', 'change user password', yargs => {
+                    yargs
+                        .option('password', {
+                            describe: 'user password',
+                            type: 'string'
+                        })
+                        .positional('user', {
+                            describe: 'username',
+                            type: 'string'
+                        });
+                })
+                .command('enable <user>', 'enable user', yargs => {
+                    yargs
+                        .positional('user', {
+                            describe: 'username',
+                            type: 'string'
+                        });
+                })
+                .command('disable <user>', 'disable user', yargs => {
+                    yargs
+                        .positional('user', {
+                            describe: 'username',
+                            type: 'string'
+                        });
+                })
+                .command('get <user>', 'get user', yargs => {
+                    yargs
+                        .positional('user', {
+                            describe: 'username',
+                            type: 'string'
+                        });
+                })
+                .command('check <user>', 'check user password', yargs => {
+                    yargs
+                        .option('password', {
+                            describe: 'user password',
+                            type: 'string'
+                        })
+                        .positional('user', {
+                            describe: 'username',
+                            type: 'string'
+                        });
+                });
         })
         .command('group add <group>', 'add group', {})
         .command('group del <group>', 'remove group', {})

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -38,25 +38,31 @@ function initYargs() {
         .command('setup', 'setup ioBroker', yargs => {
             yargs
                 .option('redis', {
-                    describe: 'setup as redis'
+                    describe: 'setup as redis',
+                    type: 'boolean'
                 })
                 .option('objects', {
                     describe: 'objects <host>',
-                    default: '127.0.0.1'
+                    default: '127.0.0.1',
+                    type: 'number'
                 })
                 .option('states', {
                     describe: 'states <host>',
-                    default: '127.0.0.1'
+                    default: '127.0.0.1',
+                    type: 'number'
                 })
                 .option('port <port>', {
                     describe: 'port of redis',
-                    default: 6379
+                    default: 6379,
+                    type: 'number'
                 })
                 .option('custom', {
-                    describe: 'custom setup'
+                    describe: 'custom setup',
+                    type: 'boolean'
                 })
                 .option('first', {
-                    describe: 'initial setup'
+                    describe: 'initial setup',
+                    type: 'boolean'
                 })
                 .argv;
         })
@@ -84,39 +90,86 @@ function initYargs() {
         .command('debug <adapter>[.instance]', 'Starts a Node.js debugging session for the adapter instance', yargs => {
             yargs
                 .option('ip', {
-                    describe: 'ip <ip>'
+                    describe: 'ip <ip>',
+                    type: 'string'
                 })
                 .option('port', {
-                    describe: 'port <port>'
+                    describe: 'port <port>',
+                    type: 'number'
                 })
                 .option('wait', {
-                    describe: 'wait'
+                    describe: 'wait',
+                    type: 'boolean'
                 })
                 .argv;
         })
         .command('info', 'shows the host info', yargs => {
             yargs.argv;
         })
-        .command('logs [adapter]', 'monitor log', yargs => {
+        .command('logs [<adapter>]', 'monitor log', yargs => {
             yargs
-                .option('lines=1000', {
-                    describe: 'number of lines'
+                .option('lines=1000', { // TODO: it's the only place we use = we should avoid this
+                    describe: 'number of lines',
+                    type: 'string'
                 })
                 .option('watch', {
-                    describe: 'watch'
+                    describe: 'watch',
+                    type: 'boolean'
                 })
                 .argv;
         })
         .command('add <adapter> [desiredNumber]', 'add instance of adapter', yargs => {
             yargs
                 .option('enabled', {
-                    describe: 'enable adapter'
+                    describe: 'enable adapter',
+                    type: 'boolean'
                 })
                 .option('host', {
-                    describe: 'host <host>'
+                    describe: 'host <host>',
+                    type: 'string'
                 })
                 .option('port', {
-                    describe: 'port <port>'
+                    describe: 'port <port>',
+                    type: 'number'
+                })
+                .argv;
+        })
+        .command('install <adapter>', 'installs a specified adapter', yargs => {
+            yargs.argv;
+        })
+        .command('rebuild <adapter>|self', 'rebuilds a specified adapter', yargs => {
+            yargs
+                .option('install', {
+                    describe: 'install',
+                    type: 'boolean'
+                })
+                .argv;
+        })
+        .command('url <url> [<name>]', 'install adapter from specified url, e.g. GitHub', yargs => {
+            yargs.argv;
+        })
+        .command('del <adapter>', 'remove adapter from system', yargs => {
+            yargs.argv;
+        })
+        .command('del <adapter>.<instance>', 'remove adapter instance', yargs => {
+            yargs.argv;
+        })
+        .command('update [<repositoryUrl>]', 'update repository and list adapters', yargs => {
+            yargs
+                .option('updateable', {
+                    describe: 'only show updateable adapters',
+                    alias: 'u',
+                    type: 'boolean'
+                })
+                .option('installed', {
+                    describe: 'only show installed adapters',
+                    alias: 'i',
+                    type: 'boolean'
+                })
+                .option('force', {
+                    describe: 'bypass hash check',
+                    alias: 'f',
+                    type: 'boolean'
                 })
                 .argv;
         })
@@ -230,7 +283,7 @@ function processCommand(command, args, params, callback) {
                 resetDbConnect,
                 params
             });
-            if (args[0] === 'custom') {
+            if (args[0] === 'custom' || params.custom) {
                 setup.setupCustom(callback);
             } else {
                 let isFirst;
@@ -2616,7 +2669,6 @@ module.exports.execute = function () {
     // direct call
     const _yargs = initYargs();
     const command = _yargs.argv._[0];
-    console.log(_yargs.argv)
 
     const args = [];
     for (let a = 1; a < _yargs.argv._.length; a++) {

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -35,288 +35,191 @@ function initYargs() {
     yargs = require('yargs')
         .scriptName(tools.appName)
         .completion('_createCompletion', false)// can be created via iob _createCompletion >> ~/.bashrc
-        .command('setup', 'setup ioBroker', yargs => {
-            yargs
-                .option('redis', {
-                    describe: 'setup as redis',
-                    type: 'boolean'
-                })
-                .option('objects', {
-                    describe: 'objects <host>',
-                    default: '127.0.0.1',
-                    type: 'number'
-                })
-                .option('states', {
-                    describe: 'states <host>',
-                    default: '127.0.0.1',
-                    type: 'number'
-                })
-                .option('port <port>', {
-                    describe: 'port of redis',
-                    default: 6379,
-                    type: 'number'
-                })
-                .option('custom', {
-                    describe: 'custom setup',
-                    type: 'boolean'
-                })
-                .option('first', {
-                    describe: 'initial setup',
-                    type: 'boolean'
-                })
-                .argv;
+        .command('setup', 'setup ioBroker', {
+            redis: {
+                describe: 'setup as redis',
+                type: 'boolean'
+            },
+            objects: {
+                describe: 'objects <host>',
+                default: '127.0.0.1',
+                type: 'number'
+            },
+            states: {
+                describe: 'states <host>',
+                default: '127.0.0.1',
+                type: 'number'
+            },
+            'port <port>': {
+                describe: 'port of redis',
+                default: 6379,
+                type: 'number'
+            },
+            custom: {
+                describe: 'custom setup',
+                type: 'boolean'
+            },
+            first: {
+                describe: 'initial setup',
+                type: 'boolean'
+            }
         })
-        .command('start', 'starts the js-controller', yargs => {
-            yargs.argv;
+        .command('start', 'starts the js-controller', {})
+        .command('stop', 'stops the js-controller', {})
+        .command('start <adapter>[.instance]', 'starts a specified adapter instance', {})
+        .command('stop <adapter>[.instance]', 'stops a specified adapter instance', {})
+        .command('start all', 'starts js-controller and all adapters', {})
+        .command('restart', 'restarts js-controller', {})
+        .command('restart <adapter>[.instance]', 'restarts a specified adapter instance', {})
+        .command('debug <adapter>[.instance]', 'Starts a Node.js debugging session for the adapter instance', {
+            ip: {
+                describe: 'ip <ip>',
+                type: 'string'
+            },
+            port: {
+                describe: 'port <port>',
+                type: 'number'
+            },
+            wait: {
+                describe: 'wait',
+                type: 'boolean'
+            }
         })
-        .command('stop', 'stops the js-controller', yargs => {
-            yargs.argv;
+        .command('info', 'shows the host info', {})
+        .command('logs [<adapter>]', 'monitor log', {
+            'lines=1000': { // TODO: it's the only place we use = we should avoid this
+                describe: 'number of lines',
+                type: 'string'
+            },
+            watch: {
+                describe: 'watch',
+                type: 'boolean'
+            }
         })
-        .command('start <adapter>[.instance]', 'starts a specified adapter instance', yargs => {
-            yargs.argv;
+        .command('add <adapter> [desiredNumber]', 'add instance of adapter', {
+            enabled: {
+                describe: 'enable adapter',
+                type: 'boolean'
+            },
+            host: {
+                describe: 'host <host>',
+                type: 'string'
+            },
+            port: {
+                describe: 'port <port>',
+                type: 'number'
+            }
         })
-        .command('stop <adapter>[.instance]', 'stops a specified adapter instance', yargs => {
-            yargs.argv;
+        .command('install <adapter>', 'installs a specified adapter', {})
+        .command('rebuild <adapter>|self', 'rebuilds a specified adapter', {
+            install: {
+                describe: 'install',
+                type: 'boolean'
+            }
         })
-        .command('start all', 'starts js-controller and all adapters', yargs => {
-            yargs.argv;
+        .command('url <url> [<name>]', 'install adapter from specified url, e.g. GitHub', {})
+        .command('del <adapter>', 'remove adapter from system', {})
+        .command('del <adapter>.<instance>', 'remove adapter instance', {})
+        .command('update [<repositoryUrl>]', 'update repository and list adapters', {
+            updateable: {
+                describe: 'only show updateable adapters',
+                alias: 'u',
+                type: 'boolean'
+            },
+            installed: {
+                describe: 'only show installed adapters',
+                alias: 'i',
+                type: 'boolean'
+            },
+            force: {
+                describe: 'bypass hash check',
+                alias: 'f',
+                type: 'boolean'
+            }
         })
-        .command('restart', 'restarts js-controller', yargs => {
-            yargs.argv;
+        .command('upgrade [<repositoryUrl>]', 'upgrade all adapters from given repository', {
+            yes: {
+                describe: 'bypass questionnaire',
+                alias: 'y',
+                type: 'boolean'
+            }
         })
-        .command('restart <adapter>[.instance]', 'restarts a specified adapter instance', yargs => {
-            yargs.argv;
+        .command('upgrade self [<repositoryUrl>]', 'upgrade js-controller and all adapters, optionally you can specify the repository url', {
+            force: {
+                describe: 'allow downgrades',
+                alias: 'f',
+                type: 'boolean'
+            }
         })
-        .command('debug <adapter>[.instance]', 'Starts a Node.js debugging session for the adapter instance', yargs => {
-            yargs
-                .option('ip', {
-                    describe: 'ip <ip>',
-                    type: 'string'
-                })
-                .option('port', {
-                    describe: 'port <port>',
-                    type: 'number'
-                })
-                .option('wait', {
-                    describe: 'wait',
-                    type: 'boolean'
-                })
-                .argv;
+        .command('upgrade <adapter> [<repositoryUrl>]', 'upgrade specified adapter, optionally you can specify the repository url', {
+            y: {
+                describe: 'bypass questionnaire',
+                alias: 'y',
+                type: 'boolean'
+            }
         })
-        .command('info', 'shows the host info', yargs => {
-            yargs.argv;
+        .command(`upload <pathToLocalFile> <pathIn${tools.appName}>`, 'upload given files to provided path to make them available for instances', {})
+        .command('upload all', 'upload all adapter files to make them available for instances', {})
+        .command('upload <adapter>', 'upload specified adapter files to make them available for instances', {})
+        .command('object get <id>', 'get object specified by id', {})
+        .command('object set <id> <json-value>', 'set object with the given id by providing a new json object', {})
+        .command('object set <id> propertyname=<value or json-value>', 'update part of the object by providing a new value or partial object', {})
+        .command('object extend <id> <json-value>', 'extend object with the given id by providing a new json object', {})
+        .command('object del <id|pattern>', 'delete object with given id or all objects matching the pattern', {
+            y: {
+                describe: 'bypass questionnaire',
+                alias: 'y',
+                type: 'boolean'
+            }
         })
-        .command('logs [<adapter>]', 'monitor log', yargs => {
-            yargs
-                .option('lines=1000', { // TODO: it's the only place we use = we should avoid this
-                    describe: 'number of lines',
-                    type: 'string'
-                })
-                .option('watch', {
-                    describe: 'watch',
-                    type: 'boolean'
-                })
-                .argv;
+        .command('object chmod <object-mode> [state-mode] <id>', 'change object rights', {})
+        .command('object chown <user> <group> <id>', 'change object ownership', {})
+        .command('object list <pattern>', 'list object matching given pattern', {})
+        .command('state get <id>', 'get state, specified by id', {})
+        .command('state getplain <id>', 'get plain state, specified by id', {
+            pretty: {
+                describe: 'prettify output',
+                type: 'boolean'
+            }
         })
-        .command('add <adapter> [desiredNumber]', 'add instance of adapter', yargs => {
-            yargs
-                .option('enabled', {
-                    describe: 'enable adapter',
-                    type: 'boolean'
-                })
-                .option('host', {
-                    describe: 'host <host>',
-                    type: 'string'
-                })
-                .option('port', {
-                    describe: 'port <port>',
-                    type: 'number'
-                })
-                .argv;
+        .command('state getvalue <id>', 'get state value, specified by id', {})
+        .command('state set <id> <value> [<ack>]', 'set state, specified by id', {})
+        .command('state del <id>', 'delete state, specified by id', {})
+        .command('message <adapter>[.instance] <command> [<message>]', 'send message to adapter instance/s', {})
+        .command('list <type> [<filter>]', 'list all entries, like objects', {})
+        .command('chmod <mode> <file>', 'change file rights', {})
+        .command('chown <user> <group> <file>', 'change file ownership', {})
+        .command('touch <file>', 'touch file', {})
+        .command('rm <file>', 'remove file', {})
+        .command(`file read <${tools.appName}-path-to-read> [<filesystem-path-to-write>]`, `read file from ${tools.appName} path and optionally write to destination`, {})
+        .command(`file write <filesystem-path-to-read> <${tools.appName}-path-to-write>`, `read file from path and write it to ${tools.appName} path`,{})
+        .command(`file rm <${tools.appName}-path-to-delete>`, 'remove file', {})
+        .command('file sync', 'sync files', {})
+        .command('user add <user>', 'add new user',{
+            ingroup: {
+                describe: 'user group',
+                type: 'string'
+            },
+            password: {
+                describe: 'user password',
+                type: 'string'
+            }
         })
-        .command('install <adapter>', 'installs a specified adapter', yargs => {
-            yargs.argv;
+        .command('user del <user>', 'delete user', {})
+        .command('user passwd <user>', 'change user password', {
+            password: {
+                describe: 'user password',
+                type: 'string'
+            }
         })
-        .command('rebuild <adapter>|self', 'rebuilds a specified adapter', yargs => {
-            yargs
-                .option('install', {
-                    describe: 'install',
-                    type: 'boolean'
-                })
-                .argv;
-        })
-        .command('url <url> [<name>]', 'install adapter from specified url, e.g. GitHub', yargs => {
-            yargs.argv;
-        })
-        .command('del <adapter>', 'remove adapter from system', yargs => {
-            yargs.argv;
-        })
-        .command('del <adapter>.<instance>', 'remove adapter instance', yargs => {
-            yargs.argv;
-        })
-        .command('update [<repositoryUrl>]', 'update repository and list adapters', yargs => {
-            yargs
-                .option('updateable', {
-                    describe: 'only show updateable adapters',
-                    alias: 'u',
-                    type: 'boolean'
-                })
-                .option('installed', {
-                    describe: 'only show installed adapters',
-                    alias: 'i',
-                    type: 'boolean'
-                })
-                .option('force', {
-                    describe: 'bypass hash check',
-                    alias: 'f',
-                    type: 'boolean'
-                })
-                .argv;
-        })
-        .command('upgrade [<repositoryUrl>]', 'upgrade all adapters from given repository', yargs => {
-            yargs
-                .option('yes', {
-                    describe: 'bypass questionnaire',
-                    alias: 'y',
-                    type: 'boolean'
-                })
-                .argv;
-        })
-        .command('upgrade self [<repositoryUrl>]', 'upgrade js-controller and all adapters, optionally you can specify the repository url', yargs => {
-            yargs
-                .option('force', {
-                    describe: 'allow downgrades',
-                    alias: 'f',
-                    type: 'boolean'
-                })
-                .argv;
-        })
-        .command('upgrade <adapter> [<repositoryUrl>]', 'upgrade specified adapter, optionally you can specify the repository url', yargs => {
-            yargs
-                .option('y', {
-                    describe: 'bypass questionnaire',
-                    alias: 'y',
-                    type: 'boolean'
-                })
-                .argv;
-        })
-        .command(`upload <pathToLocalFile> <pathIn${tools.appName}>`, 'upload given files to provided path to make them available for instances', yargs => {
-            yargs.argv;
-        })
-        .command('upload all', 'upload all adapter files to make them available for instances', yargs => {
-            yargs.argv;
-        })
-        .command('upload <adapter>', 'upload specified adapter files to make them available for instances', yargs => {
-            yargs.argv;
-        })
-        .command('object get <id>', 'get object specified by id', yargs => {
-            yargs.argv;
-        })
-        .command('object set <id> <json-value>', 'set object with the given id by providing a new json object', yargs => {
-            yargs.argv;
-        })
-        .command('object set <id> propertyname=<value or json-value>', 'update part of the object by providing a new value or partial object', yargs => {
-            yargs.argv;
-        })
-        .command('object extend <id> <json-value>', 'extend object with the given id by providing a new json object', yargs => {
-            yargs.argv;
-        })
-        .command('object del <id|pattern>', 'delete object with given id or all objects matching the pattern', yargs => {
-            yargs
-                .option('y', {
-                    describe: 'bypass questionnaire',
-                    alias: 'y',
-                    type: 'boolean'
-                })
-                .argv;
-        })
-        .command('object chmod <object-mode> [state-mode] <id>', 'change object rights', yargs => {
-            yargs.argv;
-        })
-        .command('object chown <user> <group> <id>', 'change object ownership', yargs => {
-            yargs.argv;
-        })
-        .command('object list <pattern>', 'list object matching given pattern', yargs => {
-            yargs.argv;
-        })
-        .command('state get <id>', 'get state, specified by id', yargs => {
-            yargs.argv;
-        })
-        .command('state getplain <id>', 'get plain state, specified by id', yargs => {
-            yargs
-                .option('pretty', {
-                    describe: 'prettify output',
-                    type: 'boolean'
-                })
-                .argv;
-        })
-        .command('state getvalue <id>', 'get state value, specified by id', yargs => {
-            yargs.argv;
-        })
-        .command('state set <id> <value> [<ack>]', 'set state, specified by id', yargs => {
-            yargs.argv;
-        })
-        .command('state del <id>', 'delete state, specified by id', yargs => {
-            yargs.argv;
-        })
-        .command('message <adapter>[.instance] <command> [<message>]', 'send message to adapter instance/s', yargs => {
-            yargs.argv;
-        })
-        .command('list <type> [<filter>]', 'list all entries, like objects', yargs => {
-            yargs.argv;
-        })
-        .command('chmod <mode> <file>', 'change file rights', yargs => {
-            yargs.argv;
-        })
-        .command('chown <user> <group> <file>', 'change file ownership', yargs => {
-            yargs.argv;
-        })
-        .command('touch <file>', 'touch file', yargs => {
-            yargs.argv;
-        })
-        .command('rm <file>', 'remove file', yargs => {
-            yargs.argv;
-        })
-        .command(`file read <${tools.appName}-path-to-read> [<filesystem-path-to-write>]`, `read file from ${tools.appName} path and optionally write to destination`, yargs => {
-            yargs.argv;
-        })
-        .command(`file write <filesystem-path-to-read> <${tools.appName}-path-to-write>`, `read file from path and write it to ${tools.appName} path`, yargs => {
-            yargs.argv;
-        })
-        .command(`file rm <${tools.appName}-path-to-delete>`, 'remove file', yargs => {
-            yargs.argv;
-        })
-        .command('file sync', 'sync files', yargs => {
-            yargs.argv;
-        })
-        .command('user add <user>', 'add new user', yargs => {
-            yargs
-                .option('ingroup', {
-                    describe: 'user group',
-                    type: 'string'
-                })
-                .option('password', {
-                    describe: 'user password',
-                    type: 'string'
-                })
-                .argv;
-        })
-        .command('user del <user>', 'delete user', yargs => {
-            yargs.argv;
-        })
-        .command('user passwd <user>', 'change user password', yargs => {
-            yargs
-                .option('password', {
-                    describe: 'user password',
-                    type: 'string'
-                })
-                .argv;
-        })
-        .command('user enable <user>', 'enable user', yargs => {
-            yargs.argv;
-        })
-        .command('user disable <user>', 'disable user', yargs => {
-            yargs.argv;
+        .command('user enable <user>', 'enable user', {})
+        .command('user disable <user>', 'disable user', {})
+        .command('user get <user>', 'get user', {})
+        .command('user check <user>', 'check user password', {
+            password: {
+                describe: 'user password',
+                type: 'string'
+            }
         })
         .wrap(null)
     ;

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -173,6 +173,152 @@ function initYargs() {
                 })
                 .argv;
         })
+        .command('upgrade [<repositoryUrl>]', 'upgrade all adapters from given repository', yargs => {
+            yargs
+                .option('yes', {
+                    describe: 'bypass questionnaire',
+                    alias: 'y',
+                    type: 'boolean'
+                })
+                .argv;
+        })
+        .command('upgrade self [<repositoryUrl>]', 'upgrade js-controller and all adapters, optionally you can specify the repository url', yargs => {
+            yargs
+                .option('force', {
+                    describe: 'allow downgrades',
+                    alias: 'f',
+                    type: 'boolean'
+                })
+                .argv;
+        })
+        .command('upgrade <adapter> [<repositoryUrl>]', 'upgrade specified adapter, optionally you can specify the repository url', yargs => {
+            yargs
+                .option('y', {
+                    describe: 'bypass questionnaire',
+                    alias: 'y',
+                    type: 'boolean'
+                })
+                .argv;
+        })
+        .command(`upload <pathToLocalFile> <pathIn${tools.appName}>`, 'upload given files to provided path to make them available for instances', yargs => {
+            yargs.argv;
+        })
+        .command('upload all', 'upload all adapter files to make them available for instances', yargs => {
+            yargs.argv;
+        })
+        .command('upload <adapter>', 'upload specified adapter files to make them available for instances', yargs => {
+            yargs.argv;
+        })
+        .command('object get <id>', 'get object specified by id', yargs => {
+            yargs.argv;
+        })
+        .command('object set <id> <json-value>', 'set object with the given id by providing a new json object', yargs => {
+            yargs.argv;
+        })
+        .command('object set <id> propertyname=<value or json-value>', 'update part of the object by providing a new value or partial object', yargs => {
+            yargs.argv;
+        })
+        .command('object extend <id> <json-value>', 'extend object with the given id by providing a new json object', yargs => {
+            yargs.argv;
+        })
+        .command('object del <id|pattern>', 'delete object with given id or all objects matching the pattern', yargs => {
+            yargs
+                .option('y', {
+                    describe: 'bypass questionnaire',
+                    alias: 'y',
+                    type: 'boolean'
+                })
+                .argv;
+        })
+        .command('object chmod <object-mode> [state-mode] <id>', 'change object rights', yargs => {
+            yargs.argv;
+        })
+        .command('object chown <user> <group> <id>', 'change object ownership', yargs => {
+            yargs.argv;
+        })
+        .command('object list <pattern>', 'list object matching given pattern', yargs => {
+            yargs.argv;
+        })
+        .command('state get <id>', 'get state, specified by id', yargs => {
+            yargs.argv;
+        })
+        .command('state getplain <id>', 'get plain state, specified by id', yargs => {
+            yargs
+                .option('pretty', {
+                    describe: 'prettify output',
+                    type: 'boolean'
+                })
+                .argv;
+        })
+        .command('state getvalue <id>', 'get state value, specified by id', yargs => {
+            yargs.argv;
+        })
+        .command('state set <id> <value> [<ack>]', 'set state, specified by id', yargs => {
+            yargs.argv;
+        })
+        .command('state del <id>', 'delete state, specified by id', yargs => {
+            yargs.argv;
+        })
+        .command('message <adapter>[.instance] <command> [<message>]', 'send message to adapter instance/s', yargs => {
+            yargs.argv;
+        })
+        .command('list <type> [<filter>]', 'list all entries, like objects', yargs => {
+            yargs.argv;
+        })
+        .command('chmod <mode> <file>', 'change file rights', yargs => {
+            yargs.argv;
+        })
+        .command('chown <user> <group> <file>', 'change file ownership', yargs => {
+            yargs.argv;
+        })
+        .command('touch <file>', 'touch file', yargs => {
+            yargs.argv;
+        })
+        .command('rm <file>', 'remove file', yargs => {
+            yargs.argv;
+        })
+        .command(`file read <${tools.appName}-path-to-read> [<filesystem-path-to-write>]`, `read file from ${tools.appName} path and optionally write to destination`, yargs => {
+            yargs.argv;
+        })
+        .command(`file write <filesystem-path-to-read> <${tools.appName}-path-to-write>`, `read file from path and write it to ${tools.appName} path`, yargs => {
+            yargs.argv;
+        })
+        .command(`file rm <${tools.appName}-path-to-delete>`, 'remove file', yargs => {
+            yargs.argv;
+        })
+        .command('file sync', 'sync files', yargs => {
+            yargs.argv;
+        })
+        .command('user add <user>', 'add new user', yargs => {
+            yargs
+                .option('ingroup', {
+                    describe: 'user group',
+                    type: 'string'
+                })
+                .option('password', {
+                    describe: 'user password',
+                    type: 'string'
+                })
+                .argv;
+        })
+        .command('user del <user>', 'delete user', yargs => {
+            yargs.argv;
+        })
+        .command('user passwd <user>', 'change user password', yargs => {
+            yargs
+                .option('password', {
+                    describe: 'user password',
+                    type: 'string'
+                })
+                .argv;
+        })
+        .command('user enable <user>', 'enable user', yargs => {
+            yargs.argv;
+        })
+        .command('user disable <user>', 'disable user', yargs => {
+            yargs.argv;
+        })
+        .wrap(null)
     ;
 
     return yargs;

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -221,6 +221,15 @@ function initYargs() {
                 type: 'string'
             }
         })
+        .command('group add <group>', 'add group', {})
+        .command('group del <group>', 'remove group', {})
+        .command('group list <group>', 'list group', {})
+        .command('group enable <group>', 'enable group', {})
+        .command('group disable <group>', 'disable group', {})
+        .command('group get <group>', 'get group', {})
+        .command('group adduser <group> <user>', 'add user to group', {})
+        .command('group deluser <group> <user>', 'remove user from group', {})
+        .command('host this', 'initialize this host', {})
         .wrap(null)
     ;
 

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -34,7 +34,8 @@ let yargs;
 function initYargs() {
     yargs = require('yargs')
         .scriptName(tools.appName)
-        .completion('_createCompletion', false)// can be created via iob _createCompletion >> ~/.bashrc
+        .version(false) // disable yargs own version handling, because we have our own depending on passed instances
+        .completion('_createCompletion', false) // can be created via iob _createCompletion >> ~/.bashrc or ~/.bash_profile for OSX
         .command('setup', 'setup ioBroker', {
             redis: {
                 describe: 'setup as redis',
@@ -64,14 +65,20 @@ function initYargs() {
                 type: 'boolean'
             }
         })
-        .command('start', 'starts the js-controller', {})
-        .command('stop', 'stops the js-controller', {})
-        .command('start <adapter>[.instance]', 'starts a specified adapter instance', {})
-        .command('stop <adapter>[.instance]', 'stops a specified adapter instance', {})
-        .command('start all', 'starts js-controller and all adapters', {})
-        .command('restart', 'restarts js-controller', {})
-        .command('restart <adapter>[.instance]', 'restarts a specified adapter instance', {})
-        .command('debug <adapter>[.instance]', 'Starts a Node.js debugging session for the adapter instance', {
+        .command('start', 'starts the js-controller', yargs => {
+            yargs
+                .command('all', 'starts js-controller and all adapters')
+                .command('<adapter>[.<instance>]', 'starts a specified adapter instance');
+        })
+        .command('stop', 'stops the js-controller', yargs => {
+            yargs
+                .command('<adapter>[.<instance>]', 'stops a specified adapter instance');
+        })
+        .command('restart', 'restarts js-controller', yargs => {
+            yargs
+                .command('<adapter>[.<instance>]', 'restarts a specified adapter instance', {});
+        })
+        .command('debug <adapter>[.<instance>]', 'Starts a Node.js debugging session for the adapter instance', {
             ip: {
                 describe: 'ip <ip>',
                 type: 'string'
@@ -161,40 +168,49 @@ function initYargs() {
         .command(`upload <pathToLocalFile> <pathIn${tools.appName}>`, 'upload given files to provided path to make them available for instances', {})
         .command('upload all', 'upload all adapter files to make them available for instances', {})
         .command('upload <adapter>', 'upload specified adapter files to make them available for instances', {})
-        .command('object get <id>', 'get object specified by id', {})
-        .command('object set <id> <json-value>', 'set object with the given id by providing a new json object', {})
-        .command('object set <id> propertyname=<value or json-value>', 'update part of the object by providing a new value or partial object', {})
-        .command('object extend <id> <json-value>', 'extend object with the given id by providing a new json object', {})
-        .command('object del <id|pattern>', 'delete object with given id or all objects matching the pattern', {
-            y: {
-                describe: 'bypass questionnaire',
-                alias: 'y',
-                type: 'boolean'
-            }
+        .command('object', 'object management', yargs => {
+            yargs
+                .command('get <id>', 'get object specified by id', {})
+                .command('set <id> <json-value>', 'set object with the given id by providing a new json object', {})
+                .command('set <id> propertyname=<value or json-value>', 'update part of the object by providing a new value or partial object', {})
+                .command('extend <id> <json-value>', 'extend object with the given id by providing a new json object', {})
+                .command('del <id|pattern>', 'delete object with given id or all objects matching the pattern', {
+                    y: {
+                        describe: 'bypass questionnaire',
+                        alias: 'y',
+                        type: 'boolean'
+                    }
+                })
+                .command('chmod <object-mode> [state-mode] <id>', 'change object rights', {})
+                .command('chown <user> <group> <id>', 'change object ownership', {})
+                .command('list <pattern>', 'list object matching given pattern', {});
         })
-        .command('object chmod <object-mode> [state-mode] <id>', 'change object rights', {})
-        .command('object chown <user> <group> <id>', 'change object ownership', {})
-        .command('object list <pattern>', 'list object matching given pattern', {})
-        .command('state get <id>', 'get state, specified by id', {})
-        .command('state getplain <id>', 'get plain state, specified by id', {
-            pretty: {
-                describe: 'prettify output',
-                type: 'boolean'
-            }
+        .command('state', 'state management', yargs => {
+            yargs
+                .command('get <id>', 'get state, specified by id', {})
+                .command('getplain <id>', 'get plain state, specified by id', {
+                    pretty: {
+                        describe: 'prettify output',
+                        type: 'boolean'
+                    }
+                })
+                .command('getvalue <id>', 'get state value, specified by id', {})
+                .command('set <id> <value> [<ack>]', 'set state, specified by id', {})
+                .command('del <id>', 'delete state, specified by id', {});
         })
-        .command('state getvalue <id>', 'get state value, specified by id', {})
-        .command('state set <id> <value> [<ack>]', 'set state, specified by id', {})
-        .command('state del <id>', 'delete state, specified by id', {})
         .command('message <adapter>[.instance] <command> [<message>]', 'send message to adapter instance/s', {})
         .command('list <type> [<filter>]', 'list all entries, like objects', {})
         .command('chmod <mode> <file>', 'change file rights', {})
         .command('chown <user> <group> <file>', 'change file ownership', {})
         .command('touch <file>', 'touch file', {})
         .command('rm <file>', 'remove file', {})
-        .command(`file read <${tools.appName}-path-to-read> [<filesystem-path-to-write>]`, `read file from ${tools.appName} path and optionally write to destination`, {})
-        .command(`file write <filesystem-path-to-read> <${tools.appName}-path-to-write>`, `read file from path and write it to ${tools.appName} path`,{})
-        .command(`file rm <${tools.appName}-path-to-delete>`, 'remove file', {})
-        .command('file sync', 'sync files', {})
+        .command('file', 'file management', yargs => {
+            yargs
+                .command(`read <${tools.appName}-path-to-read> [<filesystem-path-to-write>]`, `read file from ${tools.appName} path and optionally write to destination`, {})
+                .command(`write <filesystem-path-to-read> <${tools.appName}-path-to-write>`, `read file from path and write it to ${tools.appName} path`,{})
+                .command(`rm <${tools.appName}-path-to-delete>`, 'remove file', {})
+                .command('sync', 'sync files', {});
+        })
         .command('user', 'user commands', yargs => {
             yargs
                 .command('add <user>', 'add new user',yargs => {
@@ -205,72 +221,134 @@ function initYargs() {
                         .option('password', {
                             describe: 'user password',
                             type: 'string'
-                        })
-                        .positional('user', {
-                            describe: 'username',
-                            type: 'string'
                         });
                 })
-                .command('del <user>', 'delete user', yargs => {
-                    yargs
-                        .positional('user', {
-                            describe: 'username',
-                            type: 'string'
-                        });
-                })
+                .command('del <user>', 'delete user', {})
                 .command('passwd <user>', 'change user password', yargs => {
                     yargs
                         .option('password', {
                             describe: 'user password',
                             type: 'string'
-                        })
-                        .positional('user', {
-                            describe: 'username',
-                            type: 'string'
                         });
                 })
-                .command('enable <user>', 'enable user', yargs => {
-                    yargs
-                        .positional('user', {
-                            describe: 'username',
-                            type: 'string'
-                        });
-                })
-                .command('disable <user>', 'disable user', yargs => {
-                    yargs
-                        .positional('user', {
-                            describe: 'username',
-                            type: 'string'
-                        });
-                })
-                .command('get <user>', 'get user', yargs => {
-                    yargs
-                        .positional('user', {
-                            describe: 'username',
-                            type: 'string'
-                        });
-                })
+                .command('enable <user>', 'enable user', {})
+                .command('disable <user>', 'disable user', {})
+                .command('get <user>', 'get user', {})
                 .command('check <user>', 'check user password', yargs => {
                     yargs
                         .option('password', {
                             describe: 'user password',
                             type: 'string'
-                        })
-                        .positional('user', {
-                            describe: 'username',
-                            type: 'string'
                         });
                 });
         })
-        .command('group add <group>', 'add group', {})
-        .command('group del <group>', 'remove group', {})
-        .command('group list <group>', 'list group', {})
-        .command('group enable <group>', 'enable group', {})
-        .command('group disable <group>', 'disable group', {})
-        .command('group get <group>', 'get group', {})
-        .command('group adduser <group> <user>', 'add user to group', {})
-        .command('group deluser <group> <user>', 'remove user from group', {})
-        .command('host this', 'initialize this host', {})
+        .command('group', 'group management', yargs => {
+            yargs
+                .command('add <group>', 'add group', {})
+                .command('del <group>', 'remove group', {})
+                .command('list <group>', 'list group', {})
+                .command('enable <group>', 'enable group', {})
+                .command('disable <group>', 'disable group', {})
+                .command('get <group>', 'get group', {})
+                .command('adduser <group> <user>', 'add user to group', {})
+                .command('deluser <group> <user>', 'remove user from group', {});
+        })
+        .command('host <hostname>', 'set host to given hostname', yargs => {
+            yargs
+                .command('this', 'initialize current host', {})
+                .command('set <hostname>', 'set host with specified hostname', {})
+                .command('remove <hostname>', 'remove host with specified hostname', {});
+        })
+        .command('set <adapter>.<instance>', 'change settings of adapter config', {
+            customOption: {
+                describe: 'set the name of the parameter you want to change as option followed by its value, e. g. --port 80'
+            }
+        })
+        .command('license <license.file or license.text>', '', {})
+        .command('cert', 'certificate management', yargs => {
+            yargs
+                .command('create', 'create certificate', {})
+                .command('view [<certificate name>]', 'show certificate', {});
+        })
+        .command('clean', '', {})
+        .command('backup', 'create backup', {})
+        .command('restore <backup name or path>', 'restore a specified backup', {})
+        .command('validate <backup name or path>', 'validate a specified backup', {})
+        .command('status [all|<adapter>.<instance>]', 'status of ioBroker or adapter instance', {})
+        .command('repo [<name>]', 'show repo information', yargs => {
+            yargs
+                .command('set <name>', 'set active repository')
+                .command('repo del <name>', 'remove repository');
+        })
+        .command('uuid', '', {})
+        .command('unsetup', '', {})
+        .command('fix', 'execute the installation fixer script, this updates your ioBroker installation', {})
+        .command('multihost', 'multihost management', yargs => {
+            yargs
+                .command('enable', 'enable multihost discovery', {
+                    secure: {
+                        describe: 'use secure connection',
+                        type: 'boolean'
+                    },
+                    persist: {
+                        describe: 'enable persistent discovery',
+                        type: 'boolean'
+                    }
+                })
+                .command('disable', 'disable multihost discovery')
+                .command('browse', 'browse for multihost server')
+                .command('connect', 'connect to multihost server');
+        })
+        .command('compact', 'compact group management', yargs => {
+            yargs
+                .command('enable', 'enable compact mode in general')
+                .command('on', 'enable compact mode in general')
+                .command('disable', 'disable compact mode in general')
+                .command('off', 'disable compact mode in general')
+                .command('<adapter>.<instance> status', 'show if compact mode is enabled for a specific instance')
+                .command('<adapter>.<instance> group <group-id>', 'define compact group of a specific adapter')
+                .command('<adapter>.<instance> <disable|off>', 'enable or disable compact mode for specified adapter instance')
+                .command('compact <adapter>.<instance> <enable|on> [group-id]', 'enable or disable compact mode for specified adapter instance and set compact group optionally');
+        })
+        .command('plugin', 'plugin management', yargs => {
+            yargs
+                .command('enable <pluginname>', 'enables a plugin for the specified host or instance. If no host is specified, the current one is used', {
+                    host: {
+                        describe: 'hostname',
+                        type: 'string'
+                    },
+                    instance: {
+                        describe: 'instance, e.g. hm-rpc.0',
+                        type: 'string'
+                    }
+                })
+                .command('disable <pluginname>', 'disables a plugin for the specified host or instance. If no host is specified, the current one is used', {
+                    host: {
+                        describe: 'hostname',
+                        type: 'string'
+                    },
+                    instance: {
+                        describe: 'instance, e.g. hm-rpc.0',
+                        type: 'string'
+                    }
+                })
+                .command('status <pluginname>', 'checks if a plugin is enabled for the specified host or instance. If no host is specified, the current one is used', {
+                    host: {
+                        describe: 'hostname',
+                        type: 'string'
+                    },
+                    instance: {
+                        describe: 'instance, e.g. hm-rpc.0',
+                        type: 'string'
+                    }
+                });
+        })
+        .command('version [<adapter>]', 'show version of js-controller or specified adapter')
+        .option('version', {
+            describe: 'show version',
+            type: 'boolean',
+            alias: 'v'
+        })
         .wrap(null)
     ;
 

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -264,13 +264,13 @@ function initYargs() {
                 describe: 'set the name of the parameter you want to change as option followed by its value, e. g. --port 80'
             }
         })
-        .command('license <license.file or license.text>', '', {})
+        .command('license <license.file or license.text>', 'update license by given file', {})
         .command('cert', 'certificate management', yargs => {
             yargs
                 .command('create', 'create certificate', {})
                 .command('view [<certificate name>]', 'show certificate', {});
         })
-        .command('clean', '', {})
+        .command('clean <yes>', 'Clears all objects and states', {})
         .command('backup', 'create backup', {})
         .command('restore <backup name or path>', 'restore a specified backup', {})
         .command('validate <backup name or path>', 'validate a specified backup', {})
@@ -280,8 +280,8 @@ function initYargs() {
                 .command('set <name>', 'set active repository')
                 .command('repo del <name>', 'remove repository');
         })
-        .command('uuid', '', {})
-        .command('unsetup', '', {})
+        .command('uuid', 'show uuid of the installation', {})
+        .command('unsetup', 'reset license, installation secret and language', {})
         .command('fix', 'execute the installation fixer script, this updates your ioBroker installation', {})
         .command('multihost', 'multihost management', yargs => {
             yargs

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -34,318 +34,319 @@ let yargs;
 function initYargs() {
     yargs = require('yargs')
         .scriptName(tools.appName)
+        .locale('en')// otherwise it could be mixed, because our implementations are in english
         .version(false) // disable yargs own version handling, because we have our own depending on passed instances
         .completion('_createCompletion', false) // can be created via iob _createCompletion >> ~/.bashrc or ~/.bash_profile for OSX
-        .command('setup', 'setup ioBroker', {
+        .command('setup', 'Setup ioBroker', {
             redis: {
-                describe: 'setup as redis',
+                describe: 'Setup as redis',
                 type: 'boolean'
             },
             objects: {
-                describe: 'objects <host>',
+                describe: 'Objects <host>',
                 default: '127.0.0.1',
                 type: 'number'
             },
             states: {
-                describe: 'states <host>',
+                describe: 'States <host>',
                 default: '127.0.0.1',
                 type: 'number'
             },
             'port <port>': {
-                describe: 'port of redis',
+                describe: 'Port of redis',
                 default: 6379,
                 type: 'number'
             },
             custom: {
-                describe: 'custom setup',
+                describe: 'Custom setup',
                 type: 'boolean'
             },
             first: {
-                describe: 'initial setup',
+                describe: 'Initial setup',
                 type: 'boolean'
             }
         })
-        .command('start', 'starts the js-controller', yargs => {
+        .command('start', 'Starts the js-controller', yargs => {
             yargs
-                .command('all', 'starts js-controller and all adapters')
-                .command('<adapter>[.<instance>]', 'starts a specified adapter instance');
+                .command('all', 'Starts js-controller and all adapters')
+                .command('<adapter>[.<instance>]', 'Starts a specified adapter instance');
         })
         .command('stop', 'stops the js-controller', yargs => {
             yargs
-                .command('<adapter>[.<instance>]', 'stops a specified adapter instance');
+                .command('<adapter>[.<instance>]', 'Stops a specified adapter instance');
         })
-        .command('restart', 'restarts js-controller', yargs => {
+        .command('restart', 'Restarts js-controller', yargs => {
             yargs
-                .command('<adapter>[.<instance>]', 'restarts a specified adapter instance', {});
+                .command('<adapter>[.<instance>]', 'Restarts a specified adapter instance', {});
         })
         .command('debug <adapter>[.<instance>]', 'Starts a Node.js debugging session for the adapter instance', {
             ip: {
-                describe: 'ip <ip>',
+                describe: 'IP-address <ip>',
                 type: 'string'
             },
             port: {
-                describe: 'port <port>',
+                describe: 'Port <port>',
                 type: 'number'
             },
             wait: {
-                describe: 'wait',
+                describe: 'Wait',
                 type: 'boolean'
             }
         })
-        .command('info', 'shows the host info', {})
-        .command('logs [<adapter>]', 'monitor log', {
+        .command('info', 'Shows the host info', {})
+        .command('logs [<adapter>]', 'Monitor log', {
             'lines=1000': { // TODO: it's the only place we use = we should avoid this
-                describe: 'number of lines',
+                describe: 'Number of lines',
                 type: 'string'
             },
             watch: {
-                describe: 'watch',
+                describe: 'Watch',
                 type: 'boolean'
             }
         })
-        .command('add <adapter> [desiredNumber]', 'add instance of adapter', {
+        .command('add <adapter> [desiredNumber]', 'Add instance of adapter', {
             enabled: {
-                describe: 'enable adapter',
+                describe: 'Enable adapter',
                 type: 'boolean'
             },
             host: {
-                describe: 'host <host>',
+                describe: 'Host <host>',
                 type: 'string'
             },
             port: {
-                describe: 'port <port>',
+                describe: 'Port <port>',
                 type: 'number'
             }
         })
-        .command('install <adapter>', 'installs a specified adapter', {})
-        .command('rebuild <adapter>|self', 'rebuilds a specified adapter', {
+        .command('install <adapter>', 'Installs a specified adapter', {})
+        .command('rebuild <adapter>|self', 'Rebuilds a specified adapter', {
             install: {
-                describe: 'install',
+                describe: 'Install',
                 type: 'boolean'
             }
         })
-        .command('url <url> [<name>]', 'install adapter from specified url, e.g. GitHub', {})
-        .command('del <adapter>', 'remove adapter from system', {})
-        .command('del <adapter>.<instance>', 'remove adapter instance', {})
-        .command('update [<repositoryUrl>]', 'update repository and list adapters', {
+        .command('url <url> [<name>]', 'Install adapter from specified url, e.g. GitHub', {})
+        .command('del <adapter>', 'Remove adapter from system', {})
+        .command('del <adapter>.<instance>', 'Remove adapter instance', {})
+        .command('update [<repositoryUrl>]', 'Update repository and list adapters', {
             updateable: {
-                describe: 'only show updateable adapters',
+                describe: 'Only show updateable adapters',
                 alias: 'u',
                 type: 'boolean'
             },
             installed: {
-                describe: 'only show installed adapters',
+                describe: 'Only show installed adapters',
                 alias: 'i',
                 type: 'boolean'
             },
             force: {
-                describe: 'bypass hash check',
+                describe: 'Bypass hash check',
                 alias: 'f',
                 type: 'boolean'
             }
         })
-        .command('upgrade [<repositoryUrl>]', 'upgrade all adapters from given repository', {
+        .command('upgrade [<repositoryUrl>]', 'Upgrade all adapters from given repository', {
             yes: {
-                describe: 'bypass questionnaire',
+                describe: 'Bypass questionnaire',
                 alias: 'y',
                 type: 'boolean'
             }
         })
-        .command('upgrade self [<repositoryUrl>]', 'upgrade js-controller and all adapters, optionally you can specify the repository url', {
+        .command('upgrade self [<repositoryUrl>]', 'Upgrade js-controller and all adapters, optionally you can specify the repository url', {
             force: {
-                describe: 'allow downgrades',
+                describe: 'Allow downgrades',
                 alias: 'f',
                 type: 'boolean'
             }
         })
-        .command('upgrade <adapter> [<repositoryUrl>]', 'upgrade specified adapter, optionally you can specify the repository url', {
+        .command('upgrade <adapter> [<repositoryUrl>]', 'Upgrade specified adapter, optionally you can specify the repository url', {
             y: {
-                describe: 'bypass questionnaire',
+                describe: 'Bypass questionnaire',
                 alias: 'y',
                 type: 'boolean'
             }
         })
-        .command(`upload <pathToLocalFile> <pathIn${tools.appName}>`, 'upload given files to provided path to make them available for instances', {})
-        .command('upload all', 'upload all adapter files to make them available for instances', {})
-        .command('upload <adapter>', 'upload specified adapter files to make them available for instances', {})
-        .command('object', 'object management', yargs => {
+        .command(`upload <pathToLocalFile> <pathIn${tools.appName}>`, 'Upload given files to provided path to make them available for instances', {})
+        .command('upload all', 'Upload all adapter files to make them available for instances', {})
+        .command('upload <adapter>', 'Upload specified adapter files to make them available for instances', {})
+        .command('object', 'Object management', yargs => {
             yargs
-                .command('get <id>', 'get object specified by id', {})
-                .command('set <id> <json-value>', 'set object with the given id by providing a new json object', {})
-                .command('set <id> propertyname=<value or json-value>', 'update part of the object by providing a new value or partial object', {})
-                .command('extend <id> <json-value>', 'extend object with the given id by providing a new json object', {})
-                .command('del <id|pattern>', 'delete object with given id or all objects matching the pattern', {
+                .command('get <id>', 'Get object specified by id', {})
+                .command('set <id> <json-value>', 'Set object with the given id by providing a new json object', {})
+                .command('set <id> propertyname=<value or json-value>', 'Update part of the object by providing a new value or partial object', {})
+                .command('extend <id> <json-value>', 'Extend object with the given id by providing a new json object', {})
+                .command('del <id|pattern>', 'Delete object with given id or all objects matching the pattern', {
                     y: {
-                        describe: 'bypass questionnaire',
+                        describe: 'Bypass questionnaire',
                         alias: 'y',
                         type: 'boolean'
                     }
                 })
-                .command('chmod <object-mode> [state-mode] <id>', 'change object rights', {})
-                .command('chown <user> <group> <id>', 'change object ownership', {})
-                .command('list <pattern>', 'list object matching given pattern', {});
+                .command('chmod <object-mode> [state-mode] <id>', 'Change object rights', {})
+                .command('chown <user> <group> <id>', 'Change object ownership', {})
+                .command('list <pattern>', 'List object matching given pattern', {});
         })
-        .command('state', 'state management', yargs => {
+        .command('state', 'State management', yargs => {
             yargs
-                .command('get <id>', 'get state, specified by id', {})
-                .command('getplain <id>', 'get plain state, specified by id', {
+                .command('get <id>', 'Get state, specified by id', {})
+                .command('getplain <id>', 'Get plain state, specified by id', {
                     pretty: {
-                        describe: 'prettify output',
+                        describe: 'Prettify output',
                         type: 'boolean'
                     }
                 })
-                .command('getvalue <id>', 'get state value, specified by id', {})
-                .command('set <id> <value> [<ack>]', 'set state, specified by id', {})
-                .command('del <id>', 'delete state, specified by id', {});
+                .command('getvalue <id>', 'Get state value, specified by id', {})
+                .command('set <id> <value> [<ack>]', 'Set state, specified by id', {})
+                .command('del <id>', 'Delete state, specified by id', {});
         })
-        .command('message <adapter>[.instance] <command> [<message>]', 'send message to adapter instance/s', {})
-        .command('list <type> [<filter>]', 'list all entries, like objects', {})
-        .command('chmod <mode> <file>', 'change file rights', {})
-        .command('chown <user> <group> <file>', 'change file ownership', {})
-        .command('touch <file>', 'touch file', {})
-        .command('rm <file>', 'remove file', {})
-        .command('file', 'file management', yargs => {
+        .command('message <adapter>[.instance] <command> [<message>]', 'Send message to adapter instance/s', {})
+        .command('list <type> [<filter>]', 'List all entries, like objects', {})
+        .command('chmod <mode> <file>', 'Change file rights', {})
+        .command('chown <user> <group> <file>', 'Change file ownership', {})
+        .command('touch <file>', 'Touch file', {})
+        .command('rm <file>', 'Remove file', {})
+        .command('file', 'File management', yargs => {
             yargs
-                .command(`read <${tools.appName}-path-to-read> [<filesystem-path-to-write>]`, `read file from ${tools.appName} path and optionally write to destination`, {})
-                .command(`write <filesystem-path-to-read> <${tools.appName}-path-to-write>`, `read file from path and write it to ${tools.appName} path`,{})
-                .command(`rm <${tools.appName}-path-to-delete>`, 'remove file', {})
-                .command('sync', 'sync files', {});
+                .command(`read <${tools.appName}-path-to-read> [<filesystem-path-to-write>]`, `Read file from ${tools.appName} path and optionally write to destination`, {})
+                .command(`write <filesystem-path-to-read> <${tools.appName}-path-to-write>`, `Read file from path and write it to ${tools.appName} path`,{})
+                .command(`rm <${tools.appName}-path-to-delete>`, 'Remove file', {})
+                .command('sync', 'Sync files', {});
         })
-        .command('user', 'user commands', yargs => {
+        .command('user', 'User commands', yargs => {
             yargs
-                .command('add <user>', 'add new user',yargs => {
+                .command('add <user>', 'Add new user',yargs => {
                     yargs.option('ingroup', {
-                        describe: 'user group',
+                        describe: 'User group',
                         type: 'string'
                     })
                         .option('password', {
-                            describe: 'user password',
+                            describe: 'User password',
                             type: 'string'
                         });
                 })
-                .command('del <user>', 'delete user', {})
-                .command('passwd <user>', 'change user password', yargs => {
+                .command('del <user>', 'Delete user', {})
+                .command('passwd <user>', 'Change user password', yargs => {
                     yargs
                         .option('password', {
-                            describe: 'user password',
+                            describe: 'User password',
                             type: 'string'
                         });
                 })
-                .command('enable <user>', 'enable user', {})
-                .command('disable <user>', 'disable user', {})
-                .command('get <user>', 'get user', {})
-                .command('check <user>', 'check user password', yargs => {
+                .command('enable <user>', 'Enable user', {})
+                .command('disable <user>', 'Disable user', {})
+                .command('get <user>', 'Get user', {})
+                .command('check <user>', 'Check user password', yargs => {
                     yargs
                         .option('password', {
-                            describe: 'user password',
+                            describe: 'User password',
                             type: 'string'
                         });
                 });
         })
         .command('group', 'group management', yargs => {
             yargs
-                .command('add <group>', 'add group', {})
-                .command('del <group>', 'remove group', {})
-                .command('list <group>', 'list group', {})
-                .command('enable <group>', 'enable group', {})
-                .command('disable <group>', 'disable group', {})
-                .command('get <group>', 'get group', {})
-                .command('adduser <group> <user>', 'add user to group', {})
-                .command('deluser <group> <user>', 'remove user from group', {});
+                .command('add <group>', 'Add group', {})
+                .command('del <group>', 'Remove group', {})
+                .command('list <group>', 'List group', {})
+                .command('enable <group>', 'Enable group', {})
+                .command('disable <group>', 'Disable group', {})
+                .command('get <group>', 'Get group', {})
+                .command('adduser <group> <user>', 'Add user to group', {})
+                .command('deluser <group> <user>', 'Remove user from group', {});
         })
-        .command('host <hostname>', 'set host to given hostname', yargs => {
+        .command('host <hostname>', 'Set host to given hostname', yargs => {
             yargs
-                .command('this', 'initialize current host', {})
-                .command('set <hostname>', 'set host with specified hostname', {})
-                .command('remove <hostname>', 'remove host with specified hostname', {});
+                .command('this', 'Initialize current host', {})
+                .command('set <hostname>', 'Set host with specified hostname', {})
+                .command('remove <hostname>', 'Remove host with specified hostname', {});
         })
-        .command('set <adapter>.<instance>', 'change settings of adapter config', {
+        .command('set <adapter>.<instance>', 'Change settings of adapter config', {
             customOption: {
-                describe: 'set the name of the parameter you want to change as option followed by its value, e. g. --port 80'
+                describe: 'Set the name of the parameter you want to change as option followed by its value, e. g. --port 80'
             }
         })
-        .command('license <license.file or license.text>', 'update license by given file', {})
-        .command('cert', 'certificate management', yargs => {
+        .command('license <license.file or license.text>', 'Update license by given file', {})
+        .command('cert', 'Certificate management', yargs => {
             yargs
-                .command('create', 'create certificate', {})
-                .command('view [<certificate name>]', 'show certificate', {});
+                .command('create', 'Create certificate', {})
+                .command('view [<certificate name>]', 'Show certificate', {});
         })
         .command('clean <yes>', 'Clears all objects and states', {})
-        .command('backup', 'create backup', {})
-        .command('restore <backup name or path>', 'restore a specified backup', {})
-        .command('validate <backup name or path>', 'validate a specified backup', {})
-        .command('status [all|<adapter>.<instance>]', 'status of ioBroker or adapter instance', {})
-        .command('repo [<name>]', 'show repo information', yargs => {
+        .command('backup', 'Create backup', {})
+        .command('restore <backup name or path>', 'Restore a specified backup', {})
+        .command('validate <backup name or path>', 'Validate a specified backup', {})
+        .command('status [all|<adapter>.<instance>]', 'Status of ioBroker or adapter instance', {})
+        .command('repo [<name>]', 'Show repo information', yargs => {
             yargs
-                .command('set <name>', 'set active repository')
-                .command('repo del <name>', 'remove repository');
+                .command('set <name>', 'Set active repository')
+                .command('repo del <name>', 'Remove repository');
         })
-        .command('uuid', 'show uuid of the installation', {})
-        .command('unsetup', 'reset license, installation secret and language', {})
-        .command('fix', 'execute the installation fixer script, this updates your ioBroker installation', {})
-        .command('multihost', 'multihost management', yargs => {
+        .command('uuid', 'Show uuid of the installation', {})
+        .command('unsetup', 'Reset license, installation secret and language', {})
+        .command('fix', 'Execute the installation fixer script, this updates your ioBroker installation', {})
+        .command('multihost', 'Multihost management', yargs => {
             yargs
-                .command('enable', 'enable multihost discovery', {
+                .command('enable', 'Enable multihost discovery', {
                     secure: {
-                        describe: 'use secure connection',
+                        describe: 'Use secure connection',
                         type: 'boolean'
                     },
                     persist: {
-                        describe: 'enable persistent discovery',
+                        describe: 'Enable persistent discovery',
                         type: 'boolean'
                     }
                 })
-                .command('disable', 'disable multihost discovery')
-                .command('browse', 'browse for multihost server')
-                .command('connect', 'connect to multihost server');
+                .command('disable', 'Disable multihost discovery')
+                .command('browse', 'Browse for multihost server')
+                .command('connect', 'Connect to multihost server');
         })
         .command('compact', 'compact group management', yargs => {
             yargs
-                .command('enable', 'enable compact mode in general')
-                .command('on', 'enable compact mode in general')
-                .command('disable', 'disable compact mode in general')
-                .command('off', 'disable compact mode in general')
-                .command('<adapter>.<instance> status', 'show if compact mode is enabled for a specific instance')
-                .command('<adapter>.<instance> group <group-id>', 'define compact group of a specific adapter')
-                .command('<adapter>.<instance> <disable|off>', 'enable or disable compact mode for specified adapter instance')
-                .command('compact <adapter>.<instance> <enable|on> [group-id]', 'enable or disable compact mode for specified adapter instance and set compact group optionally');
+                .command('enable', 'Enable compact mode in general')
+                .command('on', 'Enable compact mode in general')
+                .command('disable', 'Disable compact mode in general')
+                .command('off', 'Disable compact mode in general')
+                .command('<adapter>.<instance> status', 'Show if compact mode is enabled for a specific instance')
+                .command('<adapter>.<instance> group <group-id>', 'Define compact group of a specific adapter')
+                .command('<adapter>.<instance> <disable|off>', 'Enable or disable compact mode for specified adapter instance')
+                .command('compact <adapter>.<instance> <enable|on> [group-id]', 'Enable or disable compact mode for specified adapter instance and set compact group optionally');
         })
-        .command('plugin', 'plugin management', yargs => {
+        .command('plugin', 'Plugin management', yargs => {
             yargs
-                .command('enable <pluginname>', 'enables a plugin for the specified host or instance. If no host is specified, the current one is used', {
+                .command('enable <pluginname>', 'Enables a plugin for the specified host or instance. If no host is specified, the current one is used', {
                     host: {
-                        describe: 'hostname',
+                        describe: 'Hostname',
                         type: 'string'
                     },
                     instance: {
-                        describe: 'instance, e.g. hm-rpc.0',
+                        describe: 'Instance, e.g. hm-rpc.0',
                         type: 'string'
                     }
                 })
-                .command('disable <pluginname>', 'disables a plugin for the specified host or instance. If no host is specified, the current one is used', {
+                .command('disable <pluginname>', 'Disables a plugin for the specified host or instance. If no host is specified, the current one is used', {
                     host: {
-                        describe: 'hostname',
+                        describe: 'Hostname',
                         type: 'string'
                     },
                     instance: {
-                        describe: 'instance, e.g. hm-rpc.0',
+                        describe: 'Instance, e.g. hm-rpc.0',
                         type: 'string'
                     }
                 })
-                .command('status <pluginname>', 'checks if a plugin is enabled for the specified host or instance. If no host is specified, the current one is used', {
+                .command('status <pluginname>', 'Checks if a plugin is enabled for the specified host or instance. If no host is specified, the current one is used', {
                     host: {
-                        describe: 'hostname',
+                        describe: 'Hostname',
                         type: 'string'
                     },
                     instance: {
-                        describe: 'instance, e.g. hm-rpc.0',
+                        describe: 'Instance, e.g. hm-rpc.0',
                         type: 'string'
                     }
                 });
         })
-        .command('version [<adapter>]', 'show version of js-controller or specified adapter')
+        .command('version [<adapter>]', 'Show version of js-controller or specified adapter')
         .option('version', {
-            describe: 'show version',
+            describe: 'Show version',
             type: 'boolean',
             alias: 'v'
         })


### PR DESCRIPTION
- this allows showing `--help` for a specific command instead of the whole output every time
- I also fixed a problem with some version commands, which were not correctly handled, because yargs returns per default on `--version` calls, returning the version of the package.json
- for most Unix systems, we can now easily create auto-completion, currently, the user could add it to his bashrc via 
`iobroker _createCompletion >> ~/.bashrc` however, we should handle this in the controller or better installer/fixer and should also add the completion for `iob` and not only `iobroker` command by adding `complete -o default -F _yargs_completions iob` too
- Closes #280 
fixes: https://github.com/ioBroker/ioBroker/issues/114