### PR TITLE
Prevent errors when jsonl-db auto-compression fails

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -69,8 +69,9 @@
       }
     },
     "node_modules/@alcalzone/jsonl-db": {
-      "version": "2.4.1",
-      "license": "MIT",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/@alcalzone/jsonl-db/-/jsonl-db-2.4.3.tgz",
+      "integrity": "sha512-ZQiVcu5CYSAjORngZIf4iVAj5pmJDFmaznY8Km1enuRhOeyyyVB1+ywhEXPhP6/vkmMB1ojlgCzZHFVYLF/9pw==",
       "dependencies": {
         "alcalzone-shared": "^4.0.1",
         "fs-extra": "^10.0.0",
@@ -14763,7 +14764,7 @@
       "version": "4.0.5",
       "license": "Apache 2.0",
       "dependencies": {
-        "@alcalzone/jsonl-db": "~2.4.1",
+        "@alcalzone/jsonl-db": "~2.4.3",
         "@iobroker/db-base": "file:../db-base",
         "@iobroker/db-objects-file": "file:../db-objects-file",
         "@iobroker/db-objects-redis": "file:../db-objects-redis",
@@ -14806,25 +14807,13 @@
       "version": "4.0.5",
       "license": "MIT",
       "dependencies": {
-        "@alcalzone/jsonl-db": "~2.4.1",
+        "@alcalzone/jsonl-db": "~2.4.3",
         "@iobroker/db-base": "file:../db-base",
         "@iobroker/db-states-file": "file:../db-states-file",
         "@iobroker/db-states-redis": "file:../db-states-redis"
       },
       "engines": {
         "node": ">=12.0.0"
-      }
-    },
-    "packages/db-states-jsonl/node_modules/@alcalzone/jsonl-db": {
-      "version": "2.4.1",
-      "license": "MIT",
-      "dependencies": {
-        "alcalzone-shared": "^4.0.1",
-        "fs-extra": "^10.0.0",
-        "proper-lockfile": "^4.1.2"
-      },
-      "engines": {
-        "node": ">=12"
       }
     },
     "packages/db-states-redis": {
@@ -14873,7 +14862,9 @@
       }
     },
     "@alcalzone/jsonl-db": {
-      "version": "2.4.1",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/@alcalzone/jsonl-db/-/jsonl-db-2.4.3.tgz",
+      "integrity": "sha512-ZQiVcu5CYSAjORngZIf4iVAj5pmJDFmaznY8Km1enuRhOeyyyVB1+ywhEXPhP6/vkmMB1ojlgCzZHFVYLF/9pw==",
       "requires": {
         "alcalzone-shared": "^4.0.1",
         "fs-extra": "^10.0.0",
@@ -15144,7 +15135,7 @@
     "@iobroker/db-objects-jsonl": {
       "version": "file:packages/db-objects-jsonl",
       "requires": {
-        "@alcalzone/jsonl-db": "~2.4.1",
+        "@alcalzone/jsonl-db": "~2.4.3",
         "@iobroker/db-base": "file:../db-base",
         "@iobroker/db-objects-file": "file:../db-objects-file",
         "@iobroker/db-objects-redis": "file:../db-objects-redis",
@@ -15172,20 +15163,10 @@
     "@iobroker/db-states-jsonl": {
       "version": "file:packages/db-states-jsonl",
       "requires": {
-        "@alcalzone/jsonl-db": "~2.4.1",
+        "@alcalzone/jsonl-db": "~2.4.3",
         "@iobroker/db-base": "file:../db-base",
         "@iobroker/db-states-file": "file:../db-states-file",
         "@iobroker/db-states-redis": "file:../db-states-redis"
-      },
-      "dependencies": {
-        "@alcalzone/jsonl-db": {
-          "version": "2.4.1",
-          "requires": {
-            "alcalzone-shared": "^4.0.1",
-            "fs-extra": "^10.0.0",
-            "proper-lockfile": "^4.1.2"
-          }
-        }
       }
     },
     "@iobroker/db-states-redis": {

--- a/packages/db-objects-jsonl/package.json
+++ b/packages/db-objects-jsonl/package.json
@@ -5,7 +5,7 @@
     "node": ">=12.0.0"
   },
   "dependencies": {
-    "@alcalzone/jsonl-db": "~2.4.1",
+    "@alcalzone/jsonl-db": "~2.4.3",
     "@iobroker/db-base": "file:../db-base",
     "@iobroker/db-objects-file": "file:../db-objects-file",
     "@iobroker/db-objects-redis": "file:../db-objects-redis",

--- a/packages/db-states-jsonl/package.json
+++ b/packages/db-states-jsonl/package.json
@@ -5,7 +5,7 @@
     "node": ">=12.0.0"
   },
   "dependencies": {
-    "@alcalzone/jsonl-db": "~2.4.1",
+    "@alcalzone/jsonl-db": "~2.4.3",
     "@iobroker/db-base": "file:../db-base",
     "@iobroker/db-states-file": "file:../db-states-file",
     "@iobroker/db-states-redis": "file:../db-states-redis"


### PR DESCRIPTION
followup to #1780
The new version of the lib catches errors during auto-compression