### PR TITLE
ci: avoid double-building in PRs

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -2,7 +2,7 @@ name: CI
 on:
   push:
     branches:
-      - "*"
+      - master
     tags: # for automatic releases
       # normal versions
       - "v[0-9]+.[0-9]+.[0-9]+"


### PR DESCRIPTION
All our PRs have builds for the push and the pull_request event. The latter is the important one because it tests the merge into master. This PR removes the branch builds, except for master, so we only have half the builds - and half the chance to fail randomly.