### PR TITLE
propagate error on sendTo methods

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -5485,7 +5485,7 @@ function Adapter(options) {
          *            }
          *        </code></pre>
          */
-        this.sendTo = (instanceName, command, message, callback) => {
+        this.sendTo = async (instanceName, command, message, callback) => {
             if ((typeof message === 'function') && (typeof callback === 'undefined')) {
                 callback = message;
                 message = undefined;
@@ -5496,7 +5496,7 @@ function Adapter(options) {
             }
             const obj = {command: command, message: message, from: 'system.adapter.' + this.namespace};
 
-            if (typeof instanceName !== 'string' || ! instanceName) {
+            if (typeof instanceName !== 'string' || !instanceName) {
                 typeof callback === 'function' && setImmediate(() => callback('No instanceName provided or not a string'));
                 return;
             }
@@ -5522,10 +5522,17 @@ function Adapter(options) {
                 }
 
                 // Send to all instances of adapter
-                adapterObjects.getObjectView('system', 'instance', {startkey: instanceName + '.', endkey: instanceName + '.\u9999'}, (err, _obj) => {
+                adapterObjects.getObjectView('system', 'instance', {
+                    startkey: instanceName + '.',
+                    endkey: instanceName + '.\u9999'
+                }, async (err, _obj) => {
                     if (_obj && _obj.rows) {
                         for (let i = 0; i < _obj.rows.length; i++) {
-                            adapterStates.pushMessage(_obj.rows[i].id, obj);
+                            try {
+                                await adapterStates.pushMessage(_obj.rows[i].id, obj);
+                            } catch (e) {
+                                return tools.maybeCallbackWithError(callback, e);
+                            }
                         }
                     }
                 });
@@ -5540,9 +5547,9 @@ function Adapter(options) {
 
                         obj.callback = {
                             message: message,
-                            id:      callbackId++,
-                            ack:     false,
-                            time:    Date.now()
+                            id: callbackId++,
+                            ack: false,
+                            time: Date.now()
                         };
                         if (callbackId >= 0xFFFFFFFF) {
                             callbackId = 1;
@@ -5565,7 +5572,11 @@ function Adapter(options) {
                     }
                 }
 
-                adapterStates.pushMessage(instanceName, obj);
+                try {
+                    await adapterStates.pushMessage(instanceName, obj);
+                } catch (e) {
+                    return tools.maybeCallbackWithError(callback, e);
+                }
             }
         };
         /**
@@ -5592,7 +5603,7 @@ function Adapter(options) {
          *            }
          *        </code></pre>
          */
-        this.sendToHost = (hostName, command, message, callback) => {
+        this.sendToHost = async (hostName, command, message, callback) => {
             if (typeof message === 'undefined') {
                 message = command;
                 command = 'send';
@@ -5617,7 +5628,7 @@ function Adapter(options) {
                 }
 
                 // Send to all hosts
-                adapterObjects.getObjectList({startkey: 'system.host.', endkey: 'system.host.' + '\u9999'}, null, (err, res) => {
+                adapterObjects.getObjectList({startkey: 'system.host.', endkey: `system.host.\u9999`}, null, async (err, res) => {
                     if (!adapterStates) { // if states is no longer existing, we do not need to unsubscribe
                         return;
                     }
@@ -5626,7 +5637,11 @@ function Adapter(options) {
                             const parts = res.rows[i].id.split('.');
                             // ignore system.host.name.alive and so on
                             if (parts.length === 3) {
-                                adapterStates.pushMessage(res.rows[i].id, obj);
+                                try {
+                                    await adapterStates.pushMessage(res.rows[i].id, obj);
+                                } catch (e) {
+                                    return tools.maybeCallbackWithError(callback, e);
+                                }
                             }
                         }
                     }
@@ -5637,7 +5652,7 @@ function Adapter(options) {
                         // force subscribe even no messagebox enabled
                         if (!this.common.messagebox && !this.mboxSubscribed) {
                             this.mboxSubscribed = true;
-                            adapterStates.subscribeMessage('system.adapter.' + this.namespace);
+                            adapterStates.subscribeMessage(`system.adapter.${this.namespace}`);
                         }
 
                         obj.callback = {
@@ -5657,7 +5672,11 @@ function Adapter(options) {
                     }
                 }
 
-                adapterStates.pushMessage(hostName, obj);
+                try {
+                    await adapterStates.pushMessage(hostName, obj);
+                } catch (e) {
+                    return tools.maybeCallbackWithError(callback, e);
+                }
             }
         };
         /**


### PR DESCRIPTION
fixes error from forum

```
Error: Connection is closed.

2021-01-14 14:58:39.900  -  [31merror [39m: host.ioBroker2 Caught by controller[5]:     at Redis.sendCommand (/opt/iobroker/node_modules/ioredis/built/redis/index.js:607:24)

 
2021-01-14 14:58:39.900  -  [31merror [39m: host.ioBroker2 Caught by controller[5]:     at Redis.publish (/opt/iobroker/node_modules/ioredis/built/commander.js:111:25)

 
2021-01-14 14:58:39.900  -  [31merror [39m: host.ioBroker2 Caught by controller[5]:     at StateRedisClient.pushMessage (/opt/iobroker/node_modules/@iobroker/db-states-redis/lib/states/statesInRedisClient.js:898:31)

2021-01-14 14:58:39.900  -  [31merror [39m: host.ioBroker2 Caught by controller[5]:     at Sourceanalytix.sendToHost (/opt/iobroker/node_modules/iobroker.js-controller/lib/adapter.js:5660:31)

2021-01-14 14:58:39.900  -  [31merror [39m: host.ioBroker2 Caught by controller[5]:     at /opt/iobroker/node_modules/iobroker.js-controller/lib/tools.js:1619:16

2021-01-14 14:58:39.901  -  [31merror [39m: host.ioBroker2 Caught by controller[5]:     at new Promise (<anonymous>)

2021-01-14 14:58:39.901  -  [31merror [39m: host.ioBroker2 Caught by controller[5]:     at Sourceanalytix.sendToHostAsync (/opt/iobroker/node_modules/iobroker.js-controller/lib/tools.js:1618:16)

2021-01-14 14:58:39.901  -  [31merror [39m: host.ioBroker2 Caught by controller[5]:     at Sourceanalytix.registerNotification (/opt/iobroker/node_modules/iobroker.js-controller/lib/adapter.js:5677:24)

2021-01-14 14:58:39.901  -  [31merror [39m: host.ioBroker2 Caught by controller[5]:     at exceptionHandler (/opt/iobroker/node_modules/iobroker.js-controller/lib/adapter.js:8457:28)

2021-01-14 14:58:39.901  -  [31merror [39m: host.ioBroker2 Caught by controller[5]:     at process.<anonymous> (/opt/iobroker/node_modules/iobroker.js-controller/lib/adapter.js:8477:45)

2021-01-14 14:58:39.901  -  [31merror [39m: host.ioBroker2 Caught by controller[5]: This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch().
```

side effect of returning promises if no cb is provided