### PR TITLE
perf: update jsonl-db lib, increase objects buffer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -375,7 +375,7 @@
     "@iobroker/db-objects-jsonl": {
       "version": "file:packages/db-objects-jsonl",
       "requires": {
-        "@alcalzone/jsonl-db": "~2.4.0",
+        "@alcalzone/jsonl-db": "~2.4.1",
         "@iobroker/db-base": "file:packages/db-base",
         "@iobroker/db-objects-file": "file:packages/db-objects-file",
         "@iobroker/db-objects-redis": "file:packages/db-objects-redis",
@@ -404,7 +404,7 @@
     "@iobroker/db-states-jsonl": {
       "version": "file:packages/db-states-jsonl",
       "requires": {
-        "@alcalzone/jsonl-db": "~2.4.0",
+        "@alcalzone/jsonl-db": "~2.4.1",
         "@iobroker/db-base": "file:packages/db-base",
         "@iobroker/db-states-file": "file:packages/db-states-file",
         "@iobroker/db-states-redis": "file:packages/db-states-redis"

--- a/packages/db-objects-jsonl/lib/objects/objectsInMemJsonlDB.js
+++ b/packages/db-objects-jsonl/lib/objects/objectsInMemJsonlDB.js
@@ -42,7 +42,7 @@ class ObjectsInMemoryJsonlDB extends ObjectsInMemoryFileDB {
             ignoreReadErrors: true,
             throttleFS: {
                 intervalMs: 60000,
-                maxBufferedCommands: 100
+                maxBufferedCommands: 1000
             }
         };
         settings.jsonlDB = {

--- a/packages/db-objects-jsonl/package.json
+++ b/packages/db-objects-jsonl/package.json
@@ -5,7 +5,7 @@
     "node": ">=12.0.0"
   },
   "dependencies": {
-    "@alcalzone/jsonl-db": "~2.4.0",
+    "@alcalzone/jsonl-db": "~2.4.1",
     "@iobroker/db-base": "file:../db-base",
     "@iobroker/db-objects-file": "file:../db-objects-file",
     "@iobroker/db-objects-redis": "file:../db-objects-redis",

--- a/packages/db-states-jsonl/package.json
+++ b/packages/db-states-jsonl/package.json
@@ -5,7 +5,7 @@
     "node": ">=12.0.0"
   },
   "dependencies": {
-    "@alcalzone/jsonl-db": "~2.4.0",
+    "@alcalzone/jsonl-db": "~2.4.1",
     "@iobroker/db-base": "file:../db-base",
     "@iobroker/db-states-file": "file:../db-states-file",
     "@iobroker/db-states-redis": "file:../db-states-redis"


### PR DESCRIPTION
The updated JSONL-DB library improves write performance by writing once instead of each line separately. It does make a little bit of a difference on my test ioBroker, but not as much as expected.

Increasing the objects buffer to 1000 also improves throughput a bit.