### PR TITLE
rename binary state operations to foreign to allow adapter to migrate…

### DIFF
--- a/packages/adapter/src/lib/adapter/adapter.js
+++ b/packages/adapter/src/lib/adapter/adapter.js
@@ -8385,7 +8385,7 @@ function Adapter(options) {
         this.setForeignBinaryStateAsync = tools.promisify(this.setForeignBinaryState, this);
 
         /**
-         * Same as setForeignBinaryState but calls fixId first
+         * Same as setForeignBinaryState but prefixes the own namespace to the id
          *
          * @alias setBinaryState
          * @memberof Adapter
@@ -8396,9 +8396,9 @@ function Adapter(options) {
          * @param {ioBroker.ErrorCallback} [callback]
          */
         this.setBinaryState = (id, binary, options, callback) => {
-            // TODO: call fix id as soon as adapters are migrated to setForeignBinaryState
+            // TODO: call fixId as soon as adapters are migrated to setForeignBinaryState
             // id = utils.fixId(id, false);
-            return this.setBinaryState(id, binary, options, callback);
+            return this.setForeignBinaryState(id, binary, options, callback);
         };
 
         /**
@@ -8482,7 +8482,7 @@ function Adapter(options) {
         this.getForeignBinaryStateAsync = tools.promisify(this.getBinaryState, this);
 
         /**
-         * Same as getForeignBinaryState but calls fixId first
+         * Same as getForeignBinaryState but prefixes the own namespace to the id
          *
          * @param {string} id The state ID
          * @param {object} options optional

--- a/packages/adapter/src/lib/adapter/adapter.js
+++ b/packages/adapter/src/lib/adapter/adapter.js
@@ -8479,7 +8479,7 @@ function Adapter(options) {
          * @memberof Adapter
          *
          */
-        this.getForeignBinaryStateAsync = tools.promisify(this.getBinaryState, this);
+        this.getForeignBinaryStateAsync = tools.promisify(this.getForeignBinaryState, this);
 
         /**
          * Same as getForeignBinaryState but prefixes the own namespace to the id

--- a/packages/adapter/src/lib/adapter/adapter.js
+++ b/packages/adapter/src/lib/adapter/adapter.js
@@ -85,6 +85,7 @@ function Adapter(options) {
         throw new Error('Configuration not set!');
     }
 
+    /** @type Utils*/
     let utils;
     let schedule;
     let restartScheduleJob;
@@ -8259,7 +8260,7 @@ function Adapter(options) {
         /**
          * Write binary block into redis, e.g image
          *
-         * @alias setBinaryState
+         * @alias setForeignBinaryState
          * @memberof Adapter
          *
          * @param {string} id of state
@@ -8268,7 +8269,7 @@ function Adapter(options) {
          * @param {ioBroker.ErrorCallback} [callback]
          *
          */
-        this.setBinaryState = async (id, binary, options, callback) => {
+        this.setForeignBinaryState = async (id, binary, options, callback) => {
             if (typeof options === 'function') {
                 callback = options;
                 options = {};
@@ -8369,20 +8370,50 @@ function Adapter(options) {
                 adapterStates.setBinaryState(id, binary, callback);
             }
         };
+
         /**
          * Promise-version of Adapter.setBinaryState
          *
-         * @alias setBinaryStateAsync
+         * @alias setForeignBinaryStateAsync
          * @memberof Adapter
          * @param {string} id of state
          * @param {Buffer} binary data
          * @param {object} [options] optional
-         * @return promise
+         * @return {Promise}
          *
+         */
+        this.setForeignBinaryStateAsync = tools.promisify(this.setForeignBinaryState, this);
+
+        /**
+         * Same as setForeignBinaryState but calls fixId first
+         *
+         * @alias setBinaryState
+         * @memberof Adapter
+         *
+         * @param {string} id of state
+         * @param {Buffer} binary data
+         * @param {object} [options] optional
+         * @param {ioBroker.ErrorCallback} [callback]
+         */
+        this.setBinaryState = (id, binary, options, callback) => {
+            // TODO: call fix id as soon as adapters are migrated to setForeignBinaryState
+            // id = utils.fixId(id, false);
+            return this.setBinaryState(id, binary, options, callback);
+        };
+
+        /**
+         * Async version of setBinaryState
+         *
+         * @alias setBinaryStateAsync
+         * @memberof Adapter
+         *
+         * @param {string} id of state
+         * @param {Buffer} binary data
+         * @param {object} [options] optional
+         * @param {Promise<void>}
          */
         this.setBinaryStateAsync = tools.promisify(this.setBinaryState, this);
 
-        // Read binary block from redis, e.g. image
         /**
          * Read a binary block from redis, e.g. an image
          *
@@ -8390,7 +8421,7 @@ function Adapter(options) {
          * @param {object} options optional
          * @param {ioBroker.GetBinaryStateCallback} callback
          */
-        this.getBinaryState = (id, options, callback) => {
+        this.getForeignBinaryState = (id, options, callback) => {
             if (typeof options === 'function') {
                 callback = options;
                 options = {};
@@ -8444,9 +8475,31 @@ function Adapter(options) {
         /**
          * Promise-version of Adapter.getBinaryState
          *
-         * @alias getBinaryStateAsync
+         * @alias getForeignBinaryStateAsync
          * @memberof Adapter
          *
+         */
+        this.getForeignBinaryStateAsync = tools.promisify(this.getBinaryState, this);
+
+        /**
+         * Same as getForeignBinaryState but calls fixId first
+         *
+         * @param {string} id The state ID
+         * @param {object} options optional
+         * @param {ioBroker.GetBinaryStateCallback} callback
+         */
+        this.getBinaryState = (id, options, callback) => {
+            // TODO: fixId as soon as all adapters are migrated to setForeignBinaryState
+            // id = utils.fixId(id);
+            return this.getForeignBinaryState(id, options, callback);
+        };
+
+        /**
+         * Promisified version of getBinaryState
+         *
+         * @param {string} id The state ID
+         * @param {object} options optional
+         * @return {Promise<Buffer>}
          */
         this.getBinaryStateAsync = tools.promisify(this.getBinaryState, this);
 

--- a/packages/controller/test/lib/testFiles.js
+++ b/packages/controller/test/lib/testFiles.js
@@ -15,6 +15,24 @@ function register(it, expect, context) {
     // writeFile
 
     // setBinaryState
+    it(testName + 'setForeignBinaryState', async () => {
+        const objId = `${context.adapter.namespace}.testSetForeignBinaryState`;
+        // create an object of type file first
+        await context.adapter.setForeignObjectAsync(objId, {
+            type: 'state',
+            common: {
+                name: objId,
+                read: true,
+                write: true,
+                type: 'file'
+            },
+            native: {}
+        });
+
+        // now we write a binary state
+        await context.adapter.setForeignBinaryStateAsync(objId, Buffer.from('1234'));
+    });
+
     it(testName + 'setBinaryState', async () => {
         const objId = `${context.adapter.namespace}.testSetBinaryState`;
         // create an object of type file first
@@ -33,7 +51,47 @@ function register(it, expect, context) {
         await context.adapter.setBinaryStateAsync(objId, Buffer.from('1234'));
     });
 
-    // getBinaryState
+    it(testName + 'getForeignBinaryState', async () => {
+        const objId = `${context.adapter.namespace}.testGetForeignBinaryState`;
+        // create an object of type file first
+        await context.adapter.setForeignObjectAsync(objId, {
+            type: 'state',
+            common: {
+                name: objId,
+                read: true,
+                write: true,
+                type: 'file'
+            },
+            native: {}
+        });
+
+        // now we write a binary state
+        await context.adapter.setForeignBinaryStateAsync(objId, Buffer.from('1234'));
+        /** @type Buffer */
+        const state = await context.adapter.getForeignBinaryStateAsync(objId);
+        expect(state.toString('utf-8')).to.be.equal('1234');
+    });
+
+    it(testName + 'getBinaryState', async () => {
+        const objId = `${context.adapter.namespace}.testGetBinaryState`;
+        // create an object of type file first
+        await context.adapter.setForeignObjectAsync(objId, {
+            type: 'state',
+            common: {
+                name: objId,
+                read: true,
+                write: true,
+                type: 'file'
+            },
+            native: {}
+        });
+
+        // now we write a binary state
+        await context.adapter.setBinaryStateAsync(objId, Buffer.from('1234'));
+        /** @type Buffer */
+        const state = await context.adapter.getBinaryStateAsync(objId);
+        expect(state.toString('utf-8')).to.be.equal('1234');
+    });
 }
 
 module.exports.register = register;


### PR DESCRIPTION
… to new methods with controller v4 dependency

- affects #1674

If controller v4 is released, we should migrate adapters to setForeign methods and if no one is using the non-foreign method anymore we can introduce fixId to them.