### PR TITLE
fix: use modified version of esbuild-register to not ignore .ts files in node_modules

### DIFF
--- a/lib/tools.js
+++ b/lib/tools.js
@@ -2366,7 +2366,7 @@ async function resolveAdapterMainFile(adapter) {
  */
 function getDefaultNodeArgs(mainFile) {
     if (mainFile.endsWith('.ts')) {
-        return ['-r', 'esbuild-register'];
+        return ['-r', '@alcalzone/esbuild-register'];
     }
     return [];
 }

--- a/main.js
+++ b/main.js
@@ -3662,7 +3662,7 @@ async function startInstance(id, wakeUp) {
                                     // Prior to requiring the main file make sure that the esbuild require hook was loaded
                                     // if this is a TypeScript adapter
                                     if (adapterMainFile.endsWith('.ts')) {
-                                        require('esbuild-register');
+                                        require('@alcalzone/esbuild-register');
                                     }
 
                                     procs[id].process = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,15 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@alcalzone/esbuild-register": {
+      "version": "2.5.1-1",
+      "resolved": "https://registry.npmjs.org/@alcalzone/esbuild-register/-/esbuild-register-2.5.1-1.tgz",
+      "integrity": "sha512-u19/K/ZaiWQhYIQZeF2FImUeJDiMD4i2h7qPdU0HVFCxoQynye59N4oy6EvjxeXaxLnGkppcb5KKeiYD4cT1iQ==",
+      "requires": {
+        "esbuild": "^0.11.5",
+        "jsonc-parser": "^3.0.0"
+      }
+    },
     "@alcalzone/jsonl-db": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/@alcalzone/jsonl-db/-/jsonl-db-1.2.4.tgz",
@@ -1918,25 +1927,9 @@
       }
     },
     "esbuild": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.12.1.tgz",
-      "integrity": "sha512-WfQ00MKm/Y4ysz1u9PCUAsV66k5lbrcEvS6aG9jhBIavpB94FBdaWeBkaZXxCZB4w+oqh+j4ozJFWnnFprOXbg=="
-    },
-    "esbuild-register": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/esbuild-register/-/esbuild-register-2.5.0.tgz",
-      "integrity": "sha512-5a8W3rH7IQbIPR9pPXJFkC3+CRMtm/OSpBz3hkWUUU63oPZ3NU6dVDGfaIjKnRizCTIRoGjNE6KEDt5p1sLwEw==",
-      "requires": {
-        "esbuild": "^0.11.5",
-        "jsonc-parser": "^3.0.0"
-      },
-      "dependencies": {
-        "esbuild": {
-          "version": "0.11.23",
-          "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.11.23.tgz",
-          "integrity": "sha512-iaiZZ9vUF5wJV8ob1tl+5aJTrwDczlvGP0JoMmnpC2B0ppiMCu8n8gmy5ZTGl5bcG081XBVn+U+jP+mPFm5T5Q=="
-        }
-      }
+      "version": "0.11.23",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.11.23.tgz",
+      "integrity": "sha512-iaiZZ9vUF5wJV8ob1tl+5aJTrwDczlvGP0JoMmnpC2B0ppiMCu8n8gmy5ZTGl5bcG081XBVn+U+jP+mPFm5T5Q=="
     },
     "escalade": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "iobroker": "./iobroker.js"
   },
   "dependencies": {
+    "@alcalzone/esbuild-register": "^2.5.1-1",
     "@iobroker/db-objects-file": "~1.2.6",
     "@iobroker/db-objects-jsonl": "~1.2.6",
     "@iobroker/db-objects-redis": "~1.2.6",
@@ -31,8 +32,6 @@
     "debug": "^4.3.1",
     "decache": "^4.6.0",
     "deep-clone": "^3.0.3",
-    "esbuild": "^0.12.1",
-    "esbuild-register": "^2.5.0",
     "event-stream": "^4.0.1",
     "fs-extra": "^9.1.0",
     "jsonwebtoken": "^8.5.1",


### PR DESCRIPTION
As discussed earlier - it turned out that `esbuild-register` does not transpile files that are inside `node_modules`. I've released a patched version that allows the input files to be inside `node_modules` but ignores non-TS files.