### PR TITLE
if we cannot de/activate sets globally do not use other behavior locally

### DIFF
--- a/packages/cli/lib/cli/cliPlugin.js
+++ b/packages/cli/lib/cli/cliPlugin.js
@@ -6,11 +6,11 @@ const { tools } = require('@iobroker/js-controller-common');
 const fs = require('fs');
 const path = require('path');
 
-const controllerIoPackPath = path.join(__dirname, '../../io-package.json');
+const controllerIoPackPath = require.resolve('iobroker.js-controller/io-package.json');
 
 /** Command iobroker plugin <enable/disable/status> <pluginname> [--host this/hostname] ... */
 module.exports = class CLIPlugin extends CLICommand {
-    /** @param {import('./cliCommand').CLICommandOptions} options */
+    /** @param {CLICommandOptions} options */
     constructor(options) {
         super(options);
     }

--- a/packages/controller/io-package.json
+++ b/packages/controller/io-package.json
@@ -1,7 +1,7 @@
 {
   "common": {
     "name": "js-controller",
-    "version": "4.0.4",
+    "version": "4.0.5",
     "platform": "Javascript/Node.js",
     "controller": true,
     "mode": "daemon",

--- a/packages/db-base/lib/redisHandler.js
+++ b/packages/db-base/lib/redisHandler.js
@@ -422,6 +422,11 @@ class RedisHandler extends EventEmitter {
      * @private
      */
     _handleExec(responseId) {
+        if (!this.activeMultiCalls[0]) {
+            this.sendError(responseId, new Error('EXEC without MULTI'));
+            return;
+        }
+
         this.activeMultiCalls[0].execId = responseId;
         this.activeMultiCalls[0].execCalled = true;
 

--- a/packages/db-objects-redis/lib/objects/objectsInRedisClient.js
+++ b/packages/db-objects-redis/lib/objects/objectsInRedisClient.js
@@ -4657,8 +4657,8 @@ class ObjectsInRedisClient {
      * @return {Promise<void>}
      */
     async activateSets() {
-        this.useSets = true;
         await this.client.set(`${this.metaNamespace}objects.features.useSets`, '1');
+        this.useSets = true;
     }
 
     /**
@@ -4666,8 +4666,8 @@ class ObjectsInRedisClient {
      * @return {Promise<void>}
      */
     async deactivateSets() {
-        this.useSets = false;
         await this.client.set(`${this.metaNamespace}objects.features.useSets`, '0');
+        this.useSets = false;
     }
 
     /**


### PR DESCRIPTION
- by setting the flag only internally if the meta set succeeds
- on exec calls without multi we respond with the same error as a real redis in our servers
- fixing the plugin cli by correctly resolving the controllers io-package.json