### PR TITLE
fix: prevent backup of jsonl DB when it is closed

### DIFF
--- a/packages/db-objects-jsonl/lib/objects/objectsInMemJsonlDB.js
+++ b/packages/db-objects-jsonl/lib/objects/objectsInMemJsonlDB.js
@@ -183,17 +183,18 @@ class ObjectsInMemoryJsonlDB extends ObjectsInMemoryFileDB {
 
     // Is regularly called and stores a compressed backup of the DB
     async saveBackup() {
-        if (!this._db.isOpen) {
-            this.log.warn(`${this.namespace} Cannot save backup ${backupFileName}: DB is closed`);
-            return;
-        }
-
         const now = Date.now();
         const tmpBackupFileName = path.join(os.tmpdir(), `${this.getTimeStr(now)}_${this.settings.jsonlDB.fileName}`);
         const backupFileName = path.join(
             this.backupDir,
             `${this.getTimeStr(now)}_${this.settings.jsonlDB.fileName}.gz`
         );
+
+        if (!this._db.isOpen) {
+            this.log.warn(`${this.namespace} Cannot save backup ${backupFileName}: DB is closed`);
+            return;
+        }
+
         try {
             if (fs.existsSync(backupFileName)) {
                 return;

--- a/packages/db-objects-jsonl/lib/objects/objectsInMemJsonlDB.js
+++ b/packages/db-objects-jsonl/lib/objects/objectsInMemJsonlDB.js
@@ -183,6 +183,11 @@ class ObjectsInMemoryJsonlDB extends ObjectsInMemoryFileDB {
 
     // Is regularly called and stores a compressed backup of the DB
     async saveBackup() {
+        if (!this._db.isOpen) {
+            this.log.warn(`${this.namespace} Cannot save backup ${backupFileName}: DB is closed`);
+            return;
+        }
+
         const now = Date.now();
         const tmpBackupFileName = path.join(os.tmpdir(), `${this.getTimeStr(now)}_${this.settings.jsonlDB.fileName}`);
         const backupFileName = path.join(
@@ -208,11 +213,11 @@ class ObjectsInMemoryJsonlDB extends ObjectsInMemoryFileDB {
     async destroy() {
         await super.destroy();
 
-        if (this._db) {
-            await this._db.close();
-        }
         if (this._backupInterval) {
             clearInterval(this._backupInterval);
+        }
+        if (this._db) {
+            await this._db.close();
         }
     }
 }

--- a/packages/db-states-jsonl/lib/states/statesInMemJsonlDB.js
+++ b/packages/db-states-jsonl/lib/states/statesInMemJsonlDB.js
@@ -206,6 +206,11 @@ class StatesInMemoryJsonlDB extends StatesInMemoryFileDB {
 
     // Is regularly called and stores a compressed backup of the DB
     async saveBackup() {
+        if (!this._db.isOpen) {
+            this.log.warn(`${this.namespace} Cannot save backup ${backupFileName}: DB is closed`);
+            return;
+        }
+
         const now = Date.now();
         const tmpBackupFileName = path.join(os.tmpdir(), `${this.getTimeStr(now)}_${this.settings.jsonlDB.fileName}`);
         const backupFileName = path.join(
@@ -231,11 +236,11 @@ class StatesInMemoryJsonlDB extends StatesInMemoryFileDB {
     async destroy() {
         await super.destroy();
 
-        if (this._db) {
-            await this._db.close();
-        }
         if (this._backupInterval) {
             clearInterval(this._backupInterval);
+        }
+        if (this._db) {
+            await this._db.close();
         }
     }
 }

--- a/packages/db-states-jsonl/lib/states/statesInMemJsonlDB.js
+++ b/packages/db-states-jsonl/lib/states/statesInMemJsonlDB.js
@@ -206,17 +206,18 @@ class StatesInMemoryJsonlDB extends StatesInMemoryFileDB {
 
     // Is regularly called and stores a compressed backup of the DB
     async saveBackup() {
-        if (!this._db.isOpen) {
-            this.log.warn(`${this.namespace} Cannot save backup ${backupFileName}: DB is closed`);
-            return;
-        }
-
         const now = Date.now();
         const tmpBackupFileName = path.join(os.tmpdir(), `${this.getTimeStr(now)}_${this.settings.jsonlDB.fileName}`);
         const backupFileName = path.join(
             this.backupDir,
             `${this.getTimeStr(now)}_${this.settings.jsonlDB.fileName}.gz`
         );
+
+        if (!this._db.isOpen) {
+            this.log.warn(`${this.namespace} Cannot save backup ${backupFileName}: DB is closed`);
+            return;
+        }
+
         try {
             if (fs.existsSync(backupFileName)) {
                 return;


### PR DESCRIPTION
fixes: #1779
I hope so at least. Next release of the jsonl-db library will also not throw an error in this case.