### PR TITLE
fix: understand .tar.gz as a valid extension for github URLs

### DIFF
--- a/lib/setup/setupInstall.js
+++ b/lib/setup/setupInstall.js
@@ -1599,7 +1599,7 @@ function Install(options) {
 
         // Try to extract name from URL
         if (!name) {
-            if (url.match(/\.tgz$|\.zip/)) {
+            if (url.match(/\.(tgz|gz|zip|tar\.gz)$/)) {
                 const parts = url.split('/');
                 const last = parts.pop();
                 const mm = last.match(/\.([-_\w\d]+)-[.\d]+/);

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -2393,7 +2393,7 @@ function parseShortGithubUrl(url) {
 }
 
 /** This is used to parse the pathname of a github URL */
-const githubPathnameRegex = /^\/(?<user>[^/]+)\/(?<repo>[^/]*?)(?:\.git)?(?:\/(?:tree|tarball|archive)\/(?<commit>.*?)(?:\.(?:zip|gz))?)?$/;
+const githubPathnameRegex = /^\/(?<user>[^/]+)\/(?<repo>[^/]*?)(?:\.git)?(?:\/(?:tree|tarball|archive)\/(?<commit>.*?)(?:\.(?:zip|gz|tar\.gz))?)?$/;
 
 /**
  * Tests if the given pathname matches the format /<githubname>/<githubrepo>[.git][/<tarball|tree|archive>/<commit-ish>[.zip|.gz]]
@@ -2404,7 +2404,7 @@ function isGithubPathname(pathname) {
 }
 
 /**
- * Tries to a github pathname format /<githubname>/<githubrepo>[.git][/<tarball|tree|archive>/<commit-ish>[.zip|.gz]] into its separate parts
+ * Tries to a github pathname format /<githubname>/<githubrepo>[.git][/<tarball|tree|archive>/<commit-ish>[.zip|.gz|.tar.gz]] into its separate parts
  * @param {string} pathname The pathname part of a Github URL
  * @returns {{user: string; repo: string; commit: string} | null}
  */


### PR DESCRIPTION
fixes: #1256