### PR TITLE
catch error in invald io-pack

### DIFF
--- a/packages/controller/lib/setup/setupUpload.js
+++ b/packages/controller/lib/setup/setupUpload.js
@@ -476,8 +476,11 @@ function Upload(options) {
         }
 
         let cfg;
-        if (fs.existsSync(adapterDir + '/io-package.json')) {
-            cfg = require(adapterDir + '/io-package.json');
+        try {
+            cfg = require(`${adapterDir}/io-package.json`);
+        } catch (e) {
+            // file not parsable or does not exist
+            console.error(`Could not read io-package.json: ${e.message}`);
         }
 
         if (!fs.existsSync(dir)) {

--- a/packages/controller/lib/setup/setupUpload.js
+++ b/packages/controller/lib/setup/setupUpload.js
@@ -446,7 +446,7 @@ function Upload(options) {
         return _results;
     }
 
-    this.uploadAdapter = (adapter, isAdmin, forceUpload, subTree, logger, callback) => {
+    this.uploadAdapter = async (adapter, isAdmin, forceUpload, subTree, logger, callback) => {
         const id = adapter + (isAdmin ? '.admin' : '');
         const adapterDir = tools.getAdapterDir(adapter);
         let dir = adapterDir ? adapterDir + (isAdmin ? '/admin' : '/www') : '';
@@ -455,8 +455,7 @@ function Upload(options) {
             callback = logger;
             logger = subTree;
             subTree = null;
-        } else
-        if (typeof subTree === 'function') {
+        } else if (typeof subTree === 'function') {
             callback = subTree;
             subTree = null;
             logger = null;
@@ -477,7 +476,7 @@ function Upload(options) {
 
         let cfg;
         try {
-            cfg = require(`${adapterDir}/io-package.json`);
+            cfg = await fs.readJSON(`${adapterDir}/io-package.json`);
         } catch (e) {
             // file not parsable or does not exist
             console.error(`Could not read io-package.json: ${e.message}`);
@@ -503,8 +502,8 @@ function Upload(options) {
             objects.getObject('system.adapter.' + adapter + '.upload', (err, obj) => {
                 if (err || !obj) {
                     objects.setObject('system.adapter.' + adapter + '.upload', {
-                        _id:   'system.adapter.' + adapter + '.upload',
-                        type:   'state',
+                        _id: 'system.adapter.' + adapter + '.upload',
+                        type: 'state',
                         common: {
                             name: adapter + '.upload',
                             type: 'number',
@@ -512,7 +511,7 @@ function Upload(options) {
                             unit: '%',
                             min: 0,
                             max: 100,
-                            def:  0,
+                            def: 0,
                             desc: 'Upload process indicator'
                         },
                         from: 'system.host.' + tools.getHostName() + '.cli',


### PR DESCRIPTION
- closes #1476
- also tried to address #1432 but there are so many usages wrapped in callbacks so the only chance for now would be to add another cb parameter, which is also messy. Furthermore, a run with an invalid io-pack json now looks like this:

```
iob u backitup
Could not read io-package.json: /opt/iobroker/node_modules/iobroker.backitup/io-package.json: Unexpected token : in JSON at position 11
upload [9] backitup.admin /opt/iobroker/node_modules/iobroker.backitup/admin/words.js words.js application/javascript
upload [8] backitup.admin /opt/iobroker/node_modules/iobroker.backitup/admin/tab_m.js tab_m.js application/javascript
upload [7] backitup.admin /opt/iobroker/node_modules/iobroker.backitup/admin/tab_m.html tab_m.html text/html
upload [6] backitup.admin /opt/iobroker/node_modules/iobroker.backitup/admin/style.css style.css text/css
upload [5] backitup.admin /opt/iobroker/node_modules/iobroker.backitup/admin/index_m.js index_m.js application/javascript
upload [4] backitup.admin /opt/iobroker/node_modules/iobroker.backitup/admin/index_m.html index_m.html text/html
upload [3] backitup.admin /opt/iobroker/node_modules/iobroker.backitup/admin/index.html index.html text/html
upload [2] backitup.admin /opt/iobroker/node_modules/iobroker.backitup/admin/backitup.svg backitup.svg image/svg+xml
upload [1] backitup.admin /opt/iobroker/node_modules/iobroker.backitup/admin/backitup.png backitup.png image/png
upload [0] backitup.admin /opt/iobroker/node_modules/iobroker.backitup/admin/adapter-settings.js adapter-settings.js application/javascript
Cannot find io-package.json in /opt/iobroker/node_modules/iobroker.backitup
Could not read io-package.json: /opt/iobroker/node_modules/iobroker.backitup/io-package.json: Unexpected token : in JSON at position 11
Cannot parse /opt/iobroker/node_modules/iobroker.backitup/io-package.json:SyntaxError: /opt/iobroker/node_modules/iobroker.backitup/io-package.json: Unexpected token : in JSON at position 11
```