### PR TITLE
prevent uploading js-controller (creating system.adapter.js-controller)

### DIFF
--- a/packages/controller/lib/setup.js
+++ b/packages/controller/lib/setup.js
@@ -490,7 +490,6 @@ async function processCommand(command, args, params, callback) {
 
                 setup.setup(async (isFirst, _isRedis) => {
                     if (isFirst) {
-
                         // Creates all instances that are needed on a fresh installation
                         const createInitialInstances = async () => {
                             const Install = require('./setup/setupInstall.js');
@@ -543,6 +542,13 @@ async function processCommand(command, args, params, callback) {
                             await repo.rename('latest', 'beta', 'http://download.iobroker.net/sources-dist-latest.json');
                         } catch (e) {
                             console.warn(e.message);
+                        }
+
+                        // there has been a bug that user can uplaod js-controller
+                        try {
+                            await objects.delObjectAsync('system.adapter.js-controller');
+                        } catch {
+                            // ignore
                         }
 
                         try {

--- a/packages/controller/lib/setup.js
+++ b/packages/controller/lib/setup.js
@@ -790,7 +790,7 @@ async function processCommand(command, args, params, callback) {
                             }
 
                             upload.uploadFile(name, subTree, (err, newName) => {
-                                !err && console.log('File "' + name + '" is successfully saved under ' + newName);
+                                !err && console.log(`File "${name}" is successfully saved under ${newName}`);
                                 return void callback(err ? EXIT_CODES.CANNOT_UPLOAD_DATA : undefined);
                             });
                         } else {

--- a/packages/controller/lib/setup/setupUpload.js
+++ b/packages/controller/lib/setup/setupUpload.js
@@ -19,10 +19,10 @@ function Upload(options) {
 
     options = options || {};
 
-    if (!options.states)      {
+    if (!options.states) {
         throw new Error('Invalid arguments: states is missing');
     }
-    if (!options.objects)     {
+    if (!options.objects) {
         throw new Error('Invalid arguments: objects is missing');
     }
 
@@ -224,11 +224,11 @@ function Upload(options) {
                 instance = instance || objects.find(obj => obj && obj.common && liveHosts.indexOf(obj.common.host) !== -1);
 
                 if (instance && instance.common.host !== hostname) {
-                    console.log('Send upload command to host "' + instance.common.host + '"... ');
+                    console.log(`Send upload command to host "${instance.common.host}"... `);
                     // send upload message to the host
                     sendToHostFromCli(instance.common.host, 'upload', adapter, response => {
-                        !response && console.error('No answer from ' + instance.common.host);
-                        response && console.log('Upload result: ' + response.result);
+                        !response && console.error(`No answer from ${instance.common.host}`);
+                        response && console.log(`Upload result: ${response.result}`);
                         setImmediate(() => this.uploadAdapterFull(adapters, callback));
                     });
                 } else {
@@ -455,8 +455,7 @@ function Upload(options) {
             callback = logger;
             logger = subTree;
             subTree = null;
-        } else
-        if (typeof subTree === 'function') {
+        } else if (typeof subTree === 'function') {
             callback = subTree;
             subTree = null;
             logger = null;
@@ -738,7 +737,7 @@ function Upload(options) {
             iopackFile = fs.readJSONSync(adapterDir + '/io-package.json');
         } catch {
             if (adapterDir) {
-                logger.error('Cannot find io-package.json in ' + adapterDir);
+                logger.error(`Cannot find io-package.json in ${adapterDir}`);
             } else {
                 logger.error(`Cannot find io-package.json for "${name}"`);
             }
@@ -746,7 +745,8 @@ function Upload(options) {
         }
         iopack = iopack || iopackFile;
 
-        if (!iopack) {
+        if (!iopack || iopack.common && iopack.common.controller) {
+            // if no iopack found or someone passed the controller
             callback(name);
         } else {
             // Always update installed From from File on disk if exists and set
@@ -754,7 +754,7 @@ function Upload(options) {
                 iopack.common = iopack.common || {};
                 iopack.common.installedFrom = iopackFile.common.installedFrom;
             }
-            objects.getObject('system.adapter.' + name, (err, obj) => {
+            objects.getObject(`system.adapter.${name}`, (err, obj) => {
                 if (err || !obj) {
                     // Not existing? Why ever ... we recreate
                     obj = {};


### PR DESCRIPTION
fixes #1471 

Should we also take further action, like deleting the object in setup first routine if it has already been created by users which executed `iob u js-controller`? Because if the object once exist it can mess some routines up where we use getObjectView with adapter filter