### PR TITLE
Allow rebuilding path instead of everything

### DIFF
--- a/packages/controller/lib/setup.js
+++ b/packages/controller/lib/setup.js
@@ -750,14 +750,14 @@ async function processCommand(command, args, params, callback) {
 
             if (commandOptions.path) {
                 if (path.isAbsolute(commandOptions.path)) {
-                    options.path = commandOptions.path;
+                    options.cwd = commandOptions.path;
                 } else {
                     console.log('Path argument needs to be an absolute path!');
                     return processExit(EXIT_CODES.INVALID_ARGUMENTS);
                 }
             }
 
-            console.log(`Rebuilding native modules...`);
+            console.log(`Rebuilding native modules${options.cwd ? ` in ${options.cwd}` : ''} ...`);
             const result = await tools.rebuildNodeModules(options);
 
             if (result.success) {

--- a/packages/controller/lib/setup.js
+++ b/packages/controller/lib/setup.js
@@ -22,6 +22,7 @@ const deepClone = require('deep-clone');
 const { isDeepStrictEqual } = require('util');
 const debug = require('debug')('iobroker:cli');
 const { tools: dbTools, getObjectsConstructor, getStatesConstructor } = require('@iobroker/js-controller-common-db');
+const path = require('path');
 
 // @ts-ignore
 require('events').EventEmitter.prototype._maxListeners = 100;
@@ -118,7 +119,7 @@ function initYargs() {
             }
         })
         .command(['install <adapter>', 'i <adapter>'], 'Installs a specified adapter', {})
