### PR TITLE
feat: auto-migrate fileDB or its backup to jsonl if newer/exists already

### DIFF
--- a/packages/controller/lib/setup/setupSetup.js
+++ b/packages/controller/lib/setup/setupSetup.js
@@ -376,6 +376,7 @@ function Setup(options) {
         const oldObjectsLocalServer = dbTools.isLocalObjectsDbServer(oldConfig.objects.type, oldConfig.objects.host);
         const newStatesLocalServer = dbTools.isLocalStatesDbServer(newConfig.states.type, newConfig.states.host);
         const newObjectsLocalServer = dbTools.isLocalObjectsDbServer(newConfig.objects.type, newConfig.objects.host);
+
         if (
             oldConfig &&
             (oldConfig.states.type !== newConfig.states.type ||
@@ -457,6 +458,17 @@ function Setup(options) {
                     console.log('directory!');
                 }
                 console.log(COLOR_RESET);
+            }
+
+            // FileDB -> JSONL migration is handled in the DB classes. Skip migration if both DBs are changed from File -> JsonL
+            if (
+                (oldConfig.states.type === newConfig.states.type ||
+                    (oldConfig.states.type === 'file' && newConfig.states.type === 'jsonl')) &&
+                (oldConfig.objects.type === newConfig.objects.type ||
+                    (oldConfig.objects.type === 'file' && newConfig.objects.type === 'jsonl'))
+            ) {
+                console.log('Explicit migration from file to jsonl is not necessary, skipping...');
+                allowMigration = false;
             }
 
             let answer = 'N';

--- a/packages/db-states-jsonl/lib/states/statesInMemJsonlDB.js
+++ b/packages/db-states-jsonl/lib/states/statesInMemJsonlDB.js
@@ -77,7 +77,9 @@ class StatesInMemoryJsonlDB extends StatesInMemoryFileDB {
     }
 
     async open() {
-        await this._db.open();
+        if (!(await this._maybeMigrateFileDB())) {
+            await this._db.open();
+        }
 
         // Create an object-like wrapper around the internal Map
         this.dataset = new Proxy(this._db, {
@@ -120,6 +122,83 @@ class StatesInMemoryJsonlDB extends StatesInMemoryFileDB {
                 this.saveBackup();
             }, this.settings.backup.period);
         }
+    }
+
+    /**
+     * Checks if an existing file DB should be migrated to JSONL
+     * @returns {Promise<boolean>} true if the file DB was migrated. false if not.
+     * If this returns true, the jsonl DB was opened and doesn't need to be opened again.
+     */
+    async _maybeMigrateFileDB() {
+        const jsonlFileName = path.join(this.dataDir, this.settings.jsonlDB.fileName);
+        const jsonFileName = path.join(this.dataDir, this.settings.fileDB.fileName);
+        const bakFileName = path.join(this.dataDir, this.settings.fileDB.fileName + '.bak');
+
+        // Check the timestamps of each file, defaulting to 0 if they don't exist
+        let jsonlTimeStamp = 0;
+        let jsonTimeStamp = 0;
+        let bakTimeStamp = 0;
+        try {
+            const stat = fs.statSync(jsonlFileName);
+            if (stat.isFile()) {
+                jsonlTimeStamp = stat.mtime;
+            }
+        } catch {
+            // ignore
+        }
+        try {
+            const stat = fs.statSync(jsonFileName);
+            if (stat.isFile()) {
+                jsonTimeStamp = stat.mtime;
+            }
+        } catch {
+            // ignore
+        }
+        try {
+            const stat = fs.statSync(bakFileName);
+            if (stat.isFile()) {
+                bakTimeStamp = stat.mtime;
+            }
+        } catch {
+            // ignore
+        }
+
+        // If there is nothing to restore, we're done
+        if (jsonTimeStamp === 0 && bakTimeStamp === 0) {
+            return false;
+        }
+
+        // Figure out which file needs to be imported
+        /** @type {string} */
+        let importFilename;
+        if (bakTimeStamp > 0 && bakTimeStamp > jsonTimeStamp && bakTimeStamp > jsonlTimeStamp) {
+            importFilename = bakFileName;
+        } else if (jsonTimeStamp > 0 && jsonTimeStamp > bakTimeStamp && jsonTimeStamp > jsonlTimeStamp) {
+            importFilename = jsonFileName;
+        }
+
+        await this._db.open();
+        this._db.clear();
+        await this._db.importJson(importFilename);
+
+        // And rename the existing files to avoid redoing the work next time
+        if (fs.existsSync(jsonFileName)) {
+            try {
+                fs.renameSync(jsonFileName, jsonFileName + '.migrated');
+            } catch {
+                // ignore
+            }
+        }
+        if (fs.existsSync(bakFileName)) {
+            try {
+                fs.renameSync(bakFileName, bakFileName + '.migrated');
+            } catch {
+                // ignore
+            }
+        }
+
+        // Signal to the caller that the DB is already open
+        return true;
     }
 
     async saveState() {


### PR DESCRIPTION
Implements these parts

> * We add a migration logic to the jsonl class that:
>     * when no jsonl file exists but a json/json.bak file it reads the json file (old style logic incl. fallbacks) and initialize the jsonl with it (https://github.com/AlCalzone/jsonl-db#import--export)
>     * if jsonl exists but an existing json/json.bak has newer date also obverwrite jsonl with the json file (?)
>     * When this was done the json files should be renamed to e.g. "*.automigrated" or such, also that next starts do not have to check them all the time

from https://github.com/ioBroker/ioBroker.js-controller/issues/1460#issuecomment-1004417929