### PR TITLE
make deleteDevice/deleteChannel more useful

### DIFF
--- a/packages/adapter/lib/adapter/adapter.js
+++ b/packages/adapter/lib/adapter/adapter.js
@@ -3785,13 +3785,12 @@ function Adapter(options) {
          * @param {object} [options] optional user context
          * @param {ioBroker.ErrorCallback} [callback] return result
          *        <pre><code>
-         *            function (err, obj) {
-         *              // obj is {id: id}
-         *              if (err) adapter.log.error('Cannot write object: ' + err);
+         *            function (err) {
+         *              if (err) adapter.log.error('Cannot delete device: ' + err);
          *            }
          *        </code></pre>
          */
-        this.deleteDevice = (deviceName, options, callback) => {
+        this.deleteDevice = async (deviceName, options, callback) => {
             if (typeof options === 'function') {
                 callback = options;
                 options = null;
@@ -3803,96 +3802,31 @@ function Adapter(options) {
 
             deviceName = deviceName.replace(FORBIDDEN_CHARS, '_').replace(/\./g, '_');
             if (!this._namespaceRegExp.test(deviceName)) {
-                deviceName = this.namespace + '.' + deviceName;
+                // make it an id
+                deviceName = `${this.namespace}.${deviceName}`;
             }
 
-            adapterObjects.getObjectView('system', 'device', {
-                startkey: deviceName,
-                endkey: deviceName
-            }, options, (err, res) => {
-                if (err || !res || !res.rows) {
-                    return tools.maybeCallbackWithError(callback, err);
-                }
-                let cnt = 0;
-                if (res.rows.length > 1) {
-                    logger.warn(this.namespaceLog + ' Found more than one device ' + deviceName);
-                }
+            // get object to check if it is a device
+            let obj;
+            try {
+                obj = await this.getForeignObjectAsync(deviceName);
+            } catch (e) {
+                return tools.maybeCallbackWithError(callback, e);
+            }
 
-                for (let t = 0; t < res.rows.length; t++) {
-                    cnt++;
-                    this.delObject(res.rows[t].id, options, err => {
-                        if (err) {
-                            return tools.maybeCallbackWithError(callback, err);
-                        }
+            if (!obj || obj.type !== 'device') {
+                // it's not a device, so return but no error
+                return tools.maybeCallback(callback);
+            }
 
-                        if (!--cnt) {
-                            let _cnt = 0;
-                            _cnt++;
-                            // read channels of device
-                            adapterObjects.getObjectView('system', 'channel', {
-                                startkey: deviceName + '.',
-                                endkey: deviceName + '.\u9999'
-                            }, options, (err, res) => {
-                                _cnt--;
-                                if (err || !res || !res.rows) {
-                                    return tools.maybeCallbackWithError(callback, err);
-                                }
-                                for (let k = 0; k < res.rows.length; k++) {
-                                    _cnt++;
-                                    this.deleteChannel(deviceName, res.rows[k].id, options, err => {
-                                        if (!--_cnt) {
-                                            typeof callback === 'function' && callback(err);
-                                            callback = null;
-                                        } else {
-                                            if (err) {
-                                                typeof callback === 'function' && callback(err);
-                                                callback = null;
-                                            }
-                                        }
-                                    });
-                                }
-                                if (!_cnt && typeof callback === 'function') {
-                                    callback();
-                                    callback = null;
-                                }
-                            });
-                            // read states of the device...
-                            _cnt++;
-                            adapterObjects.getObjectView('system', 'state', {
-                                startkey: deviceName + '.',
-                                endkey: deviceName + '.\u9999'
-                            }, options, (err, res) => {
-                                _cnt--;
-                                if (err || !res || !res.rows) {
-                                    return tools.maybeCallbackWithError(callback, err);
-                                }
-                                for (let k = 0; k < res.rows.length; k++) {
-                                    _cnt++;
-                                    this.deleteState(deviceName, '', res.rows[k].id, options, err => {
-                                        if (!--_cnt) {
-                                            typeof callback === 'function' && callback(err);
-                                            callback = null;
-                                        } else {
-                                            if (err) {
-                                                typeof callback === 'function' && callback(err);
-                                                callback = null;
-                                            }
-                                        }
-                                    });
-                                }
-                                if (!_cnt && typeof callback === 'function') {
-                                    callback();
-                                    callback = null;
-                                }
-                            });
-                        }
-                    });
-                }
-                if (!cnt && typeof callback === 'function') {
-                    callback();
-                    callback = null;
-                }
-            });
+            // it's a device now delete it + underlying structure
+            try {
+                await this.delForeignObjectAsync(deviceName, { recursive: true });
+            } catch (e) {
+                return tools.maybeCallbackWithError(callback, e);
+            }
+
+            return tools.maybeCallback(callback);
         };
         /**
          * Promise-version of Adapter.deleteDevice
@@ -4056,7 +3990,21 @@ function Adapter(options) {
          */
         this.deleteChannelFromEnumAsync = tools.promisify(this.deleteChannelFromEnum, this);
 
-        this.deleteChannel = (parentDevice, channelName, options, callback) => {
+        /**
+         * Deletes channel and udnerlying structure
+         * @alais deleteChannel
+         *
+         * @param {string} parentDevice is the part of ID like: adapter.instance.<deviceName>
+         * @param {string} channelName is the part of ID like: adapter.instance.<deviceName>.<channelName>
+         * @param {object} [options] optional user context
+         * @param {ioBroker.ErrorCallback} [callback] return result
+         *        <pre><code>
+         *            function (err) {
+         *              if (err) adapter.log.error('Cannot delete device: ' + err);
+         *            }
+         *        </code></pre>
+         */
+        this.deleteChannel = async (parentDevice, channelName, options, callback) => {
             if (typeof options === 'function') {
                 callback = options;
                 options = null;
@@ -4082,8 +4030,6 @@ function Adapter(options) {
             if (!parentDevice) {
                 parentDevice = '';
             }
-            const _parentDevice = parentDevice;
-            const _channelName = channelName;
 
             if (parentDevice) {
                 if (this._namespaceRegExp.test(parentDevice)) {
@@ -4101,59 +4047,31 @@ function Adapter(options) {
             channelName = channelName || '';
             channelName = channelName.replace(FORBIDDEN_CHARS, '_').replace(/\./g, '_');
 
-            channelName = this.namespace + '.' + this._DCS2ID(parentDevice, channelName);
+            channelName = `${this.namespace}.${this._DCS2ID(parentDevice, channelName)}`;
 
-            logger.info(this.namespaceLog + ' Delete channel ' + channelName);
+            // get object to check if it is a channel
+            let obj;
+            try {
+                obj = await this.getForeignObjectAsync(channelName);
+            } catch (e) {
+                return tools.maybeCallbackWithError(callback, e);
+            }
 
-            adapterObjects.getObjectView('system', 'channel', {
-                startkey: channelName,
-                endkey: channelName
-            }, options, (err, res) => {
-                if (err || !res || !res.rows) {
-                    return tools.maybeCallbackWithError(callback, err);
-                }
-                let cnt = 0;
-                res.rows.length > 1 && logger.warn(this.namespaceLog + ' Found more than one channel ' + channelName);
+            if (!obj || obj.type !== 'channel') {
+                // it's not a device, so return but no error
+                return tools.maybeCallback(callback);
+            }
 
-                for (let t = 0; t < res.rows.length; t++) {
-                    cnt++;
-                    this.delObject(res.rows[t].id, options, err => {
-                        if (err) {
-                            return tools.maybeCallbackWithError(callback, err);
-                        }
-                        if (!--cnt) {
-                            adapterObjects.getObjectView('system', 'state', {
-                                startkey: channelName + '.',
-                                endkey: channelName + '.\u9999'
-                            }, options, (err, res) => {
-                                if (err || !res || !res.rows) {
-                                    return tools.maybeCallbackWithError(callback, err);
-                                }
-                                let _cnt = 0;
-                                for (let k = 0; k < res.rows.length; k++) {
-                                    _cnt++;
-                                    this.deleteState(_parentDevice, _channelName, res.rows[k].id, options, err => {
-                                        if (!--_cnt && callback) {
-                                            callback(err);
-                                        } else {
-                                            if (err) {
-                                                typeof callback === 'function' && callback(err);
-                                                callback = null;
-                                            }
-                                        }
-                                    });
-                                }
-                                if (!_cnt && callback) {
-                                    callback();
-                                }
-                            });
-                        }
-                    });
-                }
-                if (!cnt && callback) {
-                    callback();
-                }
-            });
+            logger.info(`${this.namespaceLog} Delete channel ${channelName}`);
+
+            // it's a channel now delete it + underlying structure
+            try {
+                await this.delForeignObjectAsync(channelName, { recursive: true });
+            } catch (e) {
+                return tools.maybeCallbackWithError(callback, e);
+            }
+
+            return tools.maybeCallback(callback);
         };
         /**
          * Promise-version of Adapter.deleteChannel


### PR DESCRIPTION
- do not rely on legacy structure (device.channel.state) because we now have folders etc.
- closes #1429