-        .command('rebuild', 'Rebuild all native modules', {})
+        .command('rebuild [<path>]', 'Rebuild all native modules or path', {})
         .command('url <url> [<name>]', 'Install adapter from specified url, e.g. GitHub', {})
         .command(['del <adapter>', 'delete <adapter>'], 'Remove adapter from system', {
             custom: {
@@ -745,10 +746,19 @@ async function processCommand(command, args, params, callback) {
         }
 
         case 'rebuild': {
+            const options = {debug: process.argv.includes('--debug')};
+
+            if (commandOptions.path) {
+                if (path.isAbsolute(commandOptions.path)) {
+                    options.path = commandOptions.path;
+                } else {
+                    console.log('Path argument needs to be an absolute path!');
+                    return processExit(EXIT_CODES.INVALID_ARGUMENTS);
+                }
+            }
+
             console.log(`Rebuilding native modules...`);
-            const result = await tools.rebuildNodeModules({
-                debug: process.argv.includes('--debug')
-            });
+            const result = await tools.rebuildNodeModules(options);
 
             if (result.success) {
                 console.log();
@@ -2816,11 +2826,6 @@ module.exports.execute = function () {
     const command = _yargs.argv._[0];
 
     const args = [];
-    /* We can no longer use this because yargs17 parses arguments according to our help into argv instead of argv._
-    for (let a = 1; a < _yargs.argv._.length; a++) {
-        args.push(_yargs.argv._[a]);
-    }
-     */
 
     // skip interpreter, filename and command
     for (let i=3; i < process.argv.length; i++) {

--- a/packages/controller/main.js
+++ b/packages/controller/main.js
@@ -3830,8 +3830,8 @@ async function startInstance(id, wakeUp) {
                             // show for debug
                             console.error(text);
                             if (text.includes('NODE_MODULE_VERSION') || text.includes('npm rebuild') || text.includes('Cannot find module')) {
-                                // only try this at first rebuild
-                                if (!procs[id].rebuildCounter) {
+                                // only try this at second rebuild
+                                if (procs[id].rebuildCounter === 1) {
                                     // extract rebuild path - it is always between the only two single quotes
                                     const matches = text.match(/'.+'/g);
 

--- a/packages/controller/main.js
+++ b/packages/controller/main.js
@@ -2632,8 +2632,13 @@ async function processMessage(msg) {
 
         case 'rebuildAdapter':
             if (!installQueue.some(entry => entry.id === msg.message.id)) {
-                logger.info(hostLogPrefix + ' ' + msg.message.id + ' will be rebuilt');
-                installQueue.push({id: msg.message.id, rebuild: true});
+                logger.info(`${hostLogPrefix} ${msg.message.id} will be rebuilt`);
+                const installObj = {id: msg.message.id, rebuild: true};
+                if (msg.message.path) {
+                    installObj.path = msg.message.path;
+                }
+
+                installQueue.push(installObj);
                 // start install queue if not started
                 installQueue.length === 1 && installAdapters();
 
@@ -3161,10 +3166,12 @@ function installAdapters() {
             installArgs.push(commandScope);
             if (!task.rebuild) {
                 installArgs.push(name);
+            } else if (task.path) {
+                installArgs.push(task.path);
             }
         }
         logger.info(`${hostLogPrefix} ${tools.appName} ${installArgs.join(' ')}${task.rebuild ? '' : ' using ' + ((procs[task.id].downloadRetry < 3 && task.installedFrom) ? 'installedFrom' : 'installedVersion')}`);
-        installArgs.unshift(__dirname + '/' + tools.appName + '.js');
+        installArgs.unshift(`${__dirname}/${tools.appName}.js`);
 
         try {
             task.inProgress = true;
@@ -3682,12 +3689,21 @@ async function startInstance(id, wakeUp) {
                                 logger.info(`${hostLogPrefix} Adapter ${id} needs rebuild and will be restarted afterwards.`);
                                 const msg = {
                                     command: 'rebuildAdapter',
-                                    message: { id: instance._id }
+                                    message: { id: instance._id}
                                 };
+
+                                // if rebuild path given send it
+                                if (procs[id].rebuildPath) {
+                                    msg.message.path = procs[id].rebuildPath;
+                                    delete procs[id].rebuildPath;
+                                    // this is the first try, because path still there, next time try to install
+                                    procs[id].installBeforeRebuild = true;
+                                }
+
                                 if (!compactGroupController) { // execute directly
                                     processMessage(msg);
                                 } else { // send to main controller to make sure only one npm process runs at a time
-                                    sendTo('system.host.' + hostname, 'rebuildAdapter', msg);
+                                    sendTo(`system.host.${hostname}`, 'rebuildAdapter', msg);
                                 }
                             } else {
                                 logger.info(`${hostLogPrefix} Rebuild for adapter ${id} not successful in 3 tries. Adapter will not be restarted again. Please execute "npm install --production" in adapter directory manually.`);
@@ -3813,7 +3829,13 @@ async function startInstance(id, wakeUp) {
                             const text = data.toString();
                             // show for debug
                             console.error(text);
-                            if (text.includes('NODE_MODULE_VERSION') || text.includes('npm rebuild')) {
+                            if (text.includes('NODE_MODULE_VERSION') || text.includes('npm rebuild') || text.includes('Cannot find module')) {
+                                // extract rebuild path - it is always between the two only single quotes
+                                const matches = text.match(/'.+'/g);
+                                if (matches && matches.length === 1 && path.isAbsolute(matches[0])) {
+                                    // we have found a module which needs rebuild
+                                    procs[id].rebuildPath = matches[0];
+                                }
                                 procs[id].needsRebuild = true;
                             }
                             procs[id].errors = procs[id].errors || [];

--- a/packages/controller/main.js
+++ b/packages/controller/main.js
@@ -3696,8 +3696,6 @@ async function startInstance(id, wakeUp) {
                                 if (procs[id].rebuildPath) {
                                     msg.message.path = procs[id].rebuildPath;
                                     delete procs[id].rebuildPath;
-                                    // this is the first try, because path still there, next time try to install
-                                    procs[id].installBeforeRebuild = true;
                                 }
 
                                 if (!compactGroupController) { // execute directly


### PR DESCRIPTION
- closes #831, closes #781
- we now try to parse the affected module out of the error string and then rebuild this at first attempt, if this doesn't work there will be 2 classic attempts
- Open issues: 

1. How to proceed with adapter exit-code 13? Rebuild in adapter dir?
2. Is rebuild of all native modules necessary?