### PR TITLE
Fixes: Cannot read property 'enabled' of undefined

### DIFF
--- a/lib/setup/setupInstall.js
+++ b/lib/setup/setupInstall.js
@@ -204,7 +204,7 @@ function Install(options) {
                 if (!err && arr) {
                     for (let id = 0; id < arr.rows.length; id++) {
                         // stop only started instances on this host
-                        if (arr.rows[id].value.common.enabled && hostname === arr.rows[id].value.common.host) {
+                        if (arr.rows[id].value.common !== undefined && arr.rows[id].value.common.enabled && hostname === arr.rows[id].value.common.host) {
                             stoppedList.push(arr.rows[id].value);
                         }
                     }


### PR DESCRIPTION
```
/opt/iobroker/node_modules/iobroker.js-controller/lib/setup/setupInstall.js:207 if (arr.rows[id].value.common.enabled && hostname === arr.rows[id].value.common.host) { ^TypeError: Cannot read property 'enabled' of undefined at Immediate.<anonymous> (/opt/iobroker/node_modules/iobroker.js-controller/lib/setup/setupInstall.js:207:55) at processImmediate (internal/timers.js:463:21)  
ERROR: Process exited with code 1
```  

When installing new adaptors, the above error occurs.

I don't know if it's the ideal fix, however it does the job - further testing may be required.