### PR TITLE
update invalid npm version log

### DIFF
--- a/packages/controller/lib/preinstallCheck.js
+++ b/packages/controller/lib/preinstallCheck.js
@@ -35,7 +35,7 @@ function checkNpmVersion() {
                         clearTimeout(timer);
                         timer = null;
                         npmVersion = npmVersion.trim();
-                        console.log('NPM version: ' + npmVersion);
+                        console.log(`NPM version: ${npmVersion}`);
 
                         if (gte(npmVersion, '5.0.0') && lt(npmVersion, '5.7.1')) {
                             console.warn('!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!');
@@ -43,7 +43,7 @@ function checkNpmVersion() {
                             console.warn('You are using an unsupported npm version!');
                             console.warn('This can lead to problems when installing further packages');
                             console.warn();
-                            console.warn('Please use "npm install -g npm@4" to downgrade npm to 4.x or ');
+                            console.warn('Please use "npm install -g npm@6" to upgrade npm to 6.x or ');
                             console.warn('use "npm install -g npm@latest" to install a supported version of npm!');
                             console.warn(
                                 'You need to make sure to repeat this step after installing an update to NodeJS and/or npm.'

--- a/packages/controller/lib/scripts/scripts.js
+++ b/packages/controller/lib/scripts/scripts.js
@@ -1,6 +1,6 @@
 const https = require('https');
 const fs = require('fs');
-const tools = require('../tools.js');
+const { tools } = require('@iobroker/js-controller-common');
 
 function httpsGet(link, callback) {
     https
@@ -80,10 +80,10 @@ function updateVersions(callback) {
 if (process.argv.indexOf('--prepublish') !== -1) {
     httpsGet(stableURL, function (err, body) {
         if (err || !body) {
-            console.error('Cannot read sources file "' + stableURL + '": ' + err);
+            console.error(`Cannot read sources file "${stableURL}": ${err}`);
             process.exit(2);
         } else {
-            fs.writeFileSync(__dirname + '/../../conf/sources-dist.json', body);
+            fs.writeFileSync(`${__dirname}/../../conf/sources-dist.json`, body);
             process.exit();
         }
     });

--- a/packages/controller/lib/setup/setupInstall.js
+++ b/packages/controller/lib/setup/setupInstall.js
@@ -242,7 +242,7 @@ function Install(options) {
                 if (npmVersion) {
                     npmVersion = semver.valid(npmVersion.trim());
                 }
-                console.log('NPM version: ' + npmVersion);
+                console.log(`NPM version: ${npmVersion}`);
             } catch (err) {
                 console.error(`Error trying to check npm version: ${err.message}`);
             }
@@ -252,7 +252,7 @@ function Install(options) {
                 console.error('Aborting install because the npm version could not be checked!');
                 console.error('Please check that npm is installed correctly.');
                 console.error(
-                    'Use "npm install -g npm@4" or "npm install -g npm@latest" to install a supported version.'
+                    'Use "npm install -g npm@6" or "npm install -g npm@latest" to install a supported version.'
                 );
                 console.error(
                     'You need to make sure to repeat this step after installing an update to NodeJS and/or npm'
@@ -262,7 +262,7 @@ function Install(options) {
             } else if (semver.gte(npmVersion, '5.0.0') && semver.lt(npmVersion, '5.7.1')) {
                 console.error('!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!');
                 console.error('NPM 5 is only supported starting with version 5.7.1!');
-                console.error('Please use "npm install -g npm@4" to downgrade npm to 4.x or ');
+                console.error('Please use "npm install -g npm@6" to upgrade npm to 6.x or ');
                 console.error('use "npm install -g npm@latest" to install a supported version of npm!');
                 console.error(
                     'You need to make sure to repeat this step after installing an update to NodeJS and/or npm'


### PR DESCRIPTION
- closes #1895
- users should not be asked to downgrade to npm v4

An alternative would be to just ask for installing `@latest` but this could lead to problems if `latest` has some strange bugs or incompatibilities as it was the case in the past.