### PR TITLE
rm testing workaround for objects/states server subscribe issue

### DIFF
--- a/packages/db-objects-file/lib/objects/objectsInMemServerClass.js
+++ b/packages/db-objects-file/lib/objects/objectsInMemServerClass.js
@@ -21,22 +21,7 @@ class ObjectsInMemoryServerClass extends ObjectsInRedisClient {
 
     constructor(settings) {
         settings.autoConnect = false; // delay Client connection to when we need it
-
-        // hack around testing problem where subscribe was called before connect
-        // Should be removed for a later release
-        const origConnected = settings.connected;
-        settings.connected = () => {
-            this.clientConnected = true;
-            if (Array.isArray(this.storedSubscribes) && this.storedSubscribes.length) {
-                this.log.warn(`${this.namespace} Replay ${this.storedSubscribes.length} subscription calls for Objects Server that were done before the client was connected initially`);
-                this.storedSubscribes.forEach((s => this.subscribe(s.pattern, s.options, s.callback)));
-                this.storedSubscribes = [];
-            }
-            origConnected();
-        };
         super(settings);
-        this.clientConnected = false;
-        this.storedSubscribes = [];
 
         const serverSettings = {
             namespace:  settings.namespace ? `${settings.namespace}-Server` : 'Server',
@@ -65,14 +50,6 @@ class ObjectsInMemoryServerClass extends ObjectsInRedisClient {
 
     dirExists(id, name) {
         return this.objectsServer.dirExists(id, name);
-    }
-
-    subscribe(pattern, options, callback) {
-        if (!this.clientConnected) {
-            this.storedSubscribes.push({pattern, options, callback}); // we ignore the promise return because not used for this testing issue we work around here
-        } else {
-            return super.subscribe(pattern, options, callback);
-        }
     }
 }
 module.exports = ObjectsInMemoryServerClass;

--- a/packages/db-objects-jsonl/lib/objects/objectsInMemServerClass.js
+++ b/packages/db-objects-jsonl/lib/objects/objectsInMemServerClass.js
@@ -21,22 +21,7 @@ class ObjectsInMemoryServerClass extends ObjectsInRedisClient {
 
     constructor(settings) {
         settings.autoConnect = false; // delay Client connection to when we need it
-
-        // hack around testing problem where subscribe was called before connect
-        // Should be removed for a later release
-        const origConnected = settings.connected;
-        settings.connected = () => {
-            this.clientConnected = true;
-            if (Array.isArray(this.storedSubscribes) && this.storedSubscribes.length) {
-                this.log.warn(`${this.namespace} Replay ${this.storedSubscribes.length} subscription calls for Objects Server that were done before the client was connected initially`);
-                this.storedSubscribes.forEach((s => this.subscribe(s.pattern, s.options, s.callback)));
-                this.storedSubscribes = [];
-            }
-            origConnected();
-        };
         super(settings);
-        this.clientConnected = false;
-        this.storedSubscribes = [];
 
         const serverSettings = {
             namespace:  settings.namespace ? `${settings.namespace}-Server` : 'Server',
@@ -65,14 +50,6 @@ class ObjectsInMemoryServerClass extends ObjectsInRedisClient {
 
     dirExists(id, name) {
         return this.objectsServer.dirExists(id, name);
-    }
-
-    subscribe(pattern, options, callback) {
-        if (!this.clientConnected) {
-            this.storedSubscribes.push({pattern, options, callback}); // we ignore the promise return because not used for this testing issue we work around here
-        } else {
-            return super.subscribe(pattern, options, callback);
-        }
     }
 }
 module.exports = ObjectsInMemoryServerClass;

--- a/packages/db-states-file/lib/states/statesInMemServerClass.js
+++ b/packages/db-states-file/lib/states/statesInMemServerClass.js
@@ -21,22 +21,7 @@ class StatesInMemoryServerClass extends StatesInRedisClient {
 
     constructor(settings) {
         settings.autoConnect = false; // delay Client connection to when we need it
-
-        // hack around testing problem where subscribe was called before connect
-        // Should be removed for a later release
-        const origConnected = settings.connected;
-        settings.connected = () => {
-            this.clientConnected = true;
-            if (Array.isArray(this.storedSubscribes) && this.storedSubscribes.length) {
-                this.log.warn(`${this.namespace} Replay ${this.storedSubscribes.length} subscription calls for States Server that were done before the client was connected initially`);
-                this.storedSubscribes.forEach((s => this.subscribe(s.pattern, s.options, s.callback)));
-                this.storedSubscribes = [];
-            }
-            origConnected();
-        };
         super(settings);
-        this.clientConnected = false;
-        this.storedSubscribes = [];
 
         const serverSettings = {
             namespace:  settings.namespace ? `${settings.namespace}-Server` : 'Server',
@@ -57,14 +42,6 @@ class StatesInMemoryServerClass extends StatesInRedisClient {
 
     getStatus() {
         return this.statesServer.getStatus(); // return Status as Server
-    }
-
-    async subscribe(pattern, options, callback) {
-        if (!this.clientConnected) {
-            this.storedSubscribes.push({pattern, options, callback}); // we ignore the promise return because not used for this testing issue we work around here
-        } else {
-            await super.subscribe(pattern, options, callback);
-        }
     }
 }
 

--- a/packages/db-states-jsonl/lib/states/statesInMemServerClass.js
+++ b/packages/db-states-jsonl/lib/states/statesInMemServerClass.js
@@ -21,22 +21,7 @@ class StatesInMemoryServerClass extends StatesInRedisClient {
 
     constructor(settings) {
         settings.autoConnect = false; // delay Client connection to when we need it
-
-        // hack around testing problem where subscribe was called before connect
-        // Should be removed for a later release
-        const origConnected = settings.connected;
-        settings.connected = () => {
-            this.clientConnected = true;
-            if (Array.isArray(this.storedSubscribes) && this.storedSubscribes.length) {
-                this.log.warn(`${this.namespace} Replay ${this.storedSubscribes.length} subscription calls for States Server that were done before the client was connected initially`);
-                this.storedSubscribes.forEach((s => this.subscribe(s.pattern, s.options, s.callback)));
-                this.storedSubscribes = [];
-            }
-            origConnected();
-        };
         super(settings);
-        this.clientConnected = false;
-        this.storedSubscribes = [];
 
         const serverSettings = {
             namespace:  settings.namespace ? `${settings.namespace}-Server` : 'Server',
@@ -57,14 +42,6 @@ class StatesInMemoryServerClass extends StatesInRedisClient {
 
     getStatus() {
         return this.statesServer.getStatus(); // return Status as Server
-    }
-
-    async subscribe(pattern, options, callback) {
-        if (!this.clientConnected) {
-            this.storedSubscribes.push({pattern, options, callback}); // we ignore the promise return because not used for this testing issue we work around here
-        } else {
-            await super.subscribe(pattern, options, callback);
-        }
     }
 }
 


### PR DESCRIPTION
- closes #1457
- reverts https://github.com/foxriver76/ioBroker.objects-redis/commit/2d358e2da7edfbf54e7fda267a0c62d1aa3a61d1
- should be fixed by https://github.com/ioBroker/testing/commit/093b62cd2c89560a588f3f9d88a4296707f6927a and all adapters need 2.5.0 anyways because of monopreo