### PR TITLE
Make Loglevel consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,7 +317,7 @@ The logging is configured in the `iobroker.json` file and can be changed there:
 }
 ```
 
-If you want to pin a special loglevel for the file transport you can add a property "level" with a hard defined loglevel. Then no dynamic control are possible.
+If you want to pin a special loglevel for the file transport you can add a property "level" with a hard defined loglevel. Then no dynamic control is possible.
 
 Since js-controller 3.0 Logfiles on non-Windows based systems are compressed on rotation, so that the older Files need less space on your storage. 
 
@@ -374,13 +374,13 @@ ioBroker also supports logging to a syslog server. The configuration is also sto
 }
 ```
 
-If you want to pin a special loglevel for the file transport you can add a property "level" with a hard defined loglevel. Then no dynamic control are possible.
+If you want to pin a special loglevel for the file transport you can add a property "level" with a hard defined loglevel. Then no dynamic control is possible.
 
 #### Other Log transports
 
 See the iobroker.json and Admin for more transports and their settings.
 
-If you want to pin a special loglevel for the file transport you can add a property "level" with a hard defined loglevel. Then no dynamic control are possible.
+If you want to pin a special loglevel for the file transport you can add a property "level" with a hard defined loglevel. Then no dynamic control is possible.
 
 #### Adapters allow to subscribe to logs
 **Feature status:** stable

--- a/README.md
+++ b/README.md
@@ -285,6 +285,8 @@ The log level can be changed dynamically for adapter-instance and host (main con
 
 The states `system.adapter.xy.logLevel` and `system.host.hostname.logLevel` are updated on instance/controller start with the configured log level and can afterwards be used to change the loglevel during runtime. These changes are __not__ persisted, so the next restarts resets the loglevel to the configured one.
 
+The Loglevel change is only effective if there is no loglevel (property "level") defined on the transport configuration.
+
 This possibility allows to debug adapters better and during runtime.
 
 #### File based logging
@@ -314,6 +316,8 @@ The logging is configured in the `iobroker.json` file and can be changed there:
   ...
 }
 ```
+
+If you want to pin a special loglevel for the file transport you can add a property "level" with a hard defined loglevel. Then no dynamic control are possible.
 
 Since js-controller 3.0 Logfiles on non-Windows based systems are compressed on rotation, so that the older Files need less space on your storage. 
 
@@ -369,6 +373,14 @@ ioBroker also supports logging to a syslog server. The configuration is also sto
   ...
 }
 ```
+
+If you want to pin a special loglevel for the file transport you can add a property "level" with a hard defined loglevel. Then no dynamic control are possible.
+
+#### Other Log transports
+
+See the iobroker.json and Admin for more transports and their settings.
+
+If you want to pin a special loglevel for the file transport you can add a property "level" with a hard defined loglevel. Then no dynamic control are possible.
 
 #### Adapters allow to subscribe to logs
 **Feature status:** stable

--- a/packages/adapter/lib/adapter/adapter.js
+++ b/packages/adapter/lib/adapter/adapter.js
@@ -6007,7 +6007,10 @@ function Adapter(options) {
                                 if (!Object.prototype.hasOwnProperty.call(logger.transports, transport)) {
                                     continue;
                                 }
-                                logger.transports[transport].level = state.val;
+                                // set the loglevel on transport only if no loglevel was pinned in log config
+                                if (!logger.transports[transport]._defaultConfigLoglevel) {
+                                    logger.transports[transport].level = state.val;
+                                }
                             }
                             logger.info(
                                 `${this.namespaceLog} Loglevel changed from "${currentLevel}" to "${state.val}"`
@@ -9093,7 +9096,10 @@ function Adapter(options) {
                     if (adapterConfig.common.loglevel && !this.overwriteLogLevel) {
                         // set configured in DB log level
                         for (const trans of Object.keys(logger.transports)) {
-                            logger.transports[trans].level = adapterConfig.common.loglevel;
+                            // set the loglevel on transport only if no loglevel was pinned in log config
+                            if (!logger.transports[trans]._defaultConfigLoglevel) {
+                                logger.transports[trans].level = adapterConfig.common.loglevel;
+                            }
                         }
                         config.log.level = adapterConfig.common.loglevel;
                     }

--- a/packages/common/lib/common/logger.js
+++ b/packages/common/lib/common/logger.js
@@ -162,6 +162,10 @@ const logger = function (level, files, noStdout, prefix) {
             const isWindows = os.platform().startsWith('win');
             Object.keys(userOptions.transport).forEach(f => {
                 const transport = userOptions.transport[f];
+
+                transport._defaultConfigLoglevel = transport.level; // remember Loglevel if set
+                transport.level = transport.level || level;
+
                 if (transport.type === 'file' && transport.enabled !== false) {
                     transport.filename = transport.filename || 'log/' + tools.appName;
 
@@ -195,7 +199,6 @@ const logger = function (level, files, noStdout, prefix) {
 
                     transport.filename += '.%DATE%' + (transport.fileext || '');
                     //transport.label       = prefix || ''; //TODO format.label()
-                    transport.level = transport.level || level;
                     //                    transport.json        = (transport.json      !== undefined) ? transport.json      : false; // TODO format.json(), new Default!!
                     transport.silent = transport.silent !== undefined ? transport.silent : false;
                     //                    transport.colorize    = (transport.colorize  !== undefined) ? transport.colorize  : ((userOptions.colorize  === undefined) ? true : userOptions.colorize); //TODO format.colorize()

--- a/packages/controller/main.js
+++ b/packages/controller/main.js
@@ -460,7 +460,10 @@ function createStates(onConnect) {
                 ) {
                     config.log.level = state.val;
                     for (const transport of Object.keys(logger.transports)) {
-                        if (logger.transports[transport].level === currentLevel) {
+                        if (
+                            logger.transports[transport].level === currentLevel &&
+                            !logger.transports[transport]._defaultConfigLoglevel
+                        ) {
                             logger.transports[transport].level = state.val;
                         }
                     }


### PR DESCRIPTION
* remember if the config had a level set and preserve this on any dynamic changes, make feature consistent.

Logic is as follows: Configure s level in the log definieion and this will be the static loglevel for this transport. No dynamic changes! If left emoty the logevel set on adapter and controller stays defined

fixes #1322 