### PR TITLE
Improvements for JSONL-DB: auto-backup, load config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -420,7 +420,7 @@
     "@iobroker/db-objects-jsonl": {
       "version": "file:packages/db-objects-jsonl",
       "requires": {
-        "@alcalzone/jsonl-db": "^2.2.0",
+        "@alcalzone/jsonl-db": "~2.3.0",
         "@iobroker/db-base": "file:packages/db-base",
         "@iobroker/db-objects-file": "file:packages/db-objects-file",
         "@iobroker/db-objects-redis": "file:packages/db-objects-redis",
@@ -489,7 +489,7 @@
     "@iobroker/db-states-jsonl": {
       "version": "file:packages/db-states-jsonl",
       "requires": {
-        "@alcalzone/jsonl-db": "^2.2.0",
+        "@alcalzone/jsonl-db": "~2.3.0",
         "@iobroker/db-base": "file:packages/db-base",
         "@iobroker/db-states-file": "file:packages/db-states-file",
         "@iobroker/db-states-redis": "file:packages/db-states-redis"
@@ -616,7 +616,8 @@
         "debug": "^4.3.3",
         "deep-clone": "^3.0.3",
         "event-stream": "^4.0.1",
-        "fs-extra": "^10.0.0"
+        "fs-extra": "^10.0.0",
+        "readline-sync": "^1.4.10"
       },
       "dependencies": {
         "debug": {

--- a/packages/common-db/tsconfig.json
+++ b/packages/common-db/tsconfig.json
@@ -5,7 +5,7 @@
     "rootDir": "src"
   },
   "include": [
-    "src/*.ts"
+    "src/**/*.ts"
   ],
   "exclude": [
     "build/**",

--- a/packages/controller/conf/iobroker-dist.json
+++ b/packages/controller/conf/iobroker-dist.json
@@ -49,6 +49,17 @@
             "periodComment": "by default backup every 2 hours. Time is in minutes. To disable backup set the value to 0",
             "path": "",
             "pathComment": "Absolute path to backup directory or empty to backup in data directory"
+        },
+        "jsonlOptions": {
+            "autoCompress": {
+                "sizeFactor": 2,
+                "sizeFactorMinimumSize": 25000
+            },
+            "ignoreReadErrors": true,
+            "throttleFS": {
+                "intervalMs": 60000,
+                "maxBufferedCommands": 100
+            }
         }
     },
     "states" : {
@@ -76,6 +87,17 @@
             "periodComment": "by default backup every 2 hours. Time is in minutes. To disable backup set the value to 0",
             "path": "",
             "pathComment": "Absolute path to backup directory or empty to backup in data directory"
+        },
+        "jsonlOptions": {
+            "autoCompress": {
+                "sizeFactor": 10,
+                "sizeFactorMinimumSize": 50000
+            },
+            "ignoreReadErrors": true,
+            "throttleFS": {
+                "intervalMs": 60000,
+                "maxBufferedCommands": 2000
+            }
         }
     },
     "log": {

--- a/packages/controller/conf/iobroker-dist.json
+++ b/packages/controller/conf/iobroker-dist.json
@@ -51,13 +51,21 @@
             "pathComment": "Absolute path to backup directory or empty to backup in data directory"
         },
         "jsonlOptions": {
+            "// autoCompress (1)": "The JSONL DB is append-only and will contain unnecessary entries after a while.",
+            "// autoCompress (2)": "It will be compressed when the uncompressed size is >= size * sizeFactor AND >= sizeFactorMinimumSize",
+            "// autoCompress (3)": "Note that too low values here will cause the DB to be rewritten often.",
             "autoCompress": {
                 "sizeFactor": 2,
                 "sizeFactorMinimumSize": 25000
             },
+            "// ignoreReadErrors": "If single lines in the DB are corrupted, they can be ignored without losing the whole DB.",
             "ignoreReadErrors": true,
+            "// throttleFS (1)": "By default, the database immediately writes to the database file. Write accesses can be reduced using the throttleFS option.",
+            "// throttleFS (2)": "Be aware that buffered changes will be lost in case the process crashes.",
             "throttleFS": {
+                "// intervalMs": "Write to the database file no more than every intervalMs milliseconds.",
                 "intervalMs": 60000,
+                "// maxBufferedCommands": "Force writing after this many changes have been buffered. This reduces memory consumption and data loss in case of a crash.",
                 "maxBufferedCommands": 100
             }
         }
@@ -89,13 +97,21 @@
             "pathComment": "Absolute path to backup directory or empty to backup in data directory"
         },
         "jsonlOptions": {
+            "// autoCompress (1)": "The JSONL DB is append-only and will contain unnecessary entries after a while.",
+            "// autoCompress (2)": "It will be compressed when the uncompressed size is >= size * sizeFactor AND >= sizeFactorMinimumSize",
+            "// autoCompress (3)": "Note that too low values here will cause the DB to be rewritten often.",
             "autoCompress": {
                 "sizeFactor": 10,
                 "sizeFactorMinimumSize": 50000
             },
+            "// ignoreReadErrors": "If single lines in the DB are corrupted, they can be ignored without losing the whole DB.",
             "ignoreReadErrors": true,
+            "// throttleFS (1)": "By default, the database immediately writes to the database file. Write accesses can be reduced using the throttleFS option.",
+            "// throttleFS (2)": "Be aware that buffered changes will be lost in case the process crashes.",
             "throttleFS": {
+                "// intervalMs": "Write to the database file no more than every intervalMs milliseconds.",
                 "intervalMs": 60000,
+                "// maxBufferedCommands": "Force writing after this many changes have been buffered. This reduces memory consumption and data loss in case of a crash.",
                 "maxBufferedCommands": 2000
             }
         }

--- a/packages/db-base/lib/inMemFileDB.js
+++ b/packages/db-base/lib/inMemFileDB.js
@@ -236,13 +236,13 @@ class InMemoryFileDB {
         throw new Error('no communication handling implemented');
     }
 
-    deleteOldBackupFiles() {
+    deleteOldBackupFiles(baseFilename) {
         // delete files only if settings.backupNumber is not 0
         let files = fs.readdirSync(this.backupDir);
         files.sort();
         const limit = Date.now() - this.settings.backup.hours * 3600000;
 
-        files = files.filter(f => f.endsWith(this.settings.fileDB.fileName + '.gz'));
+        files = files.filter(f => f.endsWith(baseFilename + '.gz'));
 
         while (files.length > this.settings.backup.files) {
             const file = files.shift();
@@ -403,7 +403,7 @@ class InMemoryFileDB {
                     compress.end();
 
                     // analyse older files
-                    this.deleteOldBackupFiles();
+                    this.deleteOldBackupFiles(this.settings.fileDB.fileName);
                 }
             } catch (e) {
                 this.log.error(`${this.namespace} Cannot save backup ${backFileName}: ${e.message}`);

--- a/packages/db-objects-jsonl/lib/objects/objectsInMemJsonlDB.js
+++ b/packages/db-objects-jsonl/lib/objects/objectsInMemJsonlDB.js
@@ -30,8 +30,10 @@ class ObjectsInMemoryJsonlDB extends ObjectsInMemoryFileDB {
             fileName: 'objects.json',
             backupDirName: 'backup-objects'
         };
+        super(settings);
+
         /** @type {import("@alcalzone/jsonl-db").JsonlDBOptions<any>} */
-        const jsonlOptions = {
+        const jsonlOptions = this.settings.connection.jsonlOptions || {
             autoCompress: {
                 sizeFactor: 2,
                 sizeFactorMinimumSize: 25000
@@ -43,10 +45,8 @@ class ObjectsInMemoryJsonlDB extends ObjectsInMemoryFileDB {
             }
         };
         settings.jsonlDB = {
-            fileName: 'objects.jsonl',
-            options: jsonlOptions
+            fileName: 'objects.jsonl'
         };
-        super(settings);
 
         /** @type {JsonlDB<any>} */
         this._db = new JsonlDB(path.join(this.dataDir, settings.jsonlDB.fileName), jsonlOptions);

--- a/packages/db-objects-jsonl/lib/objects/objectsInMemJsonlDB.js
+++ b/packages/db-objects-jsonl/lib/objects/objectsInMemJsonlDB.js
@@ -16,6 +16,8 @@
 const ObjectsInMemoryFileDB = require('@iobroker/db-objects-file').ObjectsInMemoryFileDB;
 const { JsonlDB } = require('@alcalzone/jsonl-db');
 const path = require('path');
+const fs = require('fs');
+const os = require('os');
 
 /**
  * This class inherits InMemoryFileDB class and adds all relevant logic for objects
@@ -88,15 +90,59 @@ class ObjectsInMemoryJsonlDB extends ObjectsInMemoryFileDB {
                 };
             }
         });
+
+        if (this.settings.backup && this.settings.backup.period && !this.settings.backup.disabled) {
+            this._backupInterval = setInterval(() => {
+                this.saveBackup();
+            }, this.settings.backup.period);
+        }
     }
 
     async saveState() {
         // Nothing to do, the DB saves behind the scenes
     }
 
+    // Is regularly called and stores a compressed backup of the DB
+    async saveBackup() {
+        const now = Date.now();
+        const tmpBackupFileName = path.join(os.tmpdir(), this.getTimeStr(now) + '_' + this.settings.jsonlDB.fileName);
+        const backupFileName = path.join(
+            this.backupDir,
+            this.getTimeStr(now) + '_' + this.settings.jsonlDB.fileName + '.gz'
+        );
+        try {
+            if (fs.existsSync(backupFileName)) {
+                return;
+            }
+
+            // Create a DB dump
+            await this._db.dump(tmpBackupFileName);
+            // and zip it
+
+            const zlib = require('zlib');
+            const input = fs.createReadStream(tmpBackupFileName);
+            const output = fs.createWriteStream(backupFileName);
+            output.on('error', err => {
+                this.log.error(`${this.namespace} Cannot save ${this.datasetName}: ${err}`);
+            });
+            const compress = zlib.createGzip();
+            input.pipe(compress).pipe(output);
+
+            fs.unlinkSync(tmpBackupFileName);
+
+            // analyse older files
+            this.deleteOldBackupFiles(this.settings.jsonlDB.fileName);
+        } catch (e) {
+            this.log.error(`${this.namespace} Cannot save backup ${backupFileName}: ${e.message}`);
+        }
+    }
+
     async destroy() {
         if (this._db) {
             await this._db.close();
+        }
+        if (this._backupInterval) {
+            clearInterval(this._backupInterval);
         }
     }
 }

--- a/packages/db-objects-jsonl/package.json
+++ b/packages/db-objects-jsonl/package.json
@@ -5,7 +5,7 @@
     "node": ">=12.0.0"
   },
   "dependencies": {
-    "@alcalzone/jsonl-db": "^2.2.0",
+    "@alcalzone/jsonl-db": "~2.3.0",
     "@iobroker/db-base": "file:../db-base",
     "@iobroker/db-objects-file": "file:../db-objects-file",
     "@iobroker/db-objects-redis": "file:../db-objects-redis",

--- a/packages/db-states-jsonl/lib/states/statesInMemJsonlDB.js
+++ b/packages/db-states-jsonl/lib/states/statesInMemJsonlDB.js
@@ -53,8 +53,10 @@ class StatesInMemoryJsonlDB extends StatesInMemoryFileDB {
             fileName: 'states.json',
             backupDirName: 'backup-objects'
         };
+        super(settings);
+
         /** @type {import("@alcalzone/jsonl-db").JsonlDBOptions<any>} */
-        const jsonlOptions = {
+        const jsonlOptions = this.settings.connection.jsonlOptions || {
             autoCompress: {
                 sizeFactor: 10,
                 sizeFactorMinimumSize: 50000
@@ -66,10 +68,8 @@ class StatesInMemoryJsonlDB extends StatesInMemoryFileDB {
             }
         };
         settings.jsonlDB = {
-            fileName: 'states.jsonl',
-            options: jsonlOptions
+            fileName: 'states.jsonl'
         };
-        super(settings);
 
         /** @type {JsonlDB<any>} */
         this._db = new JsonlDB(path.join(this.dataDir, settings.jsonlDB.fileName), jsonlOptions);

--- a/packages/db-states-jsonl/lib/states/statesInMemJsonlDB.js
+++ b/packages/db-states-jsonl/lib/states/statesInMemJsonlDB.js
@@ -17,6 +17,8 @@
 const StatesInMemoryFileDB = require('@iobroker/db-states-file').StatesInMemoryFileDB;
 const { JsonlDB } = require('@alcalzone/jsonl-db');
 const path = require('path');
+const fs = require('fs');
+const os = require('os');
 
 // settings = {
 //    change:    function (id, state) {},
@@ -111,15 +113,59 @@ class StatesInMemoryJsonlDB extends StatesInMemoryFileDB {
                 };
             }
         });
+
+        if (this.settings.backup && this.settings.backup.period && !this.settings.backup.disabled) {
+            this._backupInterval = setInterval(() => {
+                this.saveBackup();
+            }, this.settings.backup.period);
+        }
     }
 
     async saveState() {
         // Nothing to do, the DB saves behind the scenes
     }
 
+    // Is regularly called and stores a compressed backup of the DB
+    async saveBackup() {
+        const now = Date.now();
+        const tmpBackupFileName = path.join(os.tmpdir(), this.getTimeStr(now) + '_' + this.settings.jsonlDB.fileName);
+        const backupFileName = path.join(
+            this.backupDir,
+            this.getTimeStr(now) + '_' + this.settings.jsonlDB.fileName + '.gz'
+        );
+        try {
+            if (fs.existsSync(backupFileName)) {
+                return;
+            }
+
+            // Create a DB dump
+            await this._db.dump(tmpBackupFileName);
+            // and zip it
+
+            const zlib = require('zlib');
+            const input = fs.createReadStream(tmpBackupFileName);
+            const output = fs.createWriteStream(backupFileName);
+            output.on('error', err => {
+                this.log.error(`${this.namespace} Cannot save ${this.datasetName}: ${err}`);
+            });
+            const compress = zlib.createGzip();
+            input.pipe(compress).pipe(output);
+
+            fs.unlinkSync(tmpBackupFileName);
+
+            // analyse older files
+            this.deleteOldBackupFiles(this.settings.jsonlDB.fileName);
+        } catch (e) {
+            this.log.error(`${this.namespace} Cannot save backup ${backupFileName}: ${e.message}`);
+        }
+    }
+
     async destroy() {
         if (this._db) {
             await this._db.close();
+        }
+        if (this._backupInterval) {
+            clearInterval(this._backupInterval);
         }
     }
 }

--- a/packages/db-states-jsonl/package.json
+++ b/packages/db-states-jsonl/package.json
@@ -5,7 +5,7 @@
     "node": ">=12.0.0"
   },
   "dependencies": {
-    "@alcalzone/jsonl-db": "^2.2.0",
+    "@alcalzone/jsonl-db": "~2.3.0",
     "@iobroker/db-base": "file:../db-base",
     "@iobroker/db-states-file": "file:../db-states-file",
     "@iobroker/db-states-redis": "file:../db-states-redis"


### PR DESCRIPTION
This PR adds a few improvements to the JSONL-DB:

- Settings are loaded from the iobroker config if possible
- Backups are automatically created. They work a bit differently, because the DB lib writes to files directly to avoid caching issues. The dump file gets written, then passed through a GZIP stream and piped into the destination file.

Are the gzipped backups restored automatically somehow or is it okay if I just write them?