### PR TITLE
fixes for strict object checks

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -1748,13 +1748,19 @@ function Adapter(options) {
                     if (state.val !== null) {
                         // now check if type is correct, null is always allowed
                         // types can be 'number', 'string', 'boolean', 'array', 'object', 'mixed', 'file', 'json'
+                        // array, object, file, json need to be string
                         if (!(obj.common.type === 'mixed' ||
                             obj.common.type === typeof state.val ||
-                            obj.common.type === 'array' && Array.isArray(state.val) ||
+                            obj.common.type === 'array' && typeof state.val === 'string' ||
                             obj.common.type === 'json' && typeof state.val === 'string' ||
-                            obj.common.type === 'file' && typeof state.val === 'object')
+                            obj.common.type === 'file' && typeof state.val === 'string' ||
+                            obj.common.type === 'object' && typeof state.val === 'string')
                         ) {
-                            logger.warn(`${this.namespaceLog} State value to set for "${id}" has wrong type "${typeof state.val}" but has to be "${obj.common.type}"`);
+                            if (['object', 'json', 'file', 'array'].includes(obj.common.type)) {
+                                logger.warn(`${this.namespaceLog} State value to set for "${id}" has wrong type "${typeof state.val}" but has to be "string"`);
+                            } else {
+                                logger.warn(`${this.namespaceLog} State value to set for "${id}" has wrong type "${typeof state.val}" but has to be "${obj.common.type}"`);
+                            }
                         }
 
                         // now round step and check min/max if it's a number

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -1731,6 +1731,10 @@ function Adapter(options) {
             // TODO: in js-c 3.5 (or 2 releases after 3.3) we should let it throw and add tests, maybe we
             // can already let the non existing object case throw with 3.4 because this is already producing a warning
             try {
+                if (Object.keys(state).length === 1 && Object.prototype.hasOwnProperty.call(state, 'ack')) {
+                    // only ack is also possible to acknowledge the current value
+                    return;
+                }
                 const obj = await adapterObjects.getObjectAsync(id);
                 // at first check object existence
                 if (!obj) {


### PR DESCRIPTION
- everything which could be type object has to be a string
- we allow the only ack-flag case