### PR TITLE
fix backup issues

### DIFF
--- a/packages/controller/lib/setup/setupBackup.js
+++ b/packages/controller/lib/setup/setupBackup.js
@@ -672,7 +672,7 @@ class BackupRestore {
         if (!force) {
             const exitCode = this._ensureCompatibility(
                 controllerDir,
-                restore.config.system.hostname || hostname,
+                restore.config ? restore.config.system.hostname || hostname : hostname,
                 restore.objects
             );
 

--- a/packages/controller/lib/setup/setupSetup.js
+++ b/packages/controller/lib/setup/setupSetup.js
@@ -44,10 +44,10 @@ function Setup(options) {
             return;
         }
 
-        for (let i = 0; i < dirpath.length; i++) {
-            rootpath = path.join(rootpath, dirpath[i]);
+        for (const dir of dirpath) {
+            rootpath = path.join(rootpath, dir);
             if (!fs.existsSync(rootpath)) {
-                if (dirpath[i] !== '..') {
+                if (dir !== '..') {
                     fs.mkdirSync(rootpath);
                 } else {
                     throw new Error(`Cannot create ${rootpath}${dirpath.join('/')}`);
@@ -554,9 +554,9 @@ function Setup(options) {
                         });
                         console.log('Restore backup ...');
                         console.log(`${COLOR_GREEN}This can take some time ... please be patient!${COLOR_RESET}`);
-                        backup.restoreBackup(filePath, err => {
+                        backup.restoreBackup(filePath, false, err => {
                             if (err) {
-                                console.log('Error happened during restore: ' + err);
+                                console.log(`Error happened during restore: ${err.message}`);
                                 console.log();
                                 console.log('restoring conf/' + tools.appName + '.json');
                                 fs.writeFileSync(tools.getConfigFileName(), JSON.stringify(oldConfig, null, 2));


### PR DESCRIPTION
missing param passed to restore lead to custom being executed with force -> calling setup first unnecessarily + hangs because of missing cb

on setup custom we use `noConfig` to not save config in backups, thus this has resulted in a crash because we assumed config is always there.