### PR TITLE
fix: use resolveAdapterMainFile for adapter startup

### DIFF
--- a/main.js
+++ b/main.js
@@ -3203,7 +3203,6 @@ async function startInstance(id, wakeUp) {
             });
     }
 
-    let fileName = instance.common.main || 'main.js';
     const adapterDir = tools.getAdapterDir(name);
     if (!fs.existsSync(adapterDir)) {
         procs[id].downloadRetry = procs[id].downloadRetry || 0;
@@ -3230,18 +3229,18 @@ async function startInstance(id, wakeUp) {
         args.push(`--max-old-space-size=${parseInt(instance.common.memoryLimitMB, 10)}`);
     }
 
-    let fileNameFull = path.join(adapterDir, fileName);
-
     // workaround for old vis.
     if (instance.common.onlyWWW && name === 'vis') {
         instance.common.onlyWWW = false;
     }
 
-    if (instance.common.mode !== 'extension' && (instance.common.onlyWWW || !fs.existsSync(fileNameFull))) {
-        fileName = name + '.js';
-        fileNameFull = path.join(adapterDir, fileName);
-        if (instance.common.onlyWWW || !fs.existsSync(fileNameFull)) {
-            // If not just www files
+    let adapterMainFile;
+    try {
+        adapterMainFile = await tools.resolveAdapterMainFile(name);
+    } catch {
+        // The main file was not found or doesn't exist. Doesn't matter for extensions.
+        // TODO: explain why it does not matter!
+        if (instance.common.mode !== 'extension') {
             if (instance.common.onlyWWW || fs.existsSync(path.join(adapterDir, 'www'))) {
                 logger.debug(`${hostLogPrefix} startInstance ${name}.${args[0]} only WWW files. Nothing to start`);
             } else {
@@ -3565,8 +3564,8 @@ async function startInstance(id, wakeUp) {
                     }
                     if (!procs[id].process) { // We were not able or should not start as compact mode
                         try {
-                            procs[id].process = cp.fork(fileNameFull, args, {
-                                execArgv: tools.getDefaultNodeArgs(fileNameFull),
+                            procs[id].process = cp.fork(adapterMainFile, args, {
+                                execArgv: tools.getDefaultNodeArgs(adapterMainFile),
                                 stdio: ['ignore', 'ignore', 'pipe', 'ipc'],
                                 windowsHide: true,
                                 cwd: adapterDir
@@ -3633,19 +3632,19 @@ async function startInstance(id, wakeUp) {
                         states.setState(id + '.sigKill', {val: 0, ack: false, from: hostObjectPrefix}, () => {
                             const _instance = (instance && instance._id && instance.common) ? instance._id.split('.').pop() || 0 : 0;
                             const logLevel = (instance && instance._id && instance.common) ? instance.common.loglevel || 'info' : 'info';
-                            if (fileNameFull) {
+                            if (adapterMainFile) {
                                 try {
                                     decache = decache || require('decache');
-                                    decache(fileNameFull);
+                                    decache(adapterMainFile);
 
                                     // Prior to requiring the main file make sure that the esbuild require hook was loaded
                                     // if this is a TypeScript adapter
-                                    if (fileNameFull.endsWith('.ts')) {
+                                    if (adapterMainFile.endsWith('.ts')) {
                                         require('esbuild-register');
                                     }
 
                                     procs[id].process = {
-                                        logic: require(fileNameFull)({
+                                        logic: require(adapterMainFile)({
                                             logLevel,
                                             compactInstance: _instance,
                                             compact: true
@@ -3858,7 +3857,7 @@ async function startInstance(id, wakeUp) {
             procs[id].schedule = schedule.scheduleJob(instance.common.schedule, () => {
                 // queue up, but only if not already queued
                 scheduledInstances[id] = {
-                    fileNameFull,
+                    fileNameFull: adapterMainFile,
                     adapterDir,
                     wakeUp
                 };
@@ -3869,8 +3868,8 @@ async function startInstance(id, wakeUp) {
             //noinspection JSUnresolvedVariable
             if (instance.common.allowInit) {
                 try {
-                    procs[id].process = cp.fork(fileNameFull, args, {
-                        execArgv: tools.getDefaultNodeArgs(fileNameFull),
+                    procs[id].process = cp.fork(adapterMainFile, args, {
+                        execArgv: tools.getDefaultNodeArgs(adapterMainFile),
                         windowsHide: true,
                         cwd: adapterDir
                     });


### PR DESCRIPTION
We deprecated `main` in `io-package.json`, but the adapter startup code was still looking for it instead of using `tools.resolveAdapterMainFile`.

This PR fixes that and cleans up the duplicate logic a bit.