### PR TITLE
perf: avoid reading `dataset[id]` multiple times

### DIFF
--- a/packages/db-objects-file/lib/objects/objectsInMemServerRedis.js
+++ b/packages/db-objects-file/lib/objects/objectsInMemServerRedis.js
@@ -349,7 +349,7 @@ class ObjectsInMemoryServer extends ObjectsInMemoryFileDB {
                             )
                         );
                     }
-                    const res = objs.rows.map(obj => JSON.stringify(this.dataset[obj.value._id || obj.id]));
+                    const res = objs.rows.map(obj => JSON.stringify(obj.value));
                     handler.sendArray(responseId, res);
                 }
             } else if (this.knownScripts[data[0]].func && data.length > 4) {
@@ -362,7 +362,7 @@ class ObjectsInMemoryServer extends ObjectsInMemoryFileDB {
                     endkey: data[4],
                     include_docs: true
                 });
-                const res = objs.rows.map(obj => JSON.stringify(this.dataset[obj.value._id || obj.id]));
+                const res = objs.rows.map(obj => JSON.stringify(obj.value));
 
                 return void handler.sendArray(responseId, res);
             } else if (this.knownScripts[data[0]].redlock) {

--- a/packages/db-objects-jsonl/lib/objects/objectsInMemServerRedis.js
+++ b/packages/db-objects-jsonl/lib/objects/objectsInMemServerRedis.js
@@ -348,7 +348,7 @@ class ObjectsInMemoryServer extends ObjectsInMemoryJsonlDB {
                             )
                         );
                     }
-                    const res = objs.rows.map(obj => JSON.stringify(this.dataset[obj.value._id || obj.id]));
+                    const res = objs.rows.map(obj => JSON.stringify(obj.value));
                     handler.sendArray(responseId, res);
                 }
             } else if (this.knownScripts[data[0]].func && data.length > 4) {
@@ -361,7 +361,7 @@ class ObjectsInMemoryServer extends ObjectsInMemoryJsonlDB {
                     endkey: data[4],
                     include_docs: true
                 });
-                const res = objs.rows.map(obj => JSON.stringify(this.dataset[obj.value._id || obj.id]));
+                const res = objs.rows.map(obj => JSON.stringify(obj.value));
 
                 return void handler.sendArray(responseId, res);
             } else if (this.knownScripts[data[0]].redlock) {


### PR DESCRIPTION
Found this while optimizing my native jsonl implementation. Each `dataset[id]` triggered another read from the DB, especially the `.map` calls in `getObjectView`.