### PR TITLE
Add custom view as standard

### DIFF
--- a/io-package.json
+++ b/io-package.json
@@ -295,12 +295,24 @@
                 },
                 "config": {
                     "map": "function(doc) { if (doc.type === 'config') emit(doc.common.name, doc) }"
+                },
+                "custom": {
+                    "map": "function(doc) { doc.type === 'state' && doc.common && doc.common.custom && emit(doc._id, doc.common.custom) }"
                 }
             },
             "acl": {
                 "owner": "system.user.admin",
                 "ownerGroup": "system.group.administrator",
                 "object": 1092
+            }
+        },
+        {
+            "_id": "_design/custom",
+            "language": "javascript",
+            "views": {
+                "state": {
+                    "map": "function(doc) { doc.type === 'state' && doc.common && doc.common.custom && emit(doc._id, doc.common.custom) }"
+                }
             }
         },
         {


### PR DESCRIPTION
Anyway many adapters like history, influx, sql, upnp, mqtt-client, ... must add this view and we can only hope, that the definition is everywhere the same.. It is better to add such a view from the very first install.