### PR TITLE
Support executing TypeScript adapters

### DIFF
--- a/lib/cli/cliDebug.js
+++ b/lib/cli/cliDebug.js
@@ -47,6 +47,7 @@ module.exports = class CLICompact extends CLICommand {
         const adapterArgs = [instance || '0', '--debug'];
         // Tell node to attach a debugger
         const nodeArgs = [
+            ...tools.getDefaultNodeArgs(mainFile),
             // --inspect[-brk][=[ip]:[port]]
             `--inspect${params.wait ? '-brk' : ''}${
                 !!params.ip || !!params.port ? '=' : ''

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -2359,7 +2359,7 @@ async function resolveAdapterMainFile(adapter) {
  */
 function getDefaultNodeArgs(mainFile) {
     if (mainFile.endsWith('.ts')) {
-        return ['-r', 'ts-node/register/transpile-only'];
+        return ['-r', 'esbuild-register'];
     }
     return [];
 }

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -2352,6 +2352,18 @@ async function resolveAdapterMainFile(adapter) {
     throw new Error(`Could not find main file of ${adapter}`);
 }
 
+/**
+ * Returns the default nodeArgs required to execute the main file, e.g. transpile hooks for TypeScript
+ * @param {string} mainFile
+ * @returns {string[]}
+ */
+function getDefaultNodeArgs(mainFile) {
+    if (mainFile.endsWith('.ts')) {
+        return ['-r', 'ts-node/register/transpile-only'];
+    }
+    return [];
+}
+
 /** This is used for the short github URL format that NPM accepts (<githubname>/<githubrepo>[#<commit-ish>]) */
 const shortGithubUrlRegex = /^(?<user>[^/]+)\/(?<repo>[^#]+)(?:#(?<commit>.+))?$/;
 
@@ -2752,6 +2764,7 @@ module.exports = {
     getCertificateInfo,
     getConfigFileName,
     getDefaultDataDir,
+    getDefaultNodeArgs,
     getFile,
     getHostInfo,
     getHostName,

--- a/main.js
+++ b/main.js
@@ -3627,11 +3627,10 @@ async function startInstance(id, wakeUp) {
                                     decache = decache || require('decache');
                                     decache(fileNameFull);
 
-                                    // Prior to requiring the main file make sure that ts-node has its hook registered
+                                    // Prior to requiring the main file make sure that the esbuild require hook was loaded
                                     // if this is a TypeScript adapter
                                     if (fileNameFull.endsWith('.ts')) {
-                                        require('ts-node/register/transpile-only');
-                                        process.env.TS_NODE_CWD = adapterDir;
+                                        require('esbuild-register');
                                     }
 
                                     procs[id].process = {

--- a/main.js
+++ b/main.js
@@ -48,7 +48,6 @@ let States;
 let decache;
 
 const semver                = require('semver');
-const { cwd } = require('process');
 let logger;
 let isDaemon                = false;
 let callbackId              = 1;

--- a/package-lock.json
+++ b/package-lock.json
@@ -615,6 +615,11 @@
       "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
       "dev": true
     },
+    "arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA=="
+    },
     "argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -1405,6 +1410,11 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
+    "create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ=="
+    },
     "cron-parser": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-3.1.0.tgz",
@@ -1614,8 +1624,7 @@
     "diff": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-      "dev": true
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A=="
     },
     "diskusage": {
       "version": "1.1.3",
@@ -4852,6 +4861,11 @@
       "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.26.0.tgz",
       "integrity": "sha512-+V5QIQ5f6CDXQpWNICELwjwuHdqeJM1UenlZWx5ujcRMc9venvluCjFb4t5NYLhb6IhkbMVOxzVuOqkgMxee2A=="
     },
+    "make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
+    },
     "make-iterator": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/make-iterator/-/make-iterator-1.0.1.tgz",
@@ -7090,6 +7104,19 @@
       "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.3.0.tgz",
       "integrity": "sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw=="
     },
+    "ts-node": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-9.1.1.tgz",
+      "integrity": "sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==",
+      "requires": {
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "source-map-support": "^0.5.17",
+        "yn": "3.1.1"
+      }
+    },
     "tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
@@ -7844,6 +7871,11 @@
           "dev": true
         }
       }
+    },
+    "yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q=="
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -615,11 +615,6 @@
       "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
       "dev": true
     },
-    "arg": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA=="
-    },
     "argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -1410,11 +1405,6 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
-    "create-require": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ=="
-    },
     "cron-parser": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-3.1.0.tgz",
@@ -1624,7 +1614,8 @@
     "diff": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A=="
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true
     },
     "diskusage": {
       "version": "1.1.3",
@@ -1847,6 +1838,22 @@
         "es5-ext": "^0.10.46",
         "es6-iterator": "^2.0.3",
         "es6-symbol": "^3.1.1"
+      }
+    },
+    "esbuild": {
+      "version": "0.8.49",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.8.49.tgz",
+      "integrity": "sha512-itiFVYv5UZz4NooO7/Y0bRGVDGz/M/cxKbl6zyNI5pnKaz1mZjvZXAFhhDVz6rGCmcdTKj5oag6rh8DaaSSmfQ=="
+    },
+    "esbuild-register": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/esbuild-register/-/esbuild-register-2.0.0.tgz",
+      "integrity": "sha512-98i1+7OnCURCbKaWw5wnY05e4v7uknFEER7LtVxi/lCs8U+sl6/LnITvfeoDLrsqxlA3O6BjxK8QqsirfYULfA==",
+      "requires": {
+        "joycon": "^2.2.5",
+        "pirates": "^4.0.1",
+        "source-map-support": "^0.5.19",
+        "strip-json-comments": "^3.1.1"
       }
     },
     "escalade": {
@@ -4310,6 +4317,11 @@
         "textextensions": "2"
       }
     },
+    "joycon": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/joycon/-/joycon-2.2.5.tgz",
+      "integrity": "sha512-YqvUxoOcVPnCp0VU1/56f+iKSdvIRJYPznH22BdXV3xMk75SFXhWeJkZ8C9XxUWt1b5x2X1SxuFygW1U0FmkEQ=="
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -4861,11 +4873,6 @@
       "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.26.0.tgz",
       "integrity": "sha512-+V5QIQ5f6CDXQpWNICELwjwuHdqeJM1UenlZWx5ujcRMc9venvluCjFb4t5NYLhb6IhkbMVOxzVuOqkgMxee2A=="
     },
-    "make-error": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
-    },
     "make-iterator": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/make-iterator/-/make-iterator-1.0.1.tgz",
@@ -5401,6 +5408,11 @@
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
       "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA=="
     },
+    "node-modules-regexp": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz",
+      "integrity": "sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA="
+    },
     "node-schedule": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/node-schedule/-/node-schedule-2.0.0.tgz",
@@ -5842,6 +5854,14 @@
       "dev": true,
       "requires": {
         "pinkie": "^2.0.0"
+      }
+    },
+    "pirates": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.1.tgz",
+      "integrity": "sha512-WuNqLTbMI3tmfef2TKxlQmAiLHKtFhlsCZnPIpuv2Ow0RDVO8lfy1Opf4NUzlMXLjPl+Men7AuVdX6TA+s+uGA==",
+      "requires": {
+        "node-modules-regexp": "^1.0.0"
       }
     },
     "posix-character-classes": {
@@ -6858,8 +6878,7 @@
     "strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-      "dev": true
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="
     },
     "supports-color": {
       "version": "5.5.0",
@@ -7103,19 +7122,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.3.0.tgz",
       "integrity": "sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw=="
-    },
-    "ts-node": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-9.1.1.tgz",
-      "integrity": "sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==",
-      "requires": {
-        "arg": "^4.1.0",
-        "create-require": "^1.1.0",
-        "diff": "^4.0.1",
-        "make-error": "^1.1.1",
-        "source-map-support": "^0.5.17",
-        "yn": "3.1.1"
-      }
     },
     "tslib": {
       "version": "1.14.1",
@@ -7871,11 +7877,6 @@
           "dev": true
         }
       }
-    },
-    "yn": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,12 +18,12 @@
     "iobroker": "./iobroker.js"
   },
   "dependencies": {
+    "@iobroker/db-objects-file": "~1.1.4",
+    "@iobroker/db-objects-redis": "~1.1.4",
+    "@iobroker/db-states-file": "~1.1.4",
+    "@iobroker/db-states-redis": "~1.1.4",
     "@iobroker/plugin-base": "~1.2.1",
     "@iobroker/plugin-sentry": "~1.1.10",
-    "@iobroker/db-states-redis": "~1.1.4",
-    "@iobroker/db-states-file": "~1.1.4",
-    "@iobroker/db-objects-redis": "~1.1.4",
-    "@iobroker/db-objects-file": "~1.1.4",
     "chokidar": "^3.5.1",
     "daemonize2": "^0.4.2",
     "debug": "^4.3.1",
@@ -46,6 +46,7 @@
     "request": "^2.88.2",
     "semver": "^7.3.4",
     "tar": "^6.1.0",
+    "ts-node": "^9.1.1",
     "winston": "^3.3.3",
     "winston-daily-rotate-file": "^4.5.0",
     "yargs": "^16.2.0"

--- a/package.json
+++ b/package.json
@@ -29,6 +29,8 @@
     "debug": "^4.3.1",
     "decache": "^4.6.0",
     "deep-clone": "^3.0.3",
+    "esbuild": "^0.8.49",
+    "esbuild-register": "^2.0.0",
     "event-stream": "^4.0.1",
     "fs-extra": "^9.1.0",
     "jsonwebtoken": "^8.5.1",
@@ -46,7 +48,6 @@
     "request": "^2.88.2",
     "semver": "^7.3.4",
     "tar": "^6.1.0",
-    "ts-node": "^9.1.1",
     "winston": "^3.3.3",
     "winston-daily-rotate-file": "^4.5.0",
     "yargs": "^16.2.0"


### PR DESCRIPTION
This PR adds support for executing TypeScript adapters (where `main` has a `.ts` extension). We achieve this by
1.) adding a transpile hook to the node executable path, which transpiles TypeScript on the fly with `esbuild` (which is much much faster than any transpiler out there). Note that this uses an unofficial extension for `esbuild` - we should keep an eye out what happens in https://github.com/evanw/esbuild/issues/148
2.) in compact mode by requiring the hook manually in case it was not loaded prior.

Since TypeScript transpilers react pretty stubborn if the `cwd` is not the adapter dir, because they need access to tsconfig.json, I've also made sure to always set it to the adapter dir. This shouldn't hurt existing adapter, at least the admin didn't complain.
 
I've tested the daemon mode with zwave2, which also loads the serialport module without problems.
Compact mode is untested, this could result in problems because of the `cwd` limitation.

fixes: #1236 