### PR TITLE
fix: carefully normalize jsonlOptions

### DIFF
--- a/packages/db-states-jsonl/lib/states/statesInMemJsonlDB.js
+++ b/packages/db-states-jsonl/lib/states/statesInMemJsonlDB.js
@@ -43,6 +43,68 @@ const { tools } = require('@iobroker/js-controller-common');
 //
 
 /**
+ * Normalizes options for the JsonlDB
+ * @param {Record<string, any> | undefined} conf The jsonlOptions options from iobroker.json
+ * @returns {import("@alcalzone/jsonl-db").JsonlDBOptions<any>}
+ */
+function normalizeJsonlOptions(conf = {}) {
+    /** @type {import("@alcalzone/jsonl-db").JsonlDBOptions<any>} */
+    const ret = {
+        autoCompress: {
+            sizeFactor: 10,
+            sizeFactorMinimumSize: 50000
+        },
+        ignoreReadErrors: true,
+        throttleFS: {
+            intervalMs: 60000,
+            maxBufferedCommands: 2000
+        },
+        lockfile: {
+            // 5 retries starting at 250ms add up to just above 2s,
+            // so the DB has 3 more seconds to load all data if it wants to stay within the 5s connectionTimeout
+            retries: 5,
+            retryMinTimeoutMs: 250,
+            // This makes sure the DB stays locked for maximum 2s even if the process crashes
+            staleMs: 2000
+        }
+    };
+
+    // Be really careful what we allow here. Incorrect settings may cause problems in production.
+    if (tools.isObject(conf.autoCompress)) {
+        const ac = conf.autoCompress;
+        // Letting the DB grow more than 100x is risky
+        if (typeof ac.sizeFactor === 'number' && ac.sizeFactor >= 2 && ac.sizeFactor <= 100) {
+            ret.autoCompress.sizeFactor = ac.sizeFactor;
+        }
+        // Also we should definitely compress once the DB has reached 200k lines or it might grow too big
+        if (
+            typeof ac.sizeFactorMinimumSize === 'number' &&
+            ac.sizeFactorMinimumSize >= 0 &&
+            ac.sizeFactorMinimumSize <= 200000
+        ) {
+            ret.autoCompress.sizeFactorMinimumSize = ac.sizeFactorMinimumSize;
+        }
+    }
+    if (tools.isObject(conf.throttleFS)) {
+        const thr = conf.throttleFS;
+        // Don't write more often than every second and write at least once every hour
+        if (typeof thr.intervalMs === 'number' && thr.intervalMs >= 1000 && thr.intervalMs <= 3600000) {
+            ret.throttleFS.intervalMs = thr.intervalMs;
+        }
+        // Don't keep too much in memory - 100k changes are more than enough
+        if (
+            typeof thr.maxBufferedCommands === 'number' &&
+            thr.maxBufferedCommands >= 0 &&
+            thr.maxBufferedCommands <= 100000
+        ) {
+            ret.throttleFS.maxBufferedCommands = thr.maxBufferedCommands;
+        }
+    }
+
+    return ret;
+}
+
+/**
  * This class inherits InMemoryFileDB class and adds all relevant logic for states
  * including the available methods for use by js-controller directly
  **/
@@ -55,26 +117,7 @@ class StatesInMemoryJsonlDB extends StatesInMemoryFileDB {
             backupDirName: 'backup-objects'
         };
 
-        /** @type {import("@alcalzone/jsonl-db").JsonlDBOptions<any>} */
-        const jsonlOptions = settings.connection.jsonlOptions || {
-            autoCompress: {
-                sizeFactor: 10,
-                sizeFactorMinimumSize: 50000
-            },
-            ignoreReadErrors: true,
-            throttleFS: {
-                intervalMs: 60000,
-                maxBufferedCommands: 2000
-            },
-            lockfile: {
-                // 5 retries starting at 250ms add up to just above 2s,
-                // so the DB has 3 more seconds to load all data if it wants to stay within the 5s connectionTimeout
-                retries: 5,
-                retryMinTimeoutMs: 250,
-                // This makes sure the DB stays locked for maximum 2s even if the process crashes
-                staleMs: 2000
-            }
-        };
+        const jsonlOptions = normalizeJsonlOptions(settings.connection.jsonlOptions);
         settings.jsonlDB = {
             fileName: 'states.jsonl'
         };


### PR DESCRIPTION
fixes: #1882 

The imposed limits are up for discussion, but mainly we need to make sure that we always apply the default settings.