### PR TITLE
Change tests to actually use a separate process to not bypass parsing of arguments

### DIFF
--- a/lib/setup.js
+++ b/lib/setup.js
@@ -2887,16 +2887,6 @@ function dbConnect(onlyCheck, params, callback) {
     });
 }
 
-module.exports.processCommand = function (_objects, _states, command, args, params, callback) {
-    objects = _objects;
-    states  = _states;
-    processCommand(command, args, params, callback);
-};
-const processCommandAsync = tools.promisifyNoError(module.exports.processCommand);
-module.exports.processCommandAsync = function (_objects, _states, _command, _args, _params) {
-    return processCommandAsync.apply(undefined, arguments);
-};
-
 module.exports.execute = function () {
     // direct call
     const _yargs = initYargs();

--- a/lib/setup/setupBackup.js
+++ b/lib/setup/setupBackup.js
@@ -231,7 +231,7 @@ class BackupRestore {
                 ('0' + d.getSeconds()    ).slice(-2) + '_backup' + tools.appName;
         }
 
-        name = name.replace(/\\/g, '/');
+        name = name.toString().replace(/\\/g, '/');
         if (name.indexOf('/') === -1) {
             const path = this.getBackupDir();
 

--- a/test/lib/setup4controller.js
+++ b/test/lib/setup4controller.js
@@ -34,11 +34,12 @@ function startController(options, callback) {
 
     console.log('startController...');
 
-    // adjust db for the cli
+    // adjust db for the cli tests
     const iobrokerJSON = fs.readJSONSync(path.join(rootDir, 'data', 'iobroker.json'));
     iobrokerJSON.objects.type = options.objects.type || 'file';
     iobrokerJSON.objects.port = (options.objects.port === undefined) ? 19001 : options.objects.port;
     iobrokerJSON.objects.host = options.objects.host || '127.0.0.1';
+    iobrokerJSON.objects.redisNamespace = options.objects.redisNamespace || '';
     iobrokerJSON.states.type = options.states.type || 'file';
     iobrokerJSON.states.port = (options.states.port === undefined) ? 19001 : options.objects.port;
     iobrokerJSON.states.host = options.states.host || '127.0.0.1';

--- a/test/lib/setup4controller.js
+++ b/test/lib/setup4controller.js
@@ -34,6 +34,16 @@ function startController(options, callback) {
 
     console.log('startController...');
 
+    // adjust db for the cli
+    const iobrokerJSON = fs.readJSONSync(path.join(rootDir, 'data', 'iobroker.json'));
+    iobrokerJSON.objects.type = options.objects.type || 'file';
+    iobrokerJSON.objects.port = (options.objects.port === undefined) ? 19001 : options.objects.port;
+    iobrokerJSON.objects.host = options.objects.host || '127.0.0.1';
+    iobrokerJSON.states.type = options.states.type || 'file';
+    iobrokerJSON.states.port = (options.states.port === undefined) ? 19001 : options.objects.port;
+    iobrokerJSON.states.host = options.states.host || '127.0.0.1';
+    fs.writeJSONSync(path.join(rootDir, 'data', 'iobroker.json'), iobrokerJSON, {spaces: 2});
+
     const settingsObjects = {
         connection: {
             type:               options.objects.type || 'file',

--- a/test/lib/setup4controller.js
+++ b/test/lib/setup4controller.js
@@ -41,7 +41,7 @@ function startController(options, callback) {
     iobrokerJSON.objects.host = options.objects.host || '127.0.0.1';
     iobrokerJSON.objects.redisNamespace = options.objects.redisNamespace || '';
     iobrokerJSON.states.type = options.states.type || 'file';
-    iobrokerJSON.states.port = (options.states.port === undefined) ? 19001 : options.objects.port;
+    iobrokerJSON.states.port = (options.states.port === undefined) ? 19000 : options.states.port;
     iobrokerJSON.states.host = options.states.host || '127.0.0.1';
     fs.writeJSONSync(path.join(rootDir, 'data', 'iobroker.json'), iobrokerJSON, {spaces: 2});
 

--- a/test/lib/testConsole.js
+++ b/test/lib/testConsole.js
@@ -39,36 +39,36 @@ function register(it, expect, context) {
     it(testName + 'user passwd', async () => {
         let res;
 
-        res = await cpPromise.exec(`${process.execPath} ${iobExecutable} passwd admin --password ${context.appName.toLowerCase()}`);
+        res = await cpPromise.exec(`"${process.execPath}" "${iobExecutable}" passwd admin --password ${context.appName.toLowerCase()}`);
         expect(res.stderr).to.be.not.ok;
 
         // check password
-        res = await cpPromise.exec(`${process.execPath} ${iobExecutable} user check admin --password ${context.appName.toLowerCase()}`);
+        res = await cpPromise.exec(`"${process.execPath}" "${iobExecutable}" user check admin --password ${context.appName.toLowerCase()}`);
         expect(res.stderr).to.be.not.ok;
         // negative check
         try {
-            await cpPromise.exec(`${process.execPath} ${iobExecutable} user check admin --password ${`${context.appName.toLowerCase()}2`}`);
+            await cpPromise.exec(`"${process.execPath}" "${iobExecutable}" user check admin --password ${`${context.appName.toLowerCase()}2`}`);
             expect(true, 'should throw').to.be.false;
         } catch {
             // ok
         }
         // set new password
-        res = await cpPromise.exec(`${process.execPath} ${iobExecutable} user passwd admin --password ${`${context.appName.toLowerCase()}1`}`);
+        res = await cpPromise.exec(`"${process.execPath}" "${iobExecutable}" user passwd admin --password ${`${context.appName.toLowerCase()}1`}`);
         expect(res.stderr).to.be.not.ok;
         // check new Password
-        res = await cpPromise.exec(`${process.execPath} ${iobExecutable} user check admin --password ${`${context.appName.toLowerCase()}1`}`);
+        res = await cpPromise.exec(`"${process.execPath}" "${iobExecutable}" user check admin --password ${`${context.appName.toLowerCase()}1`}`);
         expect(res.stderr).to.be.not.ok;
 
         // set password back
-        res = await cpPromise.exec(`${process.execPath} ${iobExecutable} user passwd admin --password ${`${context.appName.toLowerCase()}`}`);
+        res = await cpPromise.exec(`"${process.execPath}" "${iobExecutable}" user passwd admin --password ${`${context.appName.toLowerCase()}`}`);
         expect(res.stderr).to.be.not.ok;
         // check password
-        res = await cpPromise.exec(`${process.execPath} ${iobExecutable} user check admin --password ${`${context.appName.toLowerCase()}`}`);
+        res = await cpPromise.exec(`"${process.execPath}" "${iobExecutable}" user check admin --password ${`${context.appName.toLowerCase()}`}`);
         expect(res.stderr).to.be.not.ok;
 
         // set password for non existing user
         try {
-            await cpPromise.exec(`${process.execPath} ${iobExecutable} user passwd uuuser --password ${`${context.appName.toLowerCase()}1`}`);
+            await cpPromise.exec(`"${process.execPath}" "${iobExecutable}" user passwd uuuser --password ${`${context.appName.toLowerCase()}1`}`);
             expect(true, 'should throw').to.be.false;
         } catch {
             // ok
@@ -76,7 +76,7 @@ function register(it, expect, context) {
 
         // check password for non existing user
         try {
-            await cpPromise.exec(`${process.execPath} ${iobExecutable} user check uuuser --password ${`${context.appName.toLowerCase()}1`}`);
+            await cpPromise.exec(`"${process.execPath}" "${iobExecutable}" user check uuuser --password ${`${context.appName.toLowerCase()}1`}`);
             expect(true, 'should throw').to.be.false;
         } catch {
             //ok
@@ -87,7 +87,7 @@ function register(it, expect, context) {
     it(testName + 'user get', async () => {
         // check if no args set
         try {
-            await cpPromise.exec(`${process.execPath} ${iobExecutable} user`);
+            await cpPromise.exec(`"${process.execPath}" "${iobExecutable}" user`);
             expect(true, 'should throw').to.be.false;
         } catch {
             // ok
@@ -95,17 +95,17 @@ function register(it, expect, context) {
 
         // no user defined
         try {
-            await cpPromise.exec(`${process.execPath} ${iobExecutable} user get`);
+            await cpPromise.exec(`"${process.execPath}" "${iobExecutable}" user get`);
             expect(true, 'should throw').to.be.false;
         } catch {
             // ok
         }
         // check admin
-        const res = await cpPromise.exec(`${process.execPath} ${iobExecutable} user get admin`);
+        const res = await cpPromise.exec(`"${process.execPath}" "${iobExecutable}" user get admin`);
         expect(res.stderr).to.be.not.ok;
         // check invalid user
         try {
-            await cpPromise.exec(`${process.execPath} ${iobExecutable} user get aaa`);
+            await cpPromise.exec(`"${process.execPath}" "${iobExecutable}" user get aaa`);
             expect(true, 'should throw').to.be.false;
         } catch {
             // ok
@@ -117,7 +117,7 @@ function register(it, expect, context) {
         let res;
         // check if no args set
         try {
-            await cpPromise.exec(`${process.execPath} ${iobExecutable} user add`);
+            await cpPromise.exec(`"${process.execPath}" "${iobExecutable}" user add`);
             expect(true, 'should throw').to.be.false;
         } catch {
             // ok
@@ -125,19 +125,19 @@ function register(it, expect, context) {
 
         // add admin not allowed
         try {
-            await cpPromise.exec(`${process.execPath} ${iobExecutable} user add admin --password aaa`);
+            await cpPromise.exec(`"${process.execPath}" "${iobExecutable}" user add admin --password aaa`);
             expect(true, 'should throw').to.be.false;
         } catch {
             // ok
         }
 
         // add user
-        res = await cpPromise.exec(`${process.execPath} ${iobExecutable} user add newUser --password user --ingroup user`);
+        res = await cpPromise.exec(`"${process.execPath}" "${iobExecutable}" user add newUser --password user --ingroup user`);
         expect(res.stderr).to.be.not.ok;
 
         // add existing user not allowed
         try {
-            await cpPromise.exec(`${process.execPath} ${iobExecutable} user add newUser --password user`);
+            await cpPromise.exec(`"${process.execPath}" "${iobExecutable}" user add newUser --password user`);
             expect(true, 'should throw').to.be.false;
         } catch {
             // ok
@@ -145,14 +145,14 @@ function register(it, expect, context) {
 
         // add with invalid group
         try {
-            await cpPromise.exec(`${process.execPath} ${iobExecutable} user add user1 --password bbb --ingroup invalid`);
+            await cpPromise.exec(`"${process.execPath}" "${iobExecutable}" user add user1 --password bbb --ingroup invalid`);
             expect(true, 'should throw').to.be.false;
         } catch {
             // ok
         }
 
         // check adduser
-        res = await cpPromise.exec(`${process.execPath} ${iobExecutable} adduser user2 --password user --ingroup user`);
+        res = await cpPromise.exec(`"${process.execPath}" "${iobExecutable}" adduser user2 --password user --ingroup user`);
         expect(res.stderr).to.be.not.ok;
     }).timeout(20000);
 
@@ -161,28 +161,28 @@ function register(it, expect, context) {
         let res;
 
         // add second user
-        res = await cpPromise.exec(`${process.execPath} ${iobExecutable} user add user1 --password bbb --ingroup user`);
+        res = await cpPromise.exec(`"${process.execPath}" "${iobExecutable}" user add user1 --password bbb --ingroup user`);
         expect(res.stderr).to.be.not.ok;
 
         // check if no args set
         try {
-            await cpPromise.exec(`${process.execPath} ${iobExecutable} user enable`);
+            await cpPromise.exec(`"${process.execPath}" "${iobExecutable}" user enable`);
             expect(true, 'should throw').to.be.false;
         } catch {
             // ok
         }
 
         // enable admin
-        res = await cpPromise.exec(`${process.execPath} ${iobExecutable} user enable admin`);
+        res = await cpPromise.exec(`"${process.execPath}" "${iobExecutable}" user enable admin`);
         expect(res.stderr).to.be.not.ok;
 
         // test short command
-        res = await cpPromise.exec(`${process.execPath} ${iobExecutable} user e admin`);
+        res = await cpPromise.exec(`"${process.execPath}" "${iobExecutable}" user e admin`);
         expect(res.stderr).to.be.not.ok;
 
         // check invalid user
         try {
-            await cpPromise.exec(`${process.execPath} ${iobExecutable} user enable aaa`);
+            await cpPromise.exec(`"${process.execPath}" "${iobExecutable}" user enable aaa`);
             expect(true, 'should throw').to.be.false;
         } catch {
             // ok
@@ -190,18 +190,18 @@ function register(it, expect, context) {
 
         // admin cannot be disabled
         try {
-            await cpPromise.exec(`${process.execPath} ${iobExecutable} user disable admin`);
+            await cpPromise.exec(`"${process.execPath}" "${iobExecutable}" user disable admin`);
             expect(true, 'should throw').to.be.false;
         } catch {
             // ok
         }
 
         // user can be disabled
-        res = await cpPromise.exec(`${process.execPath} ${iobExecutable} user disable user1`);
+        res = await cpPromise.exec(`"${process.execPath}" "${iobExecutable}" user disable user1`);
         expect(res.stderr).to.be.not.ok;
 
         // user can be disabled
-        res = await cpPromise.exec(`${process.execPath} ${iobExecutable} user get user1`);
+        res = await cpPromise.exec(`"${process.execPath}" "${iobExecutable}" user get user1`);
         expect(res.stderr).to.be.not.ok;
     }).timeout(20000);
 
@@ -210,31 +210,31 @@ function register(it, expect, context) {
         let res;
         // check if no args set
         try {
-            await cpPromise.exec(`${process.execPath} ${iobExecutable} user del`);
+            await cpPromise.exec(`"${process.execPath}" "${iobExecutable}" user del`);
             expect(true, 'should throw').to.be.false;
         } catch {
             // ok
         }
         // delete admin not allowed
         try {
-            await cpPromise.exec(`${process.execPath} ${iobExecutable} user del admin`);
+            await cpPromise.exec(`"${process.execPath}" "${iobExecutable}" user del admin`);
             expect(true, 'should throw').to.be.false;
         } catch {
             // ok
         }
         // delete user
-        res = await cpPromise.exec(`${process.execPath} ${iobExecutable} user del user`);
+        res = await cpPromise.exec(`"${process.execPath}" "${iobExecutable}" user del user`);
         expect(res.stderr).to.be.not.ok;
 
         // delete invalid user
         try {
-            await cpPromise.exec(`${process.execPath} ${iobExecutable} user del user`);
+            await cpPromise.exec(`"${process.execPath}" "${iobExecutable}" user del user`);
             expect(true, 'should throw').to.be.false;
         } catch {
             // ok
         }
         // check userdel
-        res = await cpPromise.exec(`${process.execPath} ${iobExecutable} userdel user2`);
+        res = await cpPromise.exec(`"${process.execPath}" "${iobExecutable}" userdel user2`);
         expect(res.stderr).to.be.not.ok;
     }).timeout(20000);
 
@@ -242,7 +242,7 @@ function register(it, expect, context) {
     it(testName + 'group add', async () => {
         // check if no args set
         try {
-            await cpPromise.exec(`${process.execPath} ${iobExecutable} group add`);
+            await cpPromise.exec(`"${process.execPath}" "${iobExecutable}" group add`);
             expect(true, 'should throw').to.be.false;
         } catch {
             // ok
@@ -250,19 +250,19 @@ function register(it, expect, context) {
 
         // add administrator not allowed
         try {
-            await cpPromise.exec(`${process.execPath} ${iobExecutable} group add administrator`);
+            await cpPromise.exec(`"${process.execPath}" "${iobExecutable}" group add administrator`);
             expect(true, 'should throw').to.be.false;
         } catch {
             // ok
         }
 
         // add user
-        const res = await cpPromise.exec(`${process.execPath} ${iobExecutable} group add users`);
+        const res = await cpPromise.exec(`"${process.execPath}" "${iobExecutable}" group add users`);
         expect(res.stderr).to.be.not.ok;
 
         // add existing user not allowed
         try {
-            await cpPromise.exec(`${process.execPath} ${iobExecutable} group add users`);
+            await cpPromise.exec(`"${process.execPath}" "${iobExecutable}" group add users`);
             expect(true, 'should throw').to.be.false;
         } catch {
             // ok
@@ -273,7 +273,7 @@ function register(it, expect, context) {
     it(testName + 'group del', async () => {
         // check if no args set
         try {
-            await cpPromise.exec(`${process.execPath} ${iobExecutable} group del`);
+            await cpPromise.exec(`"${process.execPath}" "${iobExecutable}" group del`);
             expect(true, 'should throw').to.be.false;
         } catch {
             // ok
@@ -281,19 +281,19 @@ function register(it, expect, context) {
 
         // delete admin not allowed
         try {
-            await cpPromise.exec(`${process.execPath} ${iobExecutable} group del administrator`);
+            await cpPromise.exec(`"${process.execPath}" "${iobExecutable}" group del administrator`);
             expect(true, 'should throw').to.be.false;
         } catch {
             // ok
         }
 
         // delete users
-        const res = await cpPromise.exec(`${process.execPath} ${iobExecutable} group del users`);
+        const res = await cpPromise.exec(`"${process.execPath}" "${iobExecutable}" group del users`);
         expect(res.stderr).to.be.not.ok;
 
         // delete invalid group
         try {
-            await cpPromise.exec(`${process.execPath} ${iobExecutable} group del users`);
+            await cpPromise.exec(`"${process.execPath}" "${iobExecutable}" group del users`);
             expect(true, 'should throw').to.be.false;
         } catch {
             // ok
@@ -305,19 +305,19 @@ function register(it, expect, context) {
         // check if no args set
         // no user defined
         try {
-            await cpPromise.exec(`${process.execPath} ${iobExecutable} group list`);
+            await cpPromise.exec(`"${process.execPath}" "${iobExecutable}" group list`);
             expect(true, 'should throw').to.be.false;
         } catch {
             // ok
         }
 
         // check admin
-        const res = await cpPromise.exec(`${process.execPath} ${iobExecutable} group list administrator`);
+        const res = await cpPromise.exec(`"${process.execPath}" "${iobExecutable}" group list administrator`);
         expect(res.stderr).to.be.not.ok;
 
         // check invalid user
         try {
-            await cpPromise.exec(`${process.execPath} ${iobExecutable} group list aaa`);
+            await cpPromise.exec(`"${process.execPath}" "${iobExecutable}" group list aaa`);
             expect(true, 'should throw').to.be.false;
         } catch {
             // ok
@@ -326,86 +326,146 @@ function register(it, expect, context) {
 
     // group get
     it(testName + 'group get', async () => {
-        let err;
         // check if no args set
-        err = await cli.processCommandAsync(context.objects, context.states, 'group', [], {});
-        expect(err).to.be.ok;
+        try {
+            await cpPromise.exec(`"${process.execPath}" "${iobExecutable}" group`);
+            expect(true, 'should throw').to.be.false;
+        } catch {
+            // ok
+        }
+
         // no user defined
-        err = await cli.processCommandAsync(context.objects, context.states, 'group', ['get'], {});
-        expect(err).to.be.ok;
+        try {
+            await cpPromise.exec(`"${process.execPath}" "${iobExecutable}" group get`);
+            expect(true, 'should throw').to.be.false;
+        } catch {
+            // ok
+        }
+
         // check admin
-        err = await cli.processCommandAsync(context.objects, context.states, 'group', ['get', 'administrator'], {});
-        expect(err).to.be.not.ok;
+        const res = await cpPromise.exec(`"${process.execPath}" "${iobExecutable}" group get administrator`);
+        expect(res.stderr).to.be.not.ok;
+
         // check invalid user
-        err = await cli.processCommandAsync(context.objects, context.states, 'group', ['get', 'aaaa'], {});
-        expect(err).to.be.ok;
-    });
+        try {
+            await cpPromise.exec(`"${process.execPath}" "${iobExecutable}" group get aaa`);
+            expect(true, 'should throw').to.be.false;
+        } catch {
+            // ok
+        }
+    }).timeout(20000);
 
     // group disable / enable
     it(testName + 'group disable/enable', async () => {
-        let err;
+        let res;
         // add second group
-        err = await cli.processCommandAsync(context.objects, context.states, 'group', ['add', 'group1'], {});
-        expect(err).to.be.not.ok;
+        res = await cpPromise.exec(`"${process.execPath}" "${iobExecutable}" group add group1`);
+        expect(res.stderr).to.be.not.ok;
+
         // check if no args set
-        err = await cli.processCommandAsync(context.objects, context.states, 'group', ['enable'], {});
-        expect(err).to.be.ok;
+        try {
+            await cpPromise.exec(`"${process.execPath}" "${iobExecutable}" group enable`);
+            expect(true, 'should throw').to.be.false;
+        } catch {
+            // ok
+        }
+
         // enable administrator
-        err = await cli.processCommandAsync(context.objects, context.states, 'group', ['enable', 'administrator'], {});
-        expect(err).to.be.not.ok;
+        res = await cpPromise.exec(`"${process.execPath}" "${iobExecutable}" group enable administrator`);
+        expect(res.stderr).to.be.not.ok;
+
         // test short command
-        err = await cli.processCommandAsync(context.objects, context.states, 'group', ['e', 'administrator'], {});
-        expect(err).to.be.not.ok;
+        res = await cpPromise.exec(`"${process.execPath}" "${iobExecutable}" group e administrator`);
+        expect(res.stderr).to.be.not.ok;
+
         // check invalid group
-        err = await cli.processCommandAsync(context.objects, context.states, 'group', ['enable', 'aaa'], {});
-        expect(err).to.be.ok;
+        try {
+            await cpPromise.exec(`"${process.execPath}" "${iobExecutable}" group enable aaa`);
+            expect(true, 'should throw').to.be.false;
+        } catch {
+            // ok
+        }
+
         // administrator cannot be disabled
-        err = await cli.processCommandAsync(context.objects, context.states, 'group', ['disable', 'administrator'], {});
-        expect(err).to.be.ok;
+        try {
+            await cpPromise.exec(`"${process.execPath}" "${iobExecutable}" group disable administrator`);
+            expect(true, 'should throw').to.be.false;
+        } catch {
+            // ok
+        }
+
         // group can be disabled
-        err = await cli.processCommandAsync(context.objects, context.states, 'group', ['disable', 'group1'], {});
-        expect(err).to.be.not.ok;
+        res = await cpPromise.exec(`"${process.execPath}" "${iobExecutable}" group disable group1`);
+        expect(res.stderr).to.be.not.ok;
+
         // group can be disabled
-        err = await cli.processCommandAsync(context.objects, context.states, 'group', ['get', 'group1'], {});
-        expect(err).to.be.not.ok;
-    });
+        res = await cpPromise.exec(`"${process.execPath}" "${iobExecutable}" group get group1`);
+        expect(res.stderr).to.be.not.ok;
+    }).timeout(20000);
 
     // group useradd
     it(testName + 'group useradd', async () => {
-        let err;
+        let res;
+
         // add non existing user
-        err = await cli.processCommandAsync(context.objects, context.states, 'group', ['useradd', 'group1', 'user4'], {});
-        expect(err).to.be.ok;
+        try {
+            await cpPromise.exec(`"${process.execPath}" "${iobExecutable}" group useradd group1 user4`);
+            expect(true, 'should throw').to.be.false;
+        } catch {
+            // ok
+        }
+
         // add user for tests
-        err = await cli.processCommandAsync(context.objects, context.states, 'user', ['add', 'user4'], { ingroup: 'user', password: 'bbb' });
-        expect(err).to.be.not.ok;
+        res = await cpPromise.exec(`"${process.execPath}" "${iobExecutable}" user add user4 --ingroup user --password bbb`);
+        expect(res.stderr).to.be.not.ok;
+
         // add normal user to normal group
-        err = await cli.processCommandAsync(context.objects, context.states, 'group', ['useradd', 'group1', 'user4'], {});
-        expect(err).to.be.not.ok;
+        res = await cpPromise.exec(`"${process.execPath}" "${iobExecutable}" group useradd group1 user4`);
+        expect(res.stderr).to.be.not.ok;
+
         // admin yet added
-        err = await cli.processCommandAsync(context.objects, context.states, 'group', ['useradd', 'administrator', 'admin'], {});
-        expect(err).to.be.not.ok;
+        res = await cpPromise.exec(`"${process.execPath}" "${iobExecutable}" group useradd administrator admin`);
+        expect(res.stderr).to.be.not.ok;
+
         // add to invalid group
-        err = await cli.processCommandAsync(context.objects, context.states, 'group', ['useradd', 'group5', 'admin'], {});
-        expect(err).to.be.ok;
-    });
+        try {
+            await cpPromise.exec(`"${process.execPath}" "${iobExecutable}" group useradd group5 admin`);
+            expect(true, 'should throw').to.be.false;
+        } catch {
+            // ok
+        }
+    }).timeout(20000);
 
     // group userdel
     it(testName + 'group userdel', async () => {
-        let err;
         // delete non existing user
-        err = await cli.processCommandAsync(context.objects, context.states, 'group', ['userdel', 'group1', 'user5'], {});
-        expect(err).to.be.ok;
+        try {
+            await cpPromise.exec(`"${process.execPath}" "${iobExecutable}" group userdel group1 user5`);
+            expect(true, 'should throw').to.be.false;
+        } catch {
+            // ok
+        }
+
         // remove normal user from normal group
-        err = await cli.processCommandAsync(context.objects, context.states, 'group', ['userdel', 'group1', 'user4'], {});
-        expect(err).to.be.not.ok;
+        const res = await cpPromise.exec(`"${process.execPath}" "${iobExecutable}" group userdel group1 user4`);
+        expect(res.stderr).to.be.not.ok;
+
         // admin not allowed
-        err = await cli.processCommandAsync(context.objects, context.states, 'group', ['userdel', 'administrator', 'admin'], {});
-        expect(err).to.be.not.ok;
+        try {
+            await cpPromise.exec(`"${process.execPath}" "${iobExecutable}" group userdel administrator admin`);
+            expect(true, 'should throw').to.be.false;
+        } catch {
+            // ok
+        }
+
         // remove from invalid group
-        err = await cli.processCommandAsync(context.objects, context.states, 'group', ['userdel', 'group5', 'admin'], {});
-        expect(err).to.be.ok;
-    });
+        try {
+            await cpPromise.exec(`"${process.execPath}" "${iobExecutable}" group userdel group5 admin`);
+            expect(true, 'should throw').to.be.false;
+        } catch {
+            // ok
+        }
+    }).timeout(20000);
 
     // start adapter
     // stop adapter
@@ -414,13 +474,14 @@ function register(it, expect, context) {
 
     // status
     it(testName + 'status', async () => {
-        let err;
-        // delete non existing user
-        err = await cli.processCommandAsync(context.objects, context.states, 'status', [], {});
-        expect(err).to.be.not.ok;
-        // remove normal user from normal group
-        err = await cli.processCommandAsync(context.objects, context.states, 'isrun', [], {});
-        expect(err).to.be.not.ok;
+        let res;
+        // check status
+        res = await cpPromise.exec(`"${process.execPath}" "${iobExecutable}" status`);
+        expect(res.stderr).to.be.not.ok;
+
+        // check isrun
+        res = await cpPromise.exec(`"${process.execPath}" "${iobExecutable}" isrun`);
+        expect(res.stderr).to.be.not.ok;
     });
     // restart adapter
     // restart ??
@@ -428,13 +489,14 @@ function register(it, expect, context) {
     // update
     // setup
     it(testName + 'setup', async () => {
-        let err;
-        // delete non existing user
-        err = await cli.processCommandAsync(context.objects, context.states, 'setup', [], {});
-        expect(err).to.be.not.ok;
-        // remove normal user from normal group
-        err = await cli.processCommandAsync(context.objects, context.states, 'setup', ['first'], {});
-        expect(err).to.be.not.ok;
+        let res;
+        // check setup
+        res = await cpPromise.exec(`"${process.execPath}" "${iobExecutable}" setup`);
+        expect(res.stderr).to.be.not.ok;
+
+        // check setup first
+        res = await cpPromise.exec(`"${process.execPath}" "${iobExecutable}" setup first`);
+        expect(res.stderr).to.be.not.ok;
     }).timeout(20000);
 
     // setup custom
@@ -453,12 +515,14 @@ function register(it, expect, context) {
     // message
     // update
     it(testName + 'update', async () => {
-        let err;
-        // delete non existing user
-        err = await cli.processCommandAsync(context.objects, context.states, 'update', [], {});
-        expect(err).to.be.not.ok;
-        err = await cli.processCommandAsync(context.objects, context.states, 'update', ['http://download.iobroker.net/sources-dist.json'], {});
-        expect(err).to.be.not.ok;
+        let res;
+        // check update
+        res = await cpPromise.exec(`"${process.execPath}" "${iobExecutable}" update`);
+        expect(res.stderr).to.be.not.ok;
+
+        // check update with repo url
+        res = await cpPromise.exec(`"${process.execPath}" "${iobExecutable}" update http://download.iobroker.net/sources-dist.json`);
+        expect(res.stderr).to.be.not.ok;
     }).timeout(40000);
 
     // upgrade
@@ -481,9 +545,9 @@ function register(it, expect, context) {
             }
         }
 
-        let err;
-        err = await cli.processCommandAsync(context.objects, context.states, 'backup', [], {});
-        expect(err).to.be.not.ok;
+        let res;
+        res = await cpPromise.exec(`"${process.execPath}" "${iobExecutable}" backup`);
+        expect(res.stderr).to.be.not.ok;
         files = fs.readdirSync(dir);
         // check 2017_03_09-13_48_33_backupioBroker.tar.gz
         //let found = false;
@@ -500,9 +564,9 @@ function register(it, expect, context) {
         //expect(found).to.be.true;
 
         const name = Math.round(Math.random() * 10000).toString();
-        err = await cli.processCommandAsync(context.objects, context.states, 'backup', [name], {});
-        expect(err).to.be.not.ok;
-        expect(require('fs').existsSync(getBackupDir() + name + '.tar.gz')).to.be.true;
+        res = await cpPromise.exec(`"${process.execPath}" "${iobExecutable}" backup ${name}`);
+        expect(res.stderr).to.be.not.ok;
+        expect(require('fs').existsSync(`${getBackupDir() + name}.tar.gz`)).to.be.true;
     }).timeout(20000);
 
     // list l
@@ -518,25 +582,27 @@ function register(it, expect, context) {
 
     // id uuid
     it(testName + 'uuid', async () => {
-        let err;
-        // delete non existing user
-        err = await cli.processCommandAsync(context.objects, context.states, 'uuid', [], {});
-        expect(err).to.be.not.ok;
-        // remove normal user from normal group
-        err = await cli.processCommandAsync(context.objects, context.states, 'id', [], {});
-        expect(err).to.be.not.ok;
-    });
+        let res;
+        // uuid
+        res = await cpPromise.exec(`"${process.execPath}" "${iobExecutable}" uuid`);
+        expect(res.stderr).to.be.not.ok;
+
+        // id
+        res = await cpPromise.exec(`"${process.execPath}" "${iobExecutable}" id`);
+        expect(res.stderr).to.be.not.ok;
+    }).timeout(20000);
 
     // v version
     it(testName + 'version', async () => {
-        let err;
-        // delete non existing user
-        err = await cli.processCommandAsync(context.objects, context.states, 'version', [], {});
-        expect(err).to.be.not.ok;
-        // remove normal user from normal group
-        err = await cli.processCommandAsync(context.objects, context.states, 'v', [], {});
-        expect(err).to.be.not.ok;
-    });
+        let res;
+        // version
+        res = await cpPromise.exec(`"${process.execPath}" "${iobExecutable}" version`);
+        expect(res.stderr).to.be.not.ok;
+
+        // short
+        res = await cpPromise.exec(`"${process.execPath}" "${iobExecutable}" v`);
+        expect(res.stderr).to.be.not.ok;
+    }).timeout(20000);
 
     // repo
     it(testName + 'repo', async () => {

--- a/test/lib/testConsole.js
+++ b/test/lib/testConsole.js
@@ -670,7 +670,7 @@ function register(it, expect, context) {
         // try to delete non-active repo
         res = await cpPromise.exec(`"${process.execPath}" "${iobExecutable}" repo del local1`);
         expect(res.stderr).to.be.not.ok;
-    }).timeout(20000);
+    }).timeout(40000);
 
     // license
     it(testName + 'license', async () => {

--- a/test/lib/testConsole.js
+++ b/test/lib/testConsole.js
@@ -4,6 +4,9 @@
 /* jshint expr:true */
 'use strict';
 const tools = require('../../lib/tools.js');
+const path = require('path');
+const cpPromise = require('promisify-child-process');
+const iobExecutable = path.join(__dirname, '..', '..', 'iobroker.js');
 
 function getBackupDir() {
     let dataDir = tools.getDefaultDataDir();
@@ -31,84 +34,127 @@ function getBackupDir() {
 function register(it, expect, context) {
     const testName = context.name + ' ' + context.adapterShortName + ' console: ';
     const cli    = require('../../lib/setup.js');
+
     // passwd, user passwd, user check
     it(testName + 'user passwd', async () => {
-        let err;
+        let res;
 
-        err = await cli.processCommandAsync(context.objects, context.states, 'passwd', ['admin'], { password: context.appName.toLowerCase() });
-        expect(err).to.be.not.ok;
+        res = await cpPromise.exec(`${process.execPath} ${iobExecutable} passwd admin --password ${context.appName.toLowerCase()}`);
+        expect(res.stderr).to.be.not.ok;
 
         // check password
-        err = await cli.processCommandAsync(context.objects, context.states, 'user', ['check', 'admin'], { password: context.appName.toLowerCase() });
-        expect(err).to.be.not.ok;
+        res = await cpPromise.exec(`${process.execPath} ${iobExecutable} user check admin --password ${context.appName.toLowerCase()}`);
+        expect(res.stderr).to.be.not.ok;
         // negative check
-        err = await cli.processCommandAsync(context.objects, context.states, 'user', ['check', 'admin'], { password: context.appName.toLowerCase() + '2' });
-        expect(err).to.be.ok;
-
+        try {
+            await cpPromise.exec(`${process.execPath} ${iobExecutable} user check admin --password ${`${context.appName.toLowerCase()}2`}`);
+            expect(true, 'should throw').to.be.false;
+        } catch {
+            // ok
+        }
         // set new password
-        err = await cli.processCommandAsync(context.objects, context.states, 'user', ['passwd', 'admin'], { password: context.appName.toLowerCase() + '1' });
-        expect(err).to.be.not.ok;
+        res = await cpPromise.exec(`${process.execPath} ${iobExecutable} user passwd admin --password ${`${context.appName.toLowerCase()}1`}`);
+        expect(res.stderr).to.be.not.ok;
         // check new Password
-        err = await cli.processCommandAsync(context.objects, context.states, 'user', ['check', 'admin'], { password: context.appName.toLowerCase() + '1' });
-        expect(err).to.be.not.ok;
+        res = await cpPromise.exec(`${process.execPath} ${iobExecutable} user check admin --password ${`${context.appName.toLowerCase()}1`}`);
+        expect(res.stderr).to.be.not.ok;
 
         // set password back
-        err = await cli.processCommandAsync(context.objects, context.states, 'passwd', ['admin'], { password: context.appName.toLowerCase() });
-        expect(err).to.be.not.ok;
+        res = await cpPromise.exec(`${process.execPath} ${iobExecutable} user passwd admin --password ${`${context.appName.toLowerCase()}`}`);
+        expect(res.stderr).to.be.not.ok;
         // check password
-        err = await cli.processCommandAsync(context.objects, context.states, 'user', ['check', 'admin'], { password: context.appName.toLowerCase() });
-        expect(err).to.be.not.ok;
+        res = await cpPromise.exec(`${process.execPath} ${iobExecutable} user check admin --password ${`${context.appName.toLowerCase()}`}`);
+        expect(res.stderr).to.be.not.ok;
 
         // set password for non existing user
-        err = await cli.processCommandAsync(context.objects, context.states, 'passwd', ['uuuser'], { password: context.appName.toLowerCase() });
-        expect(err).to.be.ok;
-        // check password for non existing user
-        err = await cli.processCommandAsync(context.objects, context.states, 'user', ['check', 'uuuser'], { password: context.appName.toLowerCase() });
-        expect(err).to.be.ok;
+        try {
+            await cpPromise.exec(`${process.execPath} ${iobExecutable} user passwd uuuser --password ${`${context.appName.toLowerCase()}1`}`);
+            expect(true, 'should throw').to.be.false;
+        } catch {
+            // ok
+        }
 
-    }).timeout(2000);
+        // check password for non existing user
+        try {
+            await cpPromise.exec(`${process.execPath} ${iobExecutable} user check uuuser --password ${`${context.appName.toLowerCase()}1`}`);
+            expect(true, 'should throw').to.be.false;
+        } catch {
+            //ok
+        }
+    }).timeout(20000);
 
     // user get
     it(testName + 'user get', async () => {
-        let err;
-
         // check if no args set
-        err = await cli.processCommandAsync(context.objects, context.states, 'user', [], {});
-        expect(err).to.be.ok;
-        // no user defined
-        err = await cli.processCommandAsync(context.objects, context.states, 'user', ['get'], {});
-        expect(err).to.be.ok;
-        // check admin
-        err = await cli.processCommandAsync(context.objects, context.states, 'user', ['get', 'admin'], {});
-        expect(err).to.be.not.ok;
-        // check invalid user
-        err = await cli.processCommandAsync(context.objects, context.states, 'user', ['get', 'aaaa'], {});
-        expect(err).to.be.ok;
+        try {
+            await cpPromise.exec(`${process.execPath} ${iobExecutable} user`);
+            expect(true, 'should throw').to.be.false;
+        } catch {
+            // ok
+        }
 
-    });
+        // no user defined
+        try {
+            await cpPromise.exec(`${process.execPath} ${iobExecutable} user get`);
+            expect(true, 'should throw').to.be.false;
+        } catch {
+            // ok
+        }
+        // check admin
+        const res = await cpPromise.exec(`${process.execPath} ${iobExecutable} user get admin`);
+        expect(res.stderr).to.be.not.ok;
+        // check invalid user
+        try {
+            await cpPromise.exec(`${process.execPath} ${iobExecutable} user get aaa`);
+            expect(true, 'should throw').to.be.false;
+        } catch {
+            // ok
+        }
+    }).timeout(10000);
 
     // adduser user add
     it(testName + 'user add', async () => {
-        let err;
+        let res;
         // check if no args set
-        err = await cli.processCommandAsync(context.objects, context.states, 'user', ['add'], {});
-        expect(err).to.be.ok;
+        try {
+            await cpPromise.exec(`${process.execPath} ${iobExecutable} user add`);
+            expect(true, 'should throw').to.be.false;
+        } catch {
+            // ok
+        }
+
         // add admin not allowed
-        err = await cli.processCommandAsync(context.objects, context.states, 'user', ['add', 'admin'], { password: 'aaa' });
-        expect(err).to.be.ok;
+        try {
+            await cpPromise.exec(`${process.execPath} ${iobExecutable} user add admin --password aaa`);
+            expect(true, 'should throw').to.be.false;
+        } catch {
+            // ok
+        }
+
         // add user
-        err = await cli.processCommandAsync(context.objects, context.states, 'user', ['add', 'userNew'], { ingroup: 'user', password: 'user' });
-        expect(err).to.be.not.ok;
+        res = await cpPromise.exec(`${process.execPath} ${iobExecutable} user add newUser --password user --ingroup user`);
+        expect(res.stderr).to.be.not.ok;
+
         // add existing user not allowed
-        err = await cli.processCommandAsync(context.objects, context.states, 'user', ['add', 'userNew'], { password: 'user' });
-        expect(err).to.be.ok;
+        try {
+            await cpPromise.exec(`${process.execPath} ${iobExecutable} user add newUser --password user`);
+            expect(true, 'should throw').to.be.false;
+        } catch {
+            // ok
+        }
+
         // add with invalid group
-        err = await cli.processCommandAsync(context.objects, context.states, 'user', ['add', 'user1'], { ingroup: 'invalid', password: 'bbb' });
-        expect(err).to.be.ok;
+        try {
+            await cpPromise.exec(`${process.execPath} ${iobExecutable} user add user1 --password bbb --ingroup invalid`);
+            expect(true, 'should throw').to.be.false;
+        } catch {
+            // ok
+        }
+
         // check adduser
-        err = await cli.processCommandAsync(context.objects, context.states, 'adduser', ['user2'], { ingroup: 'user', password: 'bbb' });
-        expect(err).to.be.not.ok;
-    });
+        res = await cpPromise.exec(`${process.execPath} ${iobExecutable} adduser user2 --password user --ingroup user`);
+        expect(res.stderr).to.be.not.ok;
+    }).timeout(10000);
 
     // user disable / enable
     it(testName + 'user disable/enable', async () => {

--- a/test/lib/testConsole.js
+++ b/test/lib/testConsole.js
@@ -33,7 +33,6 @@ function getBackupDir() {
 
 function register(it, expect, context) {
     const testName = context.name + ' ' + context.adapterShortName + ' console: ';
-    const cli    = require('../../lib/setup.js');
 
     // passwd, user passwd, user check
     it(testName + 'user passwd', async () => {
@@ -474,15 +473,26 @@ function register(it, expect, context) {
 
     // status
     it(testName + 'status', async () => {
-        let res;
         // check status
-        res = await cpPromise.exec(`"${process.execPath}" "${iobExecutable}" status`);
-        expect(res.stderr).to.be.not.ok;
+        try {
+            await cpPromise.exec(`"${process.execPath}" "${iobExecutable}" status`);
+            expect(true, 'should throw').to.be.false;
+        } catch (e) {
+            // due to exit code 100 (controller not running) it throws
+            expect(e.code).to.be.equal(100);
+            expect(e.stdout.includes('ioBroker is not running on this host')).to.be.true;
+        }
 
         // check isrun
-        res = await cpPromise.exec(`"${process.execPath}" "${iobExecutable}" isrun`);
-        expect(res.stderr).to.be.not.ok;
-    });
+        try {
+            await cpPromise.exec(`"${process.execPath}" "${iobExecutable}" isrun`);
+            expect(true, 'should throw').to.be.false;
+        } catch (e) {
+            // due to exit code 100 (controller not running) it throws
+            expect(e.code).to.be.equal(100);
+            expect(e.stdout.includes('ioBroker is not running on this host')).to.be.true;
+        }
+    }).timeout(20000);
     // restart adapter
     // restart ??
 
@@ -635,14 +645,14 @@ function register(it, expect, context) {
 
         // add and set as active new repo, but with too less parameters
         try {
-            await cpPromise.exec(`"${process.execPath}" "${iobExecutable}" repo del local`);
+            await cpPromise.exec(`"${process.execPath}" "${iobExecutable}" repo addset local1`);
             expect(true, 'should throw').to.be.false;
         } catch {
             // ok
         }
 
         // delete non-active repo
-        res = await cpPromise.exec(`"${process.execPath}" "${iobExecutable}" addset local1 some/path`);
+        res = await cpPromise.exec(`"${process.execPath}" "${iobExecutable}" repo addset local1 some/path`);
         expect(res.stderr).to.be.not.ok;
 
         // try to add new repo with existing name

--- a/test/lib/testConsole.js
+++ b/test/lib/testConsole.js
@@ -80,7 +80,7 @@ function register(it, expect, context) {
         } catch {
             //ok
         }
-    }).timeout(20000);
+    }).timeout(40000);
 
     // user get
     it(testName + 'user get', async () => {

--- a/test/lib/testConsole.js
+++ b/test/lib/testConsole.js
@@ -110,7 +110,7 @@ function register(it, expect, context) {
         } catch {
             // ok
         }
-    }).timeout(10000);
+    }).timeout(20000);
 
     // adduser user add
     it(testName + 'user add', async () => {
@@ -154,105 +154,175 @@ function register(it, expect, context) {
         // check adduser
         res = await cpPromise.exec(`${process.execPath} ${iobExecutable} adduser user2 --password user --ingroup user`);
         expect(res.stderr).to.be.not.ok;
-    }).timeout(10000);
+    }).timeout(20000);
 
     // user disable / enable
     it(testName + 'user disable/enable', async () => {
-        let err;
+        let res;
+
         // add second user
-        err = await cli.processCommandAsync(context.objects, context.states, 'user', ['add', 'user1'], { ingroup: 'user', password: ' bbb' });
-        expect(err).to.be.not.ok;
+        res = await cpPromise.exec(`${process.execPath} ${iobExecutable} user add user1 --password bbb --ingroup user`);
+        expect(res.stderr).to.be.not.ok;
+
         // check if no args set
-        err = await cli.processCommandAsync(context.objects, context.states, 'user', ['enable'], {});
-        expect(err).to.be.ok;
+        try {
+            await cpPromise.exec(`${process.execPath} ${iobExecutable} user enable`);
+            expect(true, 'should throw').to.be.false;
+        } catch {
+            // ok
+        }
+
         // enable admin
-        err = await cli.processCommandAsync(context.objects, context.states, 'user', ['enable', 'admin'], {});
-        expect(err).to.be.not.ok;
+        res = await cpPromise.exec(`${process.execPath} ${iobExecutable} user enable admin`);
+        expect(res.stderr).to.be.not.ok;
+
         // test short command
-        err = await cli.processCommandAsync(context.objects, context.states, 'user', ['e', 'admin'], {});
-        expect(err).to.be.not.ok;
+        res = await cpPromise.exec(`${process.execPath} ${iobExecutable} user e admin`);
+        expect(res.stderr).to.be.not.ok;
+
         // check invalid user
-        err = await cli.processCommandAsync(context.objects, context.states, 'user', ['enable', 'aaa'], {});
-        expect(err).to.be.ok;
+        try {
+            await cpPromise.exec(`${process.execPath} ${iobExecutable} user enable aaa`);
+            expect(true, 'should throw').to.be.false;
+        } catch {
+            // ok
+        }
+
         // admin cannot be disabled
-        err = await cli.processCommandAsync(context.objects, context.states, 'user', ['disable', 'admin'], {});
-        expect(err).to.be.ok;
+        try {
+            await cpPromise.exec(`${process.execPath} ${iobExecutable} user disable admin`);
+            expect(true, 'should throw').to.be.false;
+        } catch {
+            // ok
+        }
+
         // user can be disabled
-        err = await cli.processCommandAsync(context.objects, context.states, 'user', ['disable', 'user1'], {});
-        expect(err).to.be.not.ok;
+        res = await cpPromise.exec(`${process.execPath} ${iobExecutable} user disable user1`);
+        expect(res.stderr).to.be.not.ok;
+
         // user can be disabled
-        err = await cli.processCommandAsync(context.objects, context.states, 'user', ['get', 'user1'], {});
-        expect(err).to.be.not.ok;
-    });
+        res = await cpPromise.exec(`${process.execPath} ${iobExecutable} user get user1`);
+        expect(res.stderr).to.be.not.ok;
+    }).timeout(20000);
 
     // ud udel userdel deluser user del
     it(testName + 'user del', async () => {
-        let err;
+        let res;
         // check if no args set
-        err = await cli.processCommandAsync(context.objects, context.states, 'user', ['del'], {});
-        expect(err).to.be.ok;
+        try {
+            await cpPromise.exec(`${process.execPath} ${iobExecutable} user del`);
+            expect(true, 'should throw').to.be.false;
+        } catch {
+            // ok
+        }
         // delete admin not allowed
-        err = await cli.processCommandAsync(context.objects, context.states, 'user', ['del', 'admin'], {});
-        expect(err).to.be.ok;
+        try {
+            await cpPromise.exec(`${process.execPath} ${iobExecutable} user del admin`);
+            expect(true, 'should throw').to.be.false;
+        } catch {
+            // ok
+        }
         // delete user
-        err = await cli.processCommandAsync(context.objects, context.states, 'user', ['del', 'user'], {});
-        expect(err).to.be.not.ok;
+        res = await cpPromise.exec(`${process.execPath} ${iobExecutable} user del user`);
+        expect(res.stderr).to.be.not.ok;
+
         // delete invalid user
-        err = await cli.processCommandAsync(context.objects, context.states, 'user', ['del', 'user'], {});
-        expect(err).to.be.ok;
+        try {
+            await cpPromise.exec(`${process.execPath} ${iobExecutable} user del user`);
+            expect(true, 'should throw').to.be.false;
+        } catch {
+            // ok
+        }
         // check userdel
-        err = await cli.processCommandAsync(context.objects, context.states, 'userdel', ['user2'], {});
-        expect(err).to.be.not.ok;
-    });
+        res = await cpPromise.exec(`${process.execPath} ${iobExecutable} userdel user2`);
+        expect(res.stderr).to.be.not.ok;
+    }).timeout(20000);
 
     // group add
     it(testName + 'group add', async () => {
-        let err;
         // check if no args set
-        err = await cli.processCommandAsync(context.objects, context.states, 'group', ['add'], {});
-        expect(err).to.be.ok;
+        try {
+            await cpPromise.exec(`${process.execPath} ${iobExecutable} group add`);
+            expect(true, 'should throw').to.be.false;
+        } catch {
+            // ok
+        }
+
         // add administrator not allowed
-        err = await cli.processCommandAsync(context.objects, context.states, 'group', ['add', 'administrator'], {});
-        expect(err).to.be.ok;
+        try {
+            await cpPromise.exec(`${process.execPath} ${iobExecutable} group add administrator`);
+            expect(true, 'should throw').to.be.false;
+        } catch {
+            // ok
+        }
+
         // add user
-        err = await cli.processCommandAsync(context.objects, context.states, 'group', ['add', 'users'], {});
-        expect(err).to.be.not.ok;
+        const res = await cpPromise.exec(`${process.execPath} ${iobExecutable} group add users`);
+        expect(res.stderr).to.be.not.ok;
+
         // add existing user not allowed
-        err = await cli.processCommandAsync(context.objects, context.states, 'group', ['add', 'users'], {});
-        expect(err).to.be.ok;
-    });
+        try {
+            await cpPromise.exec(`${process.execPath} ${iobExecutable} group add users`);
+            expect(true, 'should throw').to.be.false;
+        } catch {
+            // ok
+        }
+    }).timeout(20000);
 
     // group del
     it(testName + 'group del', async () => {
-        let err;
         // check if no args set
-        err = await cli.processCommandAsync(context.objects, context.states, 'group', ['del'], {});
-        expect(err).to.be.ok;
+        try {
+            await cpPromise.exec(`${process.execPath} ${iobExecutable} group del`);
+            expect(true, 'should throw').to.be.false;
+        } catch {
+            // ok
+        }
+
         // delete admin not allowed
-        err = await cli.processCommandAsync(context.objects, context.states, 'group', ['del', 'administrator'], {});
-        expect(err).to.be.ok;
+        try {
+            await cpPromise.exec(`${process.execPath} ${iobExecutable} group del administrator`);
+            expect(true, 'should throw').to.be.false;
+        } catch {
+            // ok
+        }
+
         // delete users
-        err = await cli.processCommandAsync(context.objects, context.states, 'group', ['del', 'users'], {});
-        expect(err).to.be.not.ok;
+        const res = await cpPromise.exec(`${process.execPath} ${iobExecutable} group del users`);
+        expect(res.stderr).to.be.not.ok;
+
         // delete invalid group
-        err = await cli.processCommandAsync(context.objects, context.states, 'group', ['del', 'users'], {});
-        expect(err).to.be.ok;
-    });
+        try {
+            await cpPromise.exec(`${process.execPath} ${iobExecutable} group del users`);
+            expect(true, 'should throw').to.be.false;
+        } catch {
+            // ok
+        }
+    }).timeout(20000);
 
     // group list
     it(testName + 'group list', async () => {
-        let err;
         // check if no args set
         // no user defined
-        err = await cli.processCommandAsync(context.objects, context.states, 'group', ['list'], {});
-        expect(err).to.be.ok;
+        try {
+            await cpPromise.exec(`${process.execPath} ${iobExecutable} group list`);
+            expect(true, 'should throw').to.be.false;
+        } catch {
+            // ok
+        }
+
         // check admin
-        err = await cli.processCommandAsync(context.objects, context.states, 'group', ['list', 'administrator'], {});
-        expect(err).to.be.not.ok;
+        const res = await cpPromise.exec(`${process.execPath} ${iobExecutable} group list administrator`);
+        expect(res.stderr).to.be.not.ok;
+
         // check invalid user
-        err = await cli.processCommandAsync(context.objects, context.states, 'group', ['list', 'aaaa'], {});
-        expect(err).to.be.ok;
-    });
+        try {
+            await cpPromise.exec(`${process.execPath} ${iobExecutable} group list aaa`);
+            expect(true, 'should throw').to.be.false;
+        } catch {
+            // ok
+        }
+    }).timeout(20000);
 
     // group get
     it(testName + 'group get', async () => {


### PR DESCRIPTION
- fixes #1385
- first thing which came up was, that yargs parsed a number as a number but we expected argument to be a string in backup https://github.com/ioBroker/ioBroker.js-controller/compare/master...foxriver76:reset-yargs?expand=1#diff-11408ea243ef9b5dafdd8274c9bba710fb64562b9b0855431bd5e6adc8414845R234