### PR TITLE
pass the renew arg to greenlock

### DIFF
--- a/lib/letsencrypt.js
+++ b/lib/letsencrypt.js
@@ -61,6 +61,7 @@ async function createServerAsync(app, settings, certificates, leSettings, log, a
         maintainerEmail: leSettings.email,
         cluster: false,
         packageAgent: pkg.name + '/' + pkg.version,
+        renew: settings.leUpdate,
         notify: (ev, params) => {
             switch (ev) {
                 case 'warning':
@@ -177,7 +178,7 @@ async function createServerAsync(app, settings, certificates, leSettings, log, a
  * @param leSettings
  * @param log
  * @deprecated
- * @returns {Server}
+ * @returns {object}
  */
 function createServer(app, settings, certificates, leSettings, log) {
     let server;


### PR DESCRIPTION
- should fix #1284
- Greenlock explicitly checks for `false` if any other falsy value is passed it assumes to update. However, it seems that we need the arg to be passed to Greenlock for both cases if update desired and if no update desired