### PR TITLE
ci: reduce max. number of open Dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,5 +14,5 @@ updates:
       interval: monthly
       time: "04:00"
       timezone: Europe/Berlin
-    open-pull-requests-limit: 20
+    open-pull-requests-limit: 5
     versioning-strategy: increase


### PR DESCRIPTION
This should avoid keeping Github Actions busy for two days when there are package conflicts which require Dependabot to rebase.