### PR TITLE
fix: parse github http URLs in iobroker url command

### DIFF
--- a/lib/setup/setupInstall.js
+++ b/lib/setup/setupInstall.js
@@ -1572,21 +1572,10 @@ function Install(options) {
                             // Install using the npm Github URL syntax `npm i user/repo_name`:
                             return void that.installAdapterFromUrl(`${user}/${repo}`, name, callback);
                         } else if (res.statusCode !== 200) {
-                            console.log(
-                                `Info: Can not get current GitHub commit, only remember that we installed from GitHub. Status: ${res.statusCode
-                                }${data && data.message
-                                    ? ` (${data.message})`
-                                    : ''
-                                }`
-                            );
+                            console.log(`Info: Can not get current GitHub commit, only remember that we installed from GitHub. Status: ${res.statusCode}${data && data.message? ` (${data.message})`: ''}`);
                             // Install using the npm Github URL syntax `npm i user/repo_name`:
                             return void that.installAdapterFromUrl(`${user}/${repo}`, name, callback);
-                        } else if (
-                            data &&
-                            Array.isArray(data) &&
-                            data.length >= 1 &&
-                            data[0].sha
-                        ) {
+                        } else if (data && Array.isArray(data) && data.length >= 1 && data[0].sha) {
                             // Install using the npm Github URL syntax `npm i user/repo_name#commit-ish`:
                             return void that.installAdapterFromUrl(`${user}/${repo}#${data[0].sha}`, name, callback);
                         } else {

--- a/lib/setup/setupInstall.js
+++ b/lib/setup/setupInstall.js
@@ -23,6 +23,7 @@ function Install(options) {
     const PacketManager    = require('./setupPacketManager');
     const osPlatform       = require('os').platform();
     const deepClone        = require('deep-clone');
+    const { URL }          = require('url');
 
     // todo solve it somehow
     const unsafePermAlways = [tools.appName.toLowerCase() + '.zwave', tools.appName.toLowerCase() + '.amazon-dash', tools.appName.toLowerCase() + '.xbox'];
@@ -1542,42 +1543,63 @@ function Install(options) {
      * @param {() => any} callback
      */
     function(url, name, callback) {
-        // try to fix URL
-        if (url.match(/^https:\/\/github\.com\//)) {
-            url = url.replace(/\.git$/, '');
-            if (!url.match(/\.zip$/) && !url.match(/\.gz$/) && !url.match(tarballRegex)) {
-                if (url.endsWith('/')) {
-                    url = url.substring(0, url.length -1);
-                }
-                const githubParts = url.match(/^https:\/\/github\.com\/([^/]+\/[^/]+)\/?.*$/);
-                if (githubParts && githubParts[1]) {
-                    request.get({
-                        url: `http://api.github.com/repos/${githubParts[1]}/commits`,
+        // If the user provided an URL, try to parse it into known ways to represent a Github URL
+        let parsedUrl;
+        try {
+            parsedUrl = new URL(url);
+        } catch { /* ignore, not a valid URL */ }
+
+        if (parsedUrl && parsedUrl.hostname === 'github.com') {
+            if (!tools.isGithubPathname(parsedUrl.pathname)) {
+                console.log(`Cannot install from GitHub. Invalid URL ${url}`);
+                return void tools.maybeCallback(callback);
+            }
+
+            // This is a URL we can parse
+            const { repo, user, commit } = tools.parseGithubPathname(parsedUrl.pathname);
+
+            if (!commit) {
+                // No commit given, try to get it from the API
+                request.get(
+                    {
+                        url: `http://api.github.com/repos/${user}/${repo}/commits`,
                         json: true,
-                        headers: {'User-Agent': 'ioBroker Adapter install'}
-                    }, (err, res, data) => {
+                        headers: { 'User-Agent': 'ioBroker Adapter install' }
+                    },
+                    (err, res, data) => {
                         if (err) {
                             console.log(`Info: Can not get current GitHub commit, only remember that we installed from GitHub: ${err}`);
                             // Install using the npm Github URL syntax `npm i user/repo_name`:
-                            return void that.installAdapterFromUrl(githubParts[1], name, callback);
+                            return void that.installAdapterFromUrl(`${user}/${repo}`, name, callback);
                         } else if (res.statusCode !== 200) {
-                            console.log(`Info: Can not get current GitHub commit, only remember that we installed from GitHub. Status: ${res.statusCode}${data && data.message ? ` (${data.message})` : ''}`);
+                            console.log(
+                                `Info: Can not get current GitHub commit, only remember that we installed from GitHub. Status: ${res.statusCode
+                                }${data && data.message
+                                    ? ` (${data.message})`
+                                    : ''
+                                }`
+                            );
                             // Install using the npm Github URL syntax `npm i user/repo_name`:
-                            return void that.installAdapterFromUrl(githubParts[1], name, callback);
-                        } else if (data && Array.isArray(data) && data.length >= 1 && data[0].sha) {
+                            return void that.installAdapterFromUrl(`${user}/${repo}`, name, callback);
+                        } else if (
+                            data &&
+                            Array.isArray(data) &&
+                            data.length >= 1 &&
+                            data[0].sha
+                        ) {
                             // Install using the npm Github URL syntax `npm i user/repo_name#commit-ish`:
-                            return void that.installAdapterFromUrl(`${githubParts[1]}#${data[0].sha}`, name, callback);
+                            return void that.installAdapterFromUrl(`${user}/${repo}#${data[0].sha}`, name, callback);
                         } else {
                             console.log('Info: Can not get current GitHub commit, only remember that we installed from GitHub. No SHA available');
                             // Install using the npm Github URL syntax `npm i user/repo_name`:
-                            return void that.installAdapterFromUrl(githubParts[1], name, callback);
+                            return void that.installAdapterFromUrl(`${user}/${repo}`, name, callback);
                         }
-                    });
-                    return;
-                } else {
-                    console.log(`Cannot install from GitHub. Invalid URL ${url}`);
-                    return void tools.maybeCallback(callback);
-                }
+                    }
+                );
+                return;
+            } else {
+                // We've extracted all we need from the URL
+                return void that.installAdapterFromUrl(`${user}/${repo}#${commit}`, name, callback);
             }
         }
         console.log(`install ${url}`);

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -2384,7 +2384,7 @@ function parseShortGithubUrl(url) {
 const githubPathnameRegex = /^\/(?<user>[^/]+)\/(?<repo>[^/]*?)(?:\.git)?(?:\/(?:tree|tarball|archive)\/(?<commit>[^/]*?)(?:\.(?:zip|gz))?)?$/;
 
 /**
- * Tests if the given pathname matches the format /<githubname>/<githubrepo>/<"tarball" or "tree">/<commit-ish>
+ * Tests if the given pathname matches the format /<githubname>/<githubrepo>[.git][/<tarball|tree|archive>/<commit-ish>[.zip|.gz]]
  * @param {string} pathname The pathname part of a Github URL
  */
 function isGithubPathname(pathname) {
@@ -2392,7 +2392,7 @@ function isGithubPathname(pathname) {
 }
 
 /**
- * Tries to a github pathname format /<githubname>/<githubrepo>/<"tarball" or "tree">/<commit-ish> into its separate parts
+ * Tries to a github pathname format /<githubname>/<githubrepo>[.git][/<tarball|tree|archive>/<commit-ish>[.zip|.gz]] into its separate parts
  * @param {string} pathname The pathname part of a Github URL
  * @returns {{user: string; repo: string; commit: string} | null}
  */

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -2408,7 +2408,6 @@ function parseGithubPathname(pathname) {
     };
 }
 
-
 /**
  * Removes properties which are given by preserve
  * @param {object} preserve - object which has true entries for all attributes which should be removed from currObj

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -2352,6 +2352,7 @@ async function resolveAdapterMainFile(adapter) {
     throw new Error(`Could not find main file of ${adapter}`);
 }
 
+/** This is used for the short github URL format that NPM accepts (<githubname>/<githubrepo>[#<commit-ish>]) */
 const shortGithubUrlRegex = /^(?<user>[^/]+)\/(?<repo>[^#]+)(?:#(?<commit>.+))?$/;
 
 /**
@@ -2378,6 +2379,35 @@ function parseShortGithubUrl(url) {
         commit: match.groups.commit
     };
 }
+
+/** This is used to parse the pathname of a github URL */
+const githubPathnameRegex = /^\/(?<user>[^/]+)\/(?<repo>[^/]*?)(?:\.git)?(?:\/(?:tree|tarball|archive)\/(?<commit>[^/]*?)(?:\.(?:zip|gz))?)?$/;
+
+/**
+ * Tests if the given pathname matches the format /<githubname>/<githubrepo>/<"tarball" or "tree">/<commit-ish>
+ * @param {string} pathname The pathname part of a Github URL
+ */
+function isGithubPathname(pathname) {
+    return githubPathnameRegex.test(pathname);
+}
+
+/**
+ * Tries to a github pathname format /<githubname>/<githubrepo>/<"tarball" or "tree">/<commit-ish> into its separate parts
+ * @param {string} pathname The pathname part of a Github URL
+ * @returns {{user: string; repo: string; commit: string} | null}
+ */
+function parseGithubPathname(pathname) {
+    const match = githubPathnameRegex.exec(pathname);
+    if (!match || !match.groups) {
+        return null;
+    }
+    return {
+        user: match.groups.user,
+        repo: match.groups.repo,
+        commit: match.groups.commit
+    };
+}
+
 
 /**
  * Removes properties which are given by preserve
@@ -2750,6 +2780,8 @@ module.exports = {
     pipeLinewise,
     isShortGithubUrl,
     parseShortGithubUrl,
+    isGithubPathname,
+    parseGithubPathname,
     removePreservedProperties,
     FORBIDDEN_CHARS,
     getLogger,


### PR DESCRIPTION
With this PR, the `iobroker url` command now also parses the following URL types correctly:
| input | output |
|---|---|
| `http(s)://(www.)github.com/username/ioBroker.reponame/archive/master.zip` | `username/ioBroker.reponame#master` |
| `http(s)://(www.)github.com/username/ioBroker.reponame/tarball/1.3.0` | `username/ioBroker.reponame#1.3.0` |
| `http(s)://(www.)github.com/username/ioBroker.reponame/tree/asbfasfsdf` | `username/ioBroker.reponame#asbfasfsdf` |
| `http(s)://(www.)github.com/username/ioBroker.reponame.git` | `username/ioBroker.reponame` |

If the commit/branch is missing, it still gets retrieved using the Github API.