### PR TITLE
Upgrade repo from insecure http://download.iobroker.net to secure https://repo.iobroker.live

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 	## __WORK IN PROGRESS__
 -->
 ## 4.1.0 - WORK IN PROGRESS Release Jana
-* Work in Progress
+* (jpawlowski) Change repository URL from insecure http://download.iobroker.net to secure https://repo.iobroker.live. Also avoids HTTP redirect and uses Cloudflare CDN for better redundancy.
 
 ## 4.0.23 (2022-04-19)
 * (AlCalzone) normalize JSONL options to prevent issues because of admin adding empty setting objects

--- a/packages/controller/io-package.json
+++ b/packages/controller/io-package.json
@@ -1,939 +1,935 @@
 {
-  "common": {
-    "name": "js-controller",
-    "version": "4.1.0",
-    "platform": "Javascript/Node.js",
-    "controller": true,
-    "mode": "daemon",
-    "title": "JS controller",
-    "titleLang": {
-      "en": "JS controller",
-      "de": "JS-Controller",
-      "ru": "Контроллер JS",
-      "pt": "Controlador JS",
-      "nl": "JS-controller",
-      "fr": "Contrôleur JS",
-      "it": "Controller JS",
-      "es": "Controlador JS",
-      "pl": "Kontroler JS",
-      "zh-cn": "JS控制器"
+    "common": {
+        "name": "js-controller",
+        "version": "4.1.0",
+        "platform": "Javascript/Node.js",
+        "controller": true,
+        "mode": "daemon",
+        "title": "JS controller",
+        "titleLang": {
+            "en": "JS controller",
+            "de": "JS-Controller",
+            "ru": "Контроллер JS",
+            "pt": "Controlador JS",
+            "nl": "JS-controller",
+            "fr": "Contrôleur JS",
+            "it": "Controller JS",
+            "es": "Controlador JS",
+            "pl": "Kontroler JS",
+            "zh-cn": "JS控制器"
+        },
+        "news": {
+            "4.0.23": {
+                "en": "see CHANGELOG.md",
+                "de": "siehe CHANGELOG.md",
+                "ru": "см. CHANGELOG.md",
+                "pt": "veja CHANGELOG.md",
+                "nl": "zie CHANGELOG.md",
+                "fr": "voir CHANGELOG.md",
+                "it": "vedi CHANGELOG.md",
+                "es": "ver CHANGELOG.md",
+                "pl": "zobacz CHANGELOG.md",
+                "zh-cn": "看到CHANGELOG.md"
+            },
+            "3.3.22": {
+                "en": "see CHANGELOG.md",
+                "de": "siehe CHANGELOG.md",
+                "ru": "см. CHANGELOG.md",
+                "pt": "veja CHANGELOG.md",
+                "nl": "zie CHANGELOG.md",
+                "fr": "voir CHANGELOG.md",
+                "it": "vedi CHANGELOG.md",
+                "es": "ver CHANGELOG.md",
+                "pl": "zobacz CHANGELOG.md",
+                "zh-cn": "看到CHANGELOG.md"
+            },
+            "3.2.16": {
+                "en": "see CHANGELOG.md",
+                "de": "siehe CHANGELOG.md",
+                "ru": "см. CHANGELOG.md",
+                "pt": "veja CHANGELOG.md",
+                "nl": "zie CHANGELOG.md",
+                "fr": "voir CHANGELOG.md",
+                "it": "vedi CHANGELOG.md",
+                "es": "ver CHANGELOG.md",
+                "pl": "zobacz CHANGELOG.md",
+                "zh-cn": "看到CHANGELOG.md"
+            },
+            "3.1.6": {
+                "en": "see CHANGELOG.md",
+                "de": "Siehe CHANGELOG.md",
+                "ru": "см. CHANGELOG.md",
+                "pt": "veja CHANGELOG.md",
+                "nl": "zie CHANGELOG.md",
+                "fr": "voir CHANGELOG.md",
+                "it": "vedi CHANGELOG.md",
+                "es": "ver CHANGELOG.md",
+                "pl": "zobacz CHANGELOG.md",
+                "zh-cn": "看到CHANGELOG.md"
+            },
+            "3.0.20": {
+                "en": "see CHANGELOG.md",
+                "de": "Siehe CHANGELOG.md",
+                "ru": "см. CHANGELOG.md",
+                "pt": "veja CHANGELOG.md",
+                "nl": "zie CHANGELOG.md",
+                "fr": "voir CHANGELOG.md",
+                "it": "vedi CHANGELOG.md",
+                "es": "ver CHANGELOG.md",
+                "pl": "zobacz CHANGELOG.md",
+                "zh-cn": "看到CHANGELOG.md"
+            }
+        },
+        "desc": {
+            "en": "Javascript/Node.js implementation of ioBroker controller",
+            "de": "Javascript/Node.js Implementierung des ioBroker-Controllers",
+            "ru": "Javascript/Node.js реализация контроллера ioBroker",
+            "pt": "Implementação do Javascript/Node.js do controlador ioBroker",
+            "nl": "Javascript/Node.js implementatie van ioBroker-controller",
+            "fr": "Implémentation Javascript/Node.js du contrôleur ioBroker",
+            "it": "Implementazione Javascript/Node.js del controller ioBroker",
+            "es": "Implementación de JavaScript/Node.js del controlador ioBroker",
+            "pl": "Implementacja JavaScript/Node.js kontrolera ioBroker",
+            "zh-cn": "Javascript / Node.js实现了ioBroker控制器"
+        },
+        "messagebox": true,
+        "readme": "https://github.com/ioBroker/ioBroker.js-controller/blob/master/README.md",
+        "authors": [
+            "bluefox <bluefox@gmail.com>",
+            "hobbyquaker <hq@ccu.io>",
+            "Apollon77 <iobroker@fischer-ka.de>"
+        ],
+        "license": "MIT",
+        "type": "general",
+        "unsafePerm": true,
+        "plugins": {
+            "sentry": {
+                "dsn": "https://ab26a840557947c088448fead588e0c5@sentry.iobroker.net/9",
+                "pathWhitelist": [
+                    "@iobroker",
+                    "iobroker.js-controller"
+                ]
+            }
+        }
     },
-    "news": {
-      "4.0.23": {
-        "en": "see CHANGELOG.md",
-        "de": "siehe CHANGELOG.md",
-        "ru": "см. CHANGELOG.md",
-        "pt": "veja CHANGELOG.md",
-        "nl": "zie CHANGELOG.md",
-        "fr": "voir CHANGELOG.md",
-        "it": "vedi CHANGELOG.md",
-        "es": "ver CHANGELOG.md",
-        "pl": "zobacz CHANGELOG.md",
-        "zh-cn": "看到CHANGELOG.md"
-      },
-      "3.3.22": {
-        "en": "see CHANGELOG.md",
-        "de": "siehe CHANGELOG.md",
-        "ru": "см. CHANGELOG.md",
-        "pt": "veja CHANGELOG.md",
-        "nl": "zie CHANGELOG.md",
-        "fr": "voir CHANGELOG.md",
-        "it": "vedi CHANGELOG.md",
-        "es": "ver CHANGELOG.md",
-        "pl": "zobacz CHANGELOG.md",
-        "zh-cn": "看到CHANGELOG.md"
-      },
-      "3.2.16": {
-        "en": "see CHANGELOG.md",
-        "de": "siehe CHANGELOG.md",
-        "ru": "см. CHANGELOG.md",
-        "pt": "veja CHANGELOG.md",
-        "nl": "zie CHANGELOG.md",
-        "fr": "voir CHANGELOG.md",
-        "it": "vedi CHANGELOG.md",
-        "es": "ver CHANGELOG.md",
-        "pl": "zobacz CHANGELOG.md",
-        "zh-cn": "看到CHANGELOG.md"
-      },
-      "3.1.6": {
-        "en": "see CHANGELOG.md",
-        "de": "Siehe CHANGELOG.md",
-        "ru": "см. CHANGELOG.md",
-        "pt": "veja CHANGELOG.md",
-        "nl": "zie CHANGELOG.md",
-        "fr": "voir CHANGELOG.md",
-        "it": "vedi CHANGELOG.md",
-        "es": "ver CHANGELOG.md",
-        "pl": "zobacz CHANGELOG.md",
-        "zh-cn": "看到CHANGELOG.md"
-      },
-      "3.0.20": {
-        "en": "see CHANGELOG.md",
-        "de": "Siehe CHANGELOG.md",
-        "ru": "см. CHANGELOG.md",
-        "pt": "veja CHANGELOG.md",
-        "nl": "zie CHANGELOG.md",
-        "fr": "voir CHANGELOG.md",
-        "it": "vedi CHANGELOG.md",
-        "es": "ver CHANGELOG.md",
-        "pl": "zobacz CHANGELOG.md",
-        "zh-cn": "看到CHANGELOG.md"
-      }
-    },
-    "desc": {
-      "en": "Javascript/Node.js implementation of ioBroker controller",
-      "de": "Javascript/Node.js Implementierung des ioBroker-Controllers",
-      "ru": "Javascript/Node.js реализация контроллера ioBroker",
-      "pt": "Implementação do Javascript/Node.js do controlador ioBroker",
-      "nl": "Javascript/Node.js implementatie van ioBroker-controller",
-      "fr": "Implémentation Javascript/Node.js du contrôleur ioBroker",
-      "it": "Implementazione Javascript/Node.js del controller ioBroker",
-      "es": "Implementación de JavaScript/Node.js del controlador ioBroker",
-      "pl": "Implementacja JavaScript/Node.js kontrolera ioBroker",
-      "zh-cn": "Javascript / Node.js实现了ioBroker控制器"
-    },
-    "messagebox": true,
-    "readme": "https://github.com/ioBroker/ioBroker.js-controller/blob/master/README.md",
-    "authors": [
-      "bluefox <bluefox@gmail.com>",
-      "hobbyquaker <hq@ccu.io>",
-      "Apollon77 <iobroker@fischer-ka.de>"
+    "objects": [{
+            "_id": "_design/system",
+            "language": "javascript",
+            "common": {
+                "name": {
+                    "en": "Object's selectors",
+                    "de": "Objekt-Selektoren",
+                    "ru": "Селекторы объекта",
+                    "pt": "Seletores de objetos",
+                    "nl": "Objectkiezers",
+                    "fr": "Sélecteurs d'objet",
+                    "it": "Selettori di oggetti",
+                    "es": "Selectores de objeto",
+                    "pl": "Selektory obiektów",
+                    "zh-cn": "对象的选择器"
+                },
+                "dontDelete": true
+            },
+            "views": {
+                "host": {
+                    "map": "function(doc) { if (doc.type === 'host') emit(doc._id, doc) }"
+                },
+                "adapter": {
+                    "map": "function(doc) { if (doc.type === 'adapter') emit(doc._id, doc) }"
+                },
+                "instance": {
+                    "map": "function(doc) { if (doc.type === 'instance') emit(doc._id, doc) }"
+                },
+                "instanceStats": {
+                    "map": "function(doc) { if (doc.type === 'instance') emit(doc._id, parseInt(doc._id.split('.').pop(), 10)) }",
+                    "reduce": "_stats"
+                },
+                "meta": {
+                    "map": "function(doc) { if (doc.type === 'meta') emit(doc._id, doc) }"
+                },
+                "device": {
+                    "map": "function(doc) { if (doc.type === 'device') emit(doc._id, doc) }"
+                },
+                "channel": {
+                    "map": "function(doc) { if (doc.type === 'channel') emit(doc._id, doc) }"
+                },
+                "state": {
+                    "map": "function(doc) { if (doc.type === 'state') emit(doc._id, doc) }"
+                },
+                "folder": {
+                    "map": "function(doc) { if (doc.type === 'folder') emit(doc._id, doc) }"
+                },
+                "enum": {
+                    "map": "function(doc) { if (doc.type === 'enum') emit(doc._id, doc) }"
+                },
+                "script": {
+                    "map": "function(doc) { if (doc.type === 'script') emit(doc._id, doc) }"
+                },
+                "group": {
+                    "map": "function(doc) { if (doc.type === 'group') emit(doc.common.name, doc) }"
+                },
+                "user": {
+                    "map": "function(doc) { if (doc.type === 'user') emit(doc.common.name, doc) }"
+                },
+                "config": {
+                    "map": "function(doc) { if (doc.type === 'config') emit(doc.common.name, doc) }"
+                },
+                "custom": {
+                    "map": "function(doc) { doc.type === 'state' && doc.common && doc.common.custom && emit(doc._id, doc.common.custom) }"
+                }
+            },
+            "acl": {
+                "owner": "system.user.admin",
+                "ownerGroup": "system.group.administrator",
+                "object": 1092
+            }
+        },
+        {
+            "_id": "system.group.administrator",
+            "type": "group",
+            "common": {
+                "icon": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGhlaWdodD0iMjRweCIgdmlld0JveD0iMCAwIDI0IDI0IiB3aWR0aD0iMjRweCI+DQogICAgPGcgZmlsbD0iY3VycmVudENvbG9yIj4NCiAgICAgICAgPHBhdGggZD0iTTQsMTh2LTAuNjVjMC0wLjM0LDAuMTYtMC42NiwwLjQxLTAuODFDNi4xLDE1LjUzLDguMDMsMTUsMTAsMTVjMC4wMywwLDAuMDUsMCwwLjA4LDAuMDFjMC4xLTAuNywwLjMtMS4zNywwLjU5LTEuOTggQzEwLjQ1LDEzLjAxLDEwLjIzLDEzLDEwLDEzYy0yLjQyLDAtNC42OCwwLjY3LTYuNjEsMS44MkMyLjUxLDE1LjM0LDIsMTYuMzIsMiwxNy4zNVYyMGg5LjI2Yy0wLjQyLTAuNi0wLjc1LTEuMjgtMC45Ny0ySDR6Ii8+DQogICAgICAgIDxwYXRoIGQ9Ik0xMCwxMmMyLjIxLDAsNC0xLjc5LDQtNHMtMS43OS00LTQtNEM3Ljc5LDQsNiw1Ljc5LDYsOFM3Ljc5LDEyLDEwLDEyeiBNMTAsNmMxLjEsMCwyLDAuOSwyLDJzLTAuOSwyLTIsMiBjLTEuMSwwLTItMC45LTItMlM4LjksNiwxMCw2eiIvPg0KICAgICAgICA8cGF0aCBkPSJNMjAuNzUsMTZjMC0wLjIyLTAuMDMtMC40Mi0wLjA2LTAuNjNsMS4xNC0xLjAxbC0xLTEuNzNsLTEuNDUsMC40OWMtMC4zMi0wLjI3LTAuNjgtMC40OC0xLjA4LTAuNjNMMTgsMTFoLTJsLTAuMywxLjQ5IGMtMC40LDAuMTUtMC43NiwwLjM2LTEuMDgsMC42M2wtMS40NS0wLjQ5bC0xLDEuNzNsMS4xNCwxLjAxYy0wLjAzLDAuMjEtMC4wNiwwLjQxLTAuMDYsMC42M3MwLjAzLDAuNDIsMC4wNiwwLjYzbC0xLjE0LDEuMDEgbDEsMS43M2wxLjQ1LTAuNDljMC4zMiwwLjI3LDAuNjgsMC40OCwxLjA4LDAuNjNMMTYsMjFoMmwwLjMtMS40OWMwLjQtMC4xNSwwLjc2LTAuMzYsMS4wOC0wLjYzbDEuNDUsMC40OWwxLTEuNzNsLTEuMTQtMS4wMSBDMjAuNzIsMTYuNDIsMjAuNzUsMTYuMjIsMjAuNzUsMTZ6IE0xNywxOGMtMS4xLDAtMi0wLjktMi0yczAuOS0yLDItMnMyLDAuOSwyLDJTMTguMSwxOCwxNywxOHoiLz4NCiAgICA8L2c+DQo8L3N2Zz4=",
+                "name": {
+                    "en": "Administrator",
+                    "de": "Administrator",
+                    "ru": "Администратор",
+                    "pt": "Administrador",
+                    "nl": "Beheerder",
+                    "fr": "Administrateur",
+                    "it": "Amministratore",
+                    "es": "Administrador",
+                    "pl": "Administrator",
+                    "zh-cn": "管理员"
+                },
+                "desc": {
+                    "en": "Can do everything with System",
+                    "de": "Darf alles mit dem System machen",
+                    "ru": "Может делать все с помощью системы",
+                    "pt": "Pode fazer tudo com o sistema",
+                    "nl": "Kan alles doen met System",
+                    "fr": "Peut tout faire avec le système",
+                    "it": "Può fare tutto con il sistema",
+                    "es": "Puede hacer todo con System",
+                    "pl": "Potrafi zrobić wszystko dzięki Systemowi",
+                    "zh-cn": "可以用系统做任何事情"
+                },
+                "members": [
+                    "system.user.admin"
+                ],
+                "dontDelete": true,
+                "acl": {
+                    "object": {
+                        "list": true,
+                        "read": true,
+                        "write": true,
+                        "delete": true
+                    },
+                    "state": {
+                        "list": true,
+                        "read": true,
+                        "write": true,
+                        "create": true,
+                        "delete": true
+                    },
+                    "users": {
+                        "list": true,
+                        "read": true,
+                        "write": true,
+                        "create": true,
+                        "delete": true
+                    },
+                    "other": {
+                        "execute": true,
+                        "http": true,
+                        "sendto": true
+                    },
+                    "file": {
+                        "list": true,
+                        "read": true,
+                        "write": true,
+                        "create": true,
+                        "delete": true
+                    }
+                }
+            },
+            "acl": {
+                "owner": "system.user.admin",
+                "ownerGroup": "system.group.administrator",
+                "object": 1604
+            }
+        },
+        {
+            "_id": "system.group.user",
+            "type": "group",
+            "common": {
+                "icon": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGhlaWdodD0iMjRweCIgdmlld0JveD0iMCAwIDI0IDI0IiB3aWR0aD0iMjRweCI+DQogICAgPHBhdGggZmlsbD0iY3VycmVudENvbG9yIiBkPSJNMTIgNmMxLjEgMCAyIC45IDIgMnMtLjkgMi0yIDItMi0uOS0yLTIgLjktMiAyLTJtMCAxMGMyLjcgMCA1LjggMS4yOSA2IDJINmMuMjMtLjcyIDMuMzEtMiA2LTJtMC0xMkM5Ljc5IDQgOCA1Ljc5IDggOHMxLjc5IDQgNCA0IDQtMS43OSA0LTQtMS43OS00LTQtNHptMCAxMGMtMi42NyAwLTggMS4zNC04IDR2MmgxNnYtMmMwLTIuNjYtNS4zMy00LTgtNHoiLz4NCjwvc3ZnPg==",
+                "name": {
+                    "en": "User",
+                    "de": "Benutzer",
+                    "ru": "Пользователь",
+                    "pt": "Do utilizador",
+                    "nl": "Gebruiker",
+                    "fr": "Utilisateur",
+                    "it": "Utente",
+                    "es": "Usuario",
+                    "pl": "Użytkownik",
+                    "zh-cn": "用户"
+                },
+                "desc": {
+                    "en": "Cannot modify everything",
+                    "de": "Darf nicht alles ändern",
+                    "ru": "Не может изменять все",
+                    "pt": "Não é possível modificar tudo",
+                    "nl": "Kan niet alles wijzigen",
+                    "fr": "Impossible de tout modifier",
+                    "it": "Non è possibile modificare tutto",
+                    "es": "No se puede modificar todo",
+                    "pl": "Nie można modyfikować wszystkiego",
+                    "zh-cn": "用户无法修改所有内容"
+                },
+                "members": [],
+                "dontDelete": true,
+                "acl": {
+                    "object": {
+                        "list": true,
+                        "read": true,
+                        "write": false,
+                        "delete": false
+                    },
+                    "state": {
+                        "list": true,
+                        "read": true,
+                        "write": true,
+                        "create": true,
+                        "delete": false
+                    },
+                    "users": {
+                        "list": true,
+                        "read": true,
+                        "write": false,
+                        "create": false,
+                        "delete": false
+                    },
+                    "other": {
+                        "execute": false,
+                        "http": true,
+                        "sendto": false
+                    },
+                    "file": {
+                        "list": true,
+                        "read": true,
+                        "write": false,
+                        "create": false,
+                        "delete": false
+                    }
+                }
+            },
+            "acl": {
+                "owner": "system.user.admin",
+                "ownerGroup": "system.group.administrator",
+                "object": 1604
+            }
+        },
+        {
+            "_id": "enum.rooms",
+            "common": {
+                "icon": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGhlaWdodD0iMjRweCIgdmlld0JveD0iMCAwIDI0IDI0IiB3aWR0aD0iMjRweCI+DQogICAgPHBhdGggZmlsbD0iY3VycmVudENvbG9yIiBkPSJNMTIgNS42OWw1IDQuNVYxOGgtMnYtNkg5djZIN3YtNy44MWw1LTQuNU0xMiAzTDIgMTJoM3Y4aDZ2LTZoMnY2aDZ2LThoM0wxMiAzeiIvPg0KPC9zdmc+",
+                "name": {
+                    "en": "Rooms",
+                    "de": "Räume",
+                    "ru": "Комнаты",
+                    "pt": "Quartos",
+                    "nl": "Kamers",
+                    "fr": "Pièces",
+                    "it": "Camere",
+                    "es": "Habitaciones",
+                    "pl": "Pokoje",
+                    "zh-cn": "客房"
+                },
+                "desc": {
+                    "en": "List of the rooms",
+                    "de": "Liste der Räume",
+                    "ru": "Список комнат",
+                    "pt": "Lista dos quartos",
+                    "nl": "Lijst met kamers",
+                    "fr": "Liste des chambres",
+                    "it": "Elenco delle stanze",
+                    "es": "Lista de las habitaciones",
+                    "pl": "Lista pokoi",
+                    "zh-cn": "房间清单"
+                },
+                "members": [],
+                "dontDelete": true
+            },
+            "type": "enum",
+            "acl": {
+                "owner": "system.user.admin",
+                "ownerGroup": "system.group.administrator",
+                "object": 1911
+            }
+        },
+        {
+            "_id": "enum.functions",
+            "common": {
+                "icon": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGhlaWdodD0iMjRweCIgdmlld0JveD0iMCAwIDI0IDI0IiB3aWR0aD0iMjRweCI+DQogICAgPHBhdGggZmlsbD0iY3VycmVudENvbG9yIiBkPSJNOSAyMWMwIC41NS40NSAxIDEgMWg0Yy41NSAwIDEtLjQ1IDEtMXYtMUg5djF6bTMtMTlDOC4xNCAyIDUgNS4xNCA1IDljMCAyLjM4IDEuMTkgNC40NyAzIDUuNzRWMTdjMCAuNTUuNDUgMSAxIDFoNmMuNTUgMCAxLS40NSAxLTF2LTIuMjZjMS44MS0xLjI3IDMtMy4zNiAzLTUuNzQgMC0zLjg2LTMuMTQtNy03LTd6bTIuODUgMTEuMWwtLjg1LjZWMTZoLTR2LTIuM2wtLjg1LS42QzcuOCAxMi4xNiA3IDEwLjYzIDcgOWMwLTIuNzYgMi4yNC01IDUtNXM1IDIuMjQgNSA1YzAgMS42My0uOCAzLjE2LTIuMTUgNC4xeiIvPg0KPC9zdmc+",
+                "name": {
+                    "en": "Functions",
+                    "de": "Funktionen",
+                    "ru": "функции",
+                    "pt": "Funções",
+                    "nl": "functies",
+                    "fr": "Les fonctions",
+                    "it": "funzioni",
+                    "es": "Funciones",
+                    "pl": "Funkcje",
+                    "zh-cn": "职能"
+                },
+                "desc": {
+                    "en": "List of the functions",
+                    "de": "Liste der Funktionen",
+                    "ru": "Список функций",
+                    "pt": "Lista das funções",
+                    "nl": "Lijst met functies",
+                    "fr": "Liste des fonctions",
+                    "it": "Elenco delle funzioni",
+                    "es": "Lista de las funciones",
+                    "pl": "Lista funkcji",
+                    "zh-cn": "功能列表"
+                },
+                "members": [],
+                "dontDelete": true
+            },
+            "type": "enum",
+            "acl": {
+                "owner": "system.user.admin",
+                "ownerGroup": "system.group.administrator",
+                "object": 1911
+            }
+        },
+        {
+            "_id": "system.config",
+            "type": "config",
+            "common": {
+                "name": {
+                    "en": "System configuration",
+                    "de": "Systemkonfiguration",
+                    "ru": "Конфигурация системы",
+                    "pt": "Configuração do sistema",
+                    "nl": "Systeem configuratie",
+                    "fr": "Configuration du système",
+                    "it": "Configurazione di sistema",
+                    "es": "Configuración del sistema",
+                    "pl": "Konfiguracja systemu",
+                    "zh-cn": "系统配置"
+                },
+                "city": "",
+                "country": "",
+                "longitude": "",
+                "latitude": "",
+                "language": "",
+                "tempUnit": "°C",
+                "currency": "",
+                "dontDelete": true,
+                "dateFormat": "DD.MM.YYYY",
+                "isFloatComma": true,
+                "licenseConfirmed": false,
+                "defaultHistory": "",
+                "expertMode": false,
+                "defaultLogLevel": "info",
+                "activeRepo": [
+                    "stable"
+                ],
+                "diag": "extended",
+                "tabs": [
+                    "tab-intro",
+                    "tab-info",
+                    "tab-adapters",
+                    "tab-instances",
+                    "tab-objects",
+                    "tab-log",
+                    "tab-scenes",
+                    "tab-javascript",
+                    "tab-text2command-0",
+                    "tab-node-red-0"
+                ]
+            },
+            "native": {},
+            "acl": {
+                "owner": "system.user.admin",
+                "ownerGroup": "system.group.administrator",
+                "object": 1604
+            }
+        },
+        {
+            "_id": "system.repositories",
+            "type": "config",
+            "common": {
+                "name": {
+                    "en": "System repositories",
+                    "de": "System-Repositories",
+                    "ru": "Системные репозитории",
+                    "pt": "Repositórios do sistema",
+                    "nl": "Systeemrepository's",
+                    "fr": "Référentiels système",
+                    "it": "Repository di sistema",
+                    "es": "Repositorios del sistema",
+                    "pl": "Repozytoria systemowe",
+                    "zh-cn": "系统资料库"
+                },
+                "dontDelete": true
+            },
+            "native": {
+                "repositories": {
+                    "stable": {
+                        "link": "https://repo.iobroker.live/sources-dist.json",
+                        "json": null
+                    },
+                    "beta": {
+                        "link": "https://repo.iobroker.live/sources-dist-latest.json",
+                        "json": null
+                    }
+                },
+                "oldRepositories": {
+                    "sources": {
+                        "link": "conf/sources-dist.json",
+                        "json": null
+                    },
+                    "online": {
+                        "link": "https://raw.githubusercontent.com/ioBroker/ioBroker.repositories/master/sources-dist.json",
+                        "json": null
+                    }
+                }
+            },
+            "acl": {
+                "owner": "system.user.admin",
+                "ownerGroup": "system.group.administrator",
+                "object": 1604
+            }
+        },
+        {
+            "_id": "system.licenses",
+            "type": "config",
+            "common": {
+                "name": {
+                    "en": "Licenses from iobroker.net",
+                    "de": "Lizenzen von iobroker.net",
+                    "ru": "Лицензии от iobroker.net",
+                    "pt": "Licenças de iobroker.net",
+                    "nl": "Licenties van iobroker.net",
+                    "fr": "Licences de iobroker.net",
+                    "it": "Licenze da iobroker.net",
+                    "es": "Licencias de iobroker.net",
+                    "pl": "Licencje z iobroker.net",
+                    "zh-cn": "来自 iobroker.net 的许可证"
+                }
+            },
+            "native": {
+                "login": "",
+                "password": "",
+                "licenses": [],
+                "readTime": 0
+            },
+            "acl": {
+                "owner": "system.user.admin",
+                "ownerGroup": "system.group.administrator",
+                "object": 1604
+            }
+        },
+        {
+            "_id": "system.certificates",
+            "type": "config",
+            "common": {
+                "icon": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGhlaWdodD0iMjRweCIgdmlld0JveD0iMCAwIDI0IDI0IiB3aWR0aD0iMjRweCI+DQogICAgPHBhdGggZmlsbD0iY3VycmVudENvbG9yIiBkPSJNMTIgMUwzIDV2NmMwIDUuNTUgMy44NCAxMC43NCA5IDEyIDUuMTYtMS4yNiA5LTYuNDUgOS0xMlY1bC05LTR6bTAgMTAuOTloN2MtLjUzIDQuMTItMy4yOCA3Ljc5LTcgOC45NFYxMkg1VjYuM2w3LTMuMTF2OC44eiIvPg0KPC9zdmc+",
+                "name": {
+                    "en": "System certificates",
+                    "de": "Systemzertifikate",
+                    "ru": "Системные сертификаты",
+                    "pt": "Certificados do sistema",
+                    "nl": "Systeem certificaten",
+                    "fr": "Certificats système",
+                    "it": "Certificati di sistema",
+                    "es": "Certificados del sistema",
+                    "pl": "Certyfikaty systemowe",
+                    "zh-cn": "系统证书"
+                }
+            },
+            "native": {
+                "certificates": {
+                    "defaultPrivate": null,
+                    "defaultPublic": null
+                }
+            },
+            "acl": {
+                "owner": "system.user.admin",
+                "ownerGroup": "system.group.administrator",
+                "object": 1536
+            }
+        },
+        {
+            "_id": "alias.0",
+            "type": "meta",
+            "common": {
+                "name": {
+                    "en": "root folder for Aliases",
+                    "de": "Stammordner für Aliase",
+                    "ru": "корневая папка для псевдонимов",
+                    "pt": "pasta raiz para aliases",
+                    "nl": "hoofdmap voor aliassen",
+                    "fr": "dossier racine pour les alias",
+                    "it": "cartella principale per gli alias",
+                    "es": "carpeta raíz para alias",
+                    "pl": "folder główny dla aliasów",
+                    "zh-cn": "别名的根文件夹"
+                },
+                "type": "meta.folder",
+                "dontDelete": true
+            },
+            "acl": {
+                "owner": "system.user.admin",
+                "ownerGroup": "system.group.administrator",
+                "object": 1604
+            }
+        },
+        {
+            "_id": "0_userdata.0",
+            "type": "meta",
+            "common": {
+                "icon": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGhlaWdodD0iMjRweCIgdmlld0JveD0iMCAwIDI0IDI0IiB3aWR0aD0iMjRweCI+DQogICAgPGcgZmlsbD0iY3VycmVudENvbG9yIj4NCiAgICAgICAgPHBhdGggZD0iTTE5LDV2MTRINVY1SDE5IE0xOSwzSDVDMy45LDMsMywzLjksMyw1djE0YzAsMS4xLDAuOSwyLDIsMmgxNGMxLjEsMCwyLTAuOSwyLTJWNUMyMSwzLjksMjAuMSwzLDE5LDNMMTksM3oiLz4NCiAgICAgICAgPHBhdGggZD0iTTE0LDE3SDd2LTJoN1YxN3ogTTE3LDEzSDd2LTJoMTBWMTN6IE0xNyw5SDdWN2gxMFY5eiIvPg0KICAgIDwvZz4NCjwvc3ZnPg==",
+                "name": {
+                    "en": "User objects and files root folder",
+                    "de": "Stammordner für Benutzerobjekte und Dateien",
+                    "ru": "Корневая папка пользовательских объектов и файлов",
+                    "pt": "Pasta raiz de objetos e arquivos do usuário",
+                    "nl": "Hoofdmap van objecten en bestanden van gebruikers",
+                    "fr": "Objets utilisateur et dossier racine des fichiers",
+                    "it": "Cartella principale di oggetti e file dell'utente",
+                    "es": "Carpeta raíz de objetos y archivos de usuario",
+                    "pl": "Folder główny obiektów i plików użytkownika",
+                    "zh-cn": "用户对象和文件根文件夹"
+                },
+                "desc": {
+                    "en": "Here you can upload your files or create your private objects and states",
+                    "de": "Hier können eigene Dateien hochgeladen oder private Objekte und Zustände erstellt werden",
+                    "ru": "Здесь вы можете загрузить свои файлы или создать свои личные объекты и состояния",
+                    "pt": "Aqui você pode enviar seus arquivos ou criar seus objetos e estados particulares",
+                    "nl": "Hier kunt u uw bestanden uploaden of uw privé-objecten en statussen maken",
+                    "fr": "Ici, vous pouvez télécharger vos fichiers ou créer vos objets et états privés",
+                    "it": "Qui puoi caricare i tuoi file o creare oggetti e stati privati",
+                    "es": "Aquí puede cargar sus archivos o crear sus objetos y estados privados",
+                    "pl": "Tutaj możesz przesyłać pliki lub tworzyć prywatne obiekty i stany",
+                    "zh-cn": "在这里您可以上传文件或创建私有对象和状态"
+                },
+                "type": "meta.user",
+                "dontDelete": true
+            },
+            "acl": {
+                "owner": "system.user.admin",
+                "ownerGroup": "system.group.administrator",
+                "object": 1604
+            }
+        },
+        {
+            "_id": "0_userdata.0.example_state",
+            "type": "state",
+            "common": {
+                "name": "Example state",
+                "role": "indicator",
+                "def": false,
+                "type": "boolean"
+            },
+            "acl": {
+                "owner": "system.user.admin",
+                "ownerGroup": "system.group.administrator",
+                "object": 1604
+            }
+        }
     ],
-    "license": "MIT",
-    "type": "general",
-    "unsafePerm": true,
-    "plugins": {
-      "sentry": {
-        "dsn": "https://ab26a840557947c088448fead588e0c5@sentry.iobroker.net/9",
-        "pathWhitelist": [
-          "@iobroker",
-          "iobroker.js-controller"
+    "notifications": [{
+        "scope": "system",
+        "name": {
+            "en": "System Notifications",
+            "de": "System-Benachrichtigungen",
+            "ru": "Системные уведомления",
+            "pt": "Notificações do sistema",
+            "nl": "Systeemmeldingen",
+            "fr": "Notifications système",
+            "it": "Notifiche di sistema",
+            "es": "Notificaciones del sistema",
+            "pl": "Powiadomienia systemowe",
+            "zh-cn": "系统通知"
+        },
+        "description": {
+            "en": "These notifications are collected by the ioBroker system and point to issues you should check and fix.",
+            "de": "Diese Benachrichtigungen werden vom ioBroker-System erfasst und weisen auf Probleme hin, die überprüft und behoben werden sollten.",
+            "ru": "Эти уведомления собираются системой ioBroker и указывают на проблемы, которые вы должны проверить и исправить.",
+            "pt": "Essas notificações são coletadas pelo sistema ioBroker e apontam para problemas que você deve verificar e corrigir.",
+            "nl": "Deze meldingen worden verzameld door het ioBroker-systeem en wijzen op problemen die u moet controleren en oplossen.",
+            "fr": "Ces notifications sont collectées par le système ioBroker et indiquent des problèmes que vous devez vérifier et résoudre.",
+            "it": "Queste notifiche vengono raccolte dal sistema ioBroker e indicano problemi che dovresti controllare e correggere.",
+            "es": "Estas notificaciones son recopiladas por el sistema ioBroker y señalan problemas que debe verificar y solucionar.",
+            "pl": "Te powiadomienia są zbierane przez system ioBroker i wskazują problemy, które należy sprawdzić i naprawić.",
+            "zh-cn": "这些通知由ioBroker系统收集，并指出您应检查并修复的问题"
+        },
+        "categories": [{
+                "category": "memIssues",
+                "name": {
+                    "en": "Issues with RAM availability",
+                    "de": "Probleme mit der Arbeitsspeicher-Verfügbarkeit",
+                    "ru": "Проблемы с доступностью оперативной памяти",
+                    "pt": "Problemas com disponibilidade de RAM",
+                    "nl": "Problemen met de beschikbaarheid van RAM",
+                    "fr": "Problèmes de disponibilité de la RAM",
+                    "it": "Problemi con la disponibilità della RAM",
+                    "es": "Problemas con la disponibilidad de RAM",
+                    "pl": "Problemy z dostępnością pamięci RAM",
+                    "zh-cn": "RAM可用性问题"
+                },
+                "severity": "alert",
+                "description": {
+                    "en": "Your system is running out of memory. Please check the number of running adapters and processes or if single processes need too many memory.",
+                    "de": "Es steht nicht genug Arbeitsspeicher zur Verfügung. Die Anzahl der laufenden Adapter und Prozesse sollte geprüft werden, oder ob einzelne Prozesse zuviel Speicher benötigen.",
+                    "ru": "В вашей системе не хватает памяти. Пожалуйста, проверьте количество работающих адаптеров и процессов, или если отдельным процессам требуется слишком много памяти.",
+                    "pt": "Seu sistema está ficando sem memória. Verifique o número de adaptadores e processos em execução ou se processos únicos precisam de muita memória.",
+                    "nl": "Uw systeem heeft onvoldoende geheugen. Controleer het aantal actieve adapters en processen of als afzonderlijke processen te veel geheugen nodig hebben.",
+                    "fr": "Votre système manque de mémoire. Veuillez vérifier le nombre d'adaptateurs et de processus en cours d'exécution ou si des processus uniques nécessitent trop de mémoire.",
+                    "it": "Il tuo sistema sta esaurendo la memoria. Controllare il numero di adattatori e processi in esecuzione o se i singoli processi richiedono troppa memoria.",
+                    "es": "Su sistema se está quedando sin memoria. Verifique el número de adaptadores y procesos en ejecución o si los procesos individuales necesitan demasiada memoria.",
+                    "pl": "W Twoim systemie kończy się pamięć. Sprawdź liczbę działających adapterów i procesów lub czy pojedyncze procesy wymagają zbyt dużej ilości pamięci.",
+                    "zh-cn": "您的系统内存不足。请检查正在运行的适配器和进程的数量，或者单个进程是否需要太多内存。"
+                },
+                "regex": [
+                    "^Exception-Code: ENOMEM",
+                    "buffer allocation failed"
+                ],
+                "limit": 10
+            },
+            {
+                "category": "fsIoErrors",
+                "name": {
+                    "en": "Issues with the file system",
+                    "de": "Probleme mit dem Dateisystem",
+                    "ru": "Проблемы с файловой системой",
+                    "pt": "Problemas com o sistema de arquivos",
+                    "nl": "Problemen met het bestandssysteem",
+                    "fr": "Problèmes avec le système de fichiers",
+                    "it": "Problemi con il file system",
+                    "es": "Problemas con el sistema de archivos",
+                    "pl": "Problemy z systemem plików",
+                    "zh-cn": "文件系统问题"
+                },
+                "severity": "alert",
+                "description": {
+                    "en": "There is an error with the file system. Maybe the file system is corrupted or wrongly configured. A file system check is required!",
+                    "de": "Es liegt ein Fehler im Dateisystem vor. Möglicherweise ist das Dateisystem beschädigt oder falsch konfiguriert. Eine Dateisystemprüfung ist erforderlich!",
+                    "ru": "Ошибка файловой системы. Возможно, файловая система повреждена или неправильно настроена. Требуется проверка файловой системы!",
+                    "pt": "Ocorreu um erro com o sistema de arquivos. Talvez o sistema de arquivos esteja corrompido ou configurado incorretamente. É necessária uma verificação do sistema de arquivos!",
+                    "nl": "Er is een fout opgetreden met het bestandssysteem. Misschien is het bestandssysteem beschadigd of verkeerd geconfigureerd. Een bestandssysteemcontrole is vereist!",
+                    "fr": "Il y a une erreur avec le système de fichiers. Le système de fichiers est peut-être corrompu ou mal configuré. Une vérification du système de fichiers est requise!",
+                    "it": "C'è un errore con il file system. Forse il file system è danneggiato o configurato in modo errato. È richiesto un controllo del file system!",
+                    "es": "Hay un error con el sistema de archivos. Quizás el sistema de archivos está dañado o configurado incorrectamente. Se requiere una verificación del sistema de archivos.",
+                    "pl": "Wystąpił błąd w systemie plików. Być może system plików jest uszkodzony lub nieprawidłowo skonfigurowany. Wymagane jest sprawdzenie systemu plików!",
+                    "zh-cn": "文件系统出错。也许文件系统已损坏或配置错误。需要文件系统检查！"
+                },
+                "regex": [
+                    "^Exception-Code: EROFS",
+                    "^Exception-Code: EIO",
+                    "^Exception-Code: ENXIO",
+                    "^Exception-Code: EMFILE",
+                    "^Exception-Code: EBADF",
+                    "^Exception-Code: ENFILE",
+                    "^Unknown system error -117[^,]*, write"
+                ],
+                "limit": 10
+            },
+            {
+                "category": "noDiskSpace",
+                "name": {
+                    "en": "Issues with free disk space",
+                    "de": "Probleme mit dem freien Speicherplatz",
+                    "ru": "Проблемы со свободным местом на диске",
+                    "pt": "Problemas com espaço livre em disco",
+                    "nl": "Problemen met vrije schijfruimte",
+                    "fr": "Problèmes d'espace disque libre",
+                    "it": "Problemi con lo spazio libero su disco",
+                    "es": "Problemas con el espacio libre en disco",
+                    "pl": "Problemy z wolnym miejscem na dysku",
+                    "zh-cn": "可用磁盘空间问题"
+                },
+                "severity": "alert",
+                "description": {
+                    "en": "There is not enough disk space left on the storage device. Please clean up some disk space.",
+                    "de": "Es steht nicht genügend Speicherplatz auf dem Datenträger zur Verfügung. Bitte bereinigen Sie etwas Speicherplatz.",
+                    "ru": "На запоминающем устройстве недостаточно места на диске. Пожалуйста, очистите место на диске.",
+                    "pt": "Não há espaço em disco suficiente no dispositivo de armazenamento. Limpe algum espaço em disco.",
+                    "nl": "Er is niet genoeg schijfruimte over op het opslagapparaat. Ruim wat schijfruimte op.",
+                    "fr": "Il n'y a pas assez d'espace disque sur le périphérique de stockage. Veuillez nettoyer de l'espace disque.",
+                    "it": "Spazio su disco insufficiente sul dispositivo di archiviazione. Si prega di pulire un po 'di spazio su disco.",
+                    "es": "No queda suficiente espacio en disco en el dispositivo de almacenamiento. Limpie algo de espacio en disco.",
+                    "pl": "Za mało miejsca na dysku na urządzeniu magazynującym. Proszę wyczyścić trochę miejsca na dysku.",
+                    "zh-cn": "存储设备上没有足够的磁盘空间。请清理一些磁盘空间。"
+                },
+                "regex": [
+                    "^Exception-Code: ENOSPC"
+                ],
+                "limit": 10
+            },
+            {
+                "category": "accessErrors",
+                "name": {
+                    "en": "Issues with file access rights",
+                    "de": "Probleme mit Dateizugriffsrechten",
+                    "ru": "Проблемы с правами доступа к файлам",
+                    "pt": "Problemas com direitos de acesso a arquivos",
+                    "nl": "Problemen met toegangsrechten voor bestanden",
+                    "fr": "Problèmes avec les droits d'accès aux fichiers",
+                    "it": "Problemi con i diritti di accesso ai file",
+                    "es": "Problemas con los derechos de acceso a archivos",
+                    "pl": "Problemy z prawami dostępu do plików",
+                    "zh-cn": "文件访问权限问题"
+                },
+                "severity": "alert",
+                "description": {
+                    "en": "There is an issue with access rights for files on the system. Running the installation fixer can solve these issues. Alternatively check the relevant directories and files.",
+                    "de": "Es liegt ein Problem mit den Zugriffsrechten für Dateien auf dem System vor. Durch Ausführen des Installationsfixers können diese behoben werden. Alternativ müssen die entsprechenden Verzeichnisse und Dateien überprüft werden.",
+                    "ru": "Возникла проблема с правами доступа к файлам в системе. Эти проблемы можно решить с помощью средства исправления установки. Или проверьте соответствующие каталоги и файлы.",
+                    "pt": "Há um problema com os direitos de acesso para arquivos no sistema. Executar o fixador de instalação pode resolver esses problemas. Como alternativa, verifique os diretórios e arquivos relevantes.",
+                    "nl": "Er is een probleem met toegangsrechten voor bestanden op het systeem. Het uitvoeren van de installatie-fixer kan deze problemen oplossen. Als alternatief kunt u de relevante mappen en bestanden controleren.",
+                    "fr": "Il y a un problème avec les droits d'accès aux fichiers sur le système. L'exécution du programme d'installation peut résoudre ces problèmes. Vous pouvez également vérifier les répertoires et fichiers concernés.",
+                    "it": "Si è verificato un problema con i diritti di accesso per i file sul sistema. L'esecuzione del programma di riparazione dell'installazione può risolvere questi problemi. In alternativa, controlla le directory e i file pertinenti.",
+                    "es": "Existe un problema con los derechos de acceso a los archivos del sistema. Ejecutar el reparador de instalación puede resolver estos problemas. Alternativamente, consulte los directorios y archivos relevantes.",
+                    "pl": "Wystąpił problem z prawami dostępu do plików w systemie. Uruchomienie narzędzia do naprawy instalacji może rozwiązać te problemy. Alternatywnie sprawdź odpowiednie katalogi i pliki.",
+                    "zh-cn": "系统上文件的访问权限存在问题。运行安装修复程序可以解决这些问题。或者，检查相关的目录和文件。"
+                },
+                "regex": [
+                    "^Exception-Code: EACCESS",
+                    "^Exception-Code: EPERM"
+                ],
+                "limit": 10
+            },
+            {
+                "category": "nonExistingFileErrors",
+                "name": {
+                    "en": "Issues with non-existing files or directories",
+                    "de": "Probleme mit nicht vorhandenen Dateien oder Verzeichnissen",
+                    "ru": "Проблемы с несуществующими файлами или каталогами",
+                    "pt": "Problemas com arquivos ou diretórios não existentes",
+                    "nl": "Problemen met niet-bestaande bestanden of mappen",
+                    "fr": "Problèmes avec des fichiers ou des répertoires non existants",
+                    "it": "Problemi con file o directory inesistenti",
+                    "es": "Problemas con archivos o directorios que no existen",
+                    "pl": "Problemy z nieistniejącymi plikami lub katalogami",
+                    "zh-cn": "文件或目录不存在的问题"
+                },
+                "severity": "alert",
+                "description": {
+                    "en": "A process tries to access a non-existing file or directory.",
+                    "de": "Ein Prozess versucht, auf eine nicht vorhandene Datei oder ein nicht vorhandenes Verzeichnis zuzugreifen.",
+                    "ru": "Процесс пытается получить доступ к несуществующему файлу или каталогу.",
+                    "pt": "Um processo tenta acessar um arquivo ou diretório não existente.",
+                    "nl": "Een proces probeert toegang te krijgen tot een niet-bestaand bestand of map.",
+                    "fr": "Un processus tente d'accéder à un fichier ou un répertoire inexistant.",
+                    "it": "Un processo tenta di accedere a un file o una directory inesistente.",
+                    "es": "Un proceso intenta acceder a un archivo o directorio que no existe.",
+                    "pl": "Proces próbuje uzyskać dostęp do nieistniejącego pliku lub katalogu.",
+                    "zh-cn": "进程尝试访问不存在的文件或目录。"
+                },
+                "regex": [
+                    "^Exception-Code: ENOENT"
+                ],
+                "limit": 10
+            },
+            {
+                "category": "remoteHostErrors",
+                "name": {
+                    "en": "Issues with remote servers",
+                    "de": "Probleme mit Remote-Servern",
+                    "ru": "Проблемы с удаленными серверами",
+                    "pt": "Problemas com servidores remotos",
+                    "nl": "Problemen met externe servers",
+                    "fr": "Problèmes avec les serveurs distants",
+                    "it": "Problemi con i server remoti",
+                    "es": "Problemas con servidores remotos",
+                    "pl": "Problemy ze zdalnymi serwerami",
+                    "zh-cn": "远程服务器的问题"
+                },
+                "severity": "alert",
+                "description": {
+                    "en": "Issue with remote servers that are expected to be online. Also mounted remote file systems could be unavailable and need to be checked.",
+                    "de": "Problem mit Remoteservern, von denen erwartet wird, dass sie online sind. Auch gemountete Remote-Dateisysteme sind möglicherweise nicht verfügbar und müssen überprüft werden.",
+                    "ru": "Проблема с удаленными серверами, которые должны быть в сети. Кроме того, смонтированные удаленные файловые системы могут быть недоступны, и их необходимо проверить.",
+                    "pt": "Problema com servidores remotos que deveriam estar online. Além disso, os sistemas de arquivos remotos montados podem estar indisponíveis e precisam ser verificados.",
+                    "nl": "Probleem met externe servers waarvan wordt verwacht dat ze online zijn. Ook gekoppelde externe bestandssystemen zijn mogelijk niet beschikbaar en moeten worden gecontroleerd.",
+                    "fr": "Problème avec les serveurs distants censés être en ligne. Les systèmes de fichiers distants montés peuvent également être indisponibles et doivent être vérifiés.",
+                    "it": "Problema con i server remoti che dovrebbero essere online. Anche i file system remoti montati potrebbero non essere disponibili e devono essere controllati.",
+                    "es": "Problema con los servidores remotos que se espera que estén en línea. Además, los sistemas de archivos remotos montados pueden no estar disponibles y deben revisarse.",
+                    "pl": "Problem ze zdalnymi serwerami, które powinny być w trybie online. Również zamontowane zdalne systemy plików mogą być niedostępne i należy je sprawdzić.",
+                    "zh-cn": "预期会联机的远程服务器出现问题。安装的远程文件系统也可能不可用，需要进行检查。"
+                },
+                "regex": [
+                    "^Exception-Code: EHOSTDOWN"
+                ],
+                "limit": 10
+            },
+            {
+                "category": "restartLoop",
+                "name": {
+                    "en": "Issues with frequently crashing adapter instances",
+                    "de": "Probleme mit häufig abstürzenden Adapterinstanzen",
+                    "ru": "Проблемы с частыми сбоями экземпляров адаптера",
+                    "pt": "Problemas com falhas frequentes de instâncias do adaptador",
+                    "nl": "Problemen met vaak crashende adapterinstanties",
+                    "fr": "Problèmes avec les instances d'adaptateur qui plantent fréquemment",
+                    "it": "Problemi con le istanze dell'adattatore che si arrestano frequentemente",
+                    "es": "Problemas con instancias de adaptador que fallan con frecuencia",
+                    "pl": "Problemy z często zawieszającymi się instancjami adaptera",
+                    "zh-cn": "适配器实例频繁崩溃的问题"
+                },
+                "severity": "alert",
+                "description": {
+                    "en": "An adapter instance is frequently crashing on startup and was stopped because of this. The log file needs to be checked before restarting the instance.",
+                    "de": "Eine Adapterinstanz stürzt beim Start häufig ab und wurde aus diesem Grund gestoppt. Die Protokolldatei muss vor dem Neustart der Instanz überprüft werden.",
+                    "ru": "Экземпляр адаптера часто дает сбой при запуске и был остановлен из-за этого. Перед перезапуском экземпляра необходимо проверить файл журнала.",
+                    "pt": "Uma instância do adaptador frequentemente falha na inicialização e foi interrompida por causa disso. O arquivo de log precisa ser verificado antes de reiniciar a instância.",
+                    "nl": "Een adapterinstantie crasht vaak bij het opstarten en is hierdoor gestopt. Het logboekbestand moet worden gecontroleerd voordat het exemplaar opnieuw wordt opgestart.",
+                    "fr": "Une instance d'adaptateur plante fréquemment au démarrage et a été arrêtée à cause de cela. Le fichier journal doit être vérifié avant de redémarrer l'instance.",
+                    "it": "Un'istanza dell'adattatore si blocca spesso all'avvio ed è stata interrotta per questo motivo. Il file di registro deve essere controllato prima di riavviare l'istanza.",
+                    "es": "Una instancia de adaptador falla con frecuencia al iniciarse y se detuvo debido a esto. Es necesario comprobar el archivo de registro antes de reiniciar la instancia.",
+                    "pl": "Instancja adaptera często ulega awarii podczas uruchamiania i została z tego powodu zatrzymana. Plik dziennika należy sprawdzić przed ponownym uruchomieniem instancji.",
+                    "zh-cn": "适配器实例在启动时经常崩溃，因此已被停止。重新启动实例之前，需要检查日志文件。"
+                },
+                "regex": [],
+                "limit": 1
+            },
+            {
+                "category": "fileToJsonl",
+                "name": {
+                    "en": "Auto migration to JSONL",
+                    "de": "Automatische Migration zu JSONL",
+                    "ru": "Автоматическая миграция на JSONL",
+                    "pt": "Migração automática para JSONL",
+                    "nl": "Automatische migratie naar JSONL",
+                    "fr": "Migration automatique vers JSONL",
+                    "it": "Migrazione automatica a JSONL",
+                    "es": "Migración automática a JSONL",
+                    "pl": "Automatyczna migracja do JSONL",
+                    "zh-cn": "自动迁移到 JSONL"
+                },
+                "severity": "notify",
+                "description": {
+                    "en": "The used database type in your system was automatically changed from \"file\" to \"jsonl\". This means that a normal downgrade is only possible to js-controller 3.3 or higher! Additionally the database file now have \".jsonl\" as file ending. For further questions please check in our forums.",
+                    "de": "Der verwendete Datenbanktyp des Systems wurde automatisch von „file“ auf „jsonl“ geändert. Das bedeutet, dass ein normales Downgrade nur auf js-controller 3.3 oder höher möglich ist! Zusätzlich hat die Datenbankdatei jetzt \".jsonl\" als Dateiendung. Weitere Fragen werden im ioBroker-Forum beantwortet.",
+                    "ru": "Используемый тип базы данных в вашей системе был автоматически изменен с \"file\" на \"jsonl\". Это значит, что нормальный даунгрейд возможен только до js-controller 3.3 и выше! Кроме того, файл базы данных теперь имеет расширение «.jsonl». Если у вас возникнут дополнительные вопросы, пожалуйста, посетите наш форум.",
+                    "pt": "O tipo de banco de dados usado em seu sistema foi alterado automaticamente de \"file\" para \"jsonl\". Isso significa que um downgrade normal só é possível para js-controller 3.3 ou superior! Além disso, o arquivo de banco de dados agora tem \".jsonl\" como final de arquivo. Para mais perguntas, por favor, verifique em nossos fóruns.",
+                    "nl": "Het gebruikte databasetype in uw systeem is automatisch gewijzigd van \"file\" naar \"jsonl\". Dit betekent dat een normale downgrade alleen mogelijk is naar js-controller 3.3 of hoger! Bovendien heeft het databasebestand nu \".jsonl\" als bestandsuitgang. Voor verdere vragen kunt u terecht op onze forums.",
+                    "fr": "Le type de base de données utilisé dans votre système a été automatiquement modifié de \"file\" à \"jsonl\". Cela signifie qu'une rétrogradation normale n'est possible que vers js-controller 3.3 ou supérieur ! De plus, le fichier de base de données a maintenant \".jsonl\" comme fin de fichier. Pour d'autres questions, veuillez consulter nos forums.",
+                    "it": "Il tipo di database utilizzato nel sistema è stato automaticamente modificato da \"file\" a \"jsonl\". Ciò significa che un normale downgrade è possibile solo a js-controller 3.3 o versioni successive! Inoltre, il file di database ora ha \".jsonl\" come fine del file. Per ulteriori domande, controlla nei nostri forum.",
+                    "es": "El tipo de base de datos utilizado en su sistema se cambió automáticamente de \"file\" a \"jsonl\". ¡Esto significa que una degradación normal solo es posible a js-controller 3.3 o superior! Además, el archivo de la base de datos ahora tiene \".jsonl\" como final de archivo. Si tiene más preguntas, consulte nuestros foros.",
+                    "pl": "Używany typ bazy danych w twoim systemie został automatycznie zmieniony z \"file\" na \"jsonl\". Oznacza to, że normalny downgrade jest możliwy tylko do js-controller 3.3 lub nowszego! Dodatkowo plik bazy danych ma teraz końcówkę „.jsonl”. W przypadku dalszych pytań odwiedź nasze fora.",
+                    "zh-cn": "您系统中使用的数据库类型已自动从“文件”更改为“jsonl”。这意味着只能正常降级到 js-controller 3.3 或更高版本！此外，数据库文件现在以“.jsonl”作为文件结尾。如有更多问题，请查看我们的论坛。"
+                },
+                "regex": [],
+                "limit": 1
+            }
         ]
-      }
-    }
-  },
-  "objects": [
-    {
-      "_id": "_design/system",
-      "language": "javascript",
-      "common": {
-        "name": {
-          "en": "Object's selectors",
-          "de": "Objekt-Selektoren",
-          "ru": "Селекторы объекта",
-          "pt": "Seletores de objetos",
-          "nl": "Objectkiezers",
-          "fr": "Sélecteurs d'objet",
-          "it": "Selettori di oggetti",
-          "es": "Selectores de objeto",
-          "pl": "Selektory obiektów",
-          "zh-cn": "对象的选择器"
-        },
-        "dontDelete": true
-      },
-      "views": {
-        "host": {
-          "map": "function(doc) { if (doc.type === 'host') emit(doc._id, doc) }"
-        },
-        "adapter": {
-          "map": "function(doc) { if (doc.type === 'adapter') emit(doc._id, doc) }"
-        },
-        "instance": {
-          "map": "function(doc) { if (doc.type === 'instance') emit(doc._id, doc) }"
-        },
-        "instanceStats": {
-          "map": "function(doc) { if (doc.type === 'instance') emit(doc._id, parseInt(doc._id.split('.').pop(), 10)) }",
-          "reduce": "_stats"
-        },
-        "meta": {
-          "map": "function(doc) { if (doc.type === 'meta') emit(doc._id, doc) }"
-        },
-        "device": {
-          "map": "function(doc) { if (doc.type === 'device') emit(doc._id, doc) }"
-        },
-        "channel": {
-          "map": "function(doc) { if (doc.type === 'channel') emit(doc._id, doc) }"
-        },
-        "state": {
-          "map": "function(doc) { if (doc.type === 'state') emit(doc._id, doc) }"
-        },
-        "folder": {
-          "map": "function(doc) { if (doc.type === 'folder') emit(doc._id, doc) }"
-        },
-        "enum": {
-          "map": "function(doc) { if (doc.type === 'enum') emit(doc._id, doc) }"
-        },
-        "script": {
-          "map": "function(doc) { if (doc.type === 'script') emit(doc._id, doc) }"
-        },
-        "group": {
-          "map": "function(doc) { if (doc.type === 'group') emit(doc.common.name, doc) }"
-        },
-        "user": {
-          "map": "function(doc) { if (doc.type === 'user') emit(doc.common.name, doc) }"
-        },
-        "config": {
-          "map": "function(doc) { if (doc.type === 'config') emit(doc.common.name, doc) }"
-        },
-        "custom": {
-          "map": "function(doc) { doc.type === 'state' && doc.common && doc.common.custom && emit(doc._id, doc.common.custom) }"
-        }
-      },
-      "acl": {
-        "owner": "system.user.admin",
-        "ownerGroup": "system.group.administrator",
-        "object": 1092
-      }
-    },
-    {
-      "_id": "system.group.administrator",
-      "type": "group",
-      "common": {
-        "icon": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGhlaWdodD0iMjRweCIgdmlld0JveD0iMCAwIDI0IDI0IiB3aWR0aD0iMjRweCI+DQogICAgPGcgZmlsbD0iY3VycmVudENvbG9yIj4NCiAgICAgICAgPHBhdGggZD0iTTQsMTh2LTAuNjVjMC0wLjM0LDAuMTYtMC42NiwwLjQxLTAuODFDNi4xLDE1LjUzLDguMDMsMTUsMTAsMTVjMC4wMywwLDAuMDUsMCwwLjA4LDAuMDFjMC4xLTAuNywwLjMtMS4zNywwLjU5LTEuOTggQzEwLjQ1LDEzLjAxLDEwLjIzLDEzLDEwLDEzYy0yLjQyLDAtNC42OCwwLjY3LTYuNjEsMS44MkMyLjUxLDE1LjM0LDIsMTYuMzIsMiwxNy4zNVYyMGg5LjI2Yy0wLjQyLTAuNi0wLjc1LTEuMjgtMC45Ny0ySDR6Ii8+DQogICAgICAgIDxwYXRoIGQ9Ik0xMCwxMmMyLjIxLDAsNC0xLjc5LDQtNHMtMS43OS00LTQtNEM3Ljc5LDQsNiw1Ljc5LDYsOFM3Ljc5LDEyLDEwLDEyeiBNMTAsNmMxLjEsMCwyLDAuOSwyLDJzLTAuOSwyLTIsMiBjLTEuMSwwLTItMC45LTItMlM4LjksNiwxMCw2eiIvPg0KICAgICAgICA8cGF0aCBkPSJNMjAuNzUsMTZjMC0wLjIyLTAuMDMtMC40Mi0wLjA2LTAuNjNsMS4xNC0xLjAxbC0xLTEuNzNsLTEuNDUsMC40OWMtMC4zMi0wLjI3LTAuNjgtMC40OC0xLjA4LTAuNjNMMTgsMTFoLTJsLTAuMywxLjQ5IGMtMC40LDAuMTUtMC43NiwwLjM2LTEuMDgsMC42M2wtMS40NS0wLjQ5bC0xLDEuNzNsMS4xNCwxLjAxYy0wLjAzLDAuMjEtMC4wNiwwLjQxLTAuMDYsMC42M3MwLjAzLDAuNDIsMC4wNiwwLjYzbC0xLjE0LDEuMDEgbDEsMS43M2wxLjQ1LTAuNDljMC4zMiwwLjI3LDAuNjgsMC40OCwxLjA4LDAuNjNMMTYsMjFoMmwwLjMtMS40OWMwLjQtMC4xNSwwLjc2LTAuMzYsMS4wOC0wLjYzbDEuNDUsMC40OWwxLTEuNzNsLTEuMTQtMS4wMSBDMjAuNzIsMTYuNDIsMjAuNzUsMTYuMjIsMjAuNzUsMTZ6IE0xNywxOGMtMS4xLDAtMi0wLjktMi0yczAuOS0yLDItMnMyLDAuOSwyLDJTMTguMSwxOCwxNywxOHoiLz4NCiAgICA8L2c+DQo8L3N2Zz4=",
-        "name": {
-          "en": "Administrator",
-          "de": "Administrator",
-          "ru": "Администратор",
-          "pt": "Administrador",
-          "nl": "Beheerder",
-          "fr": "Administrateur",
-          "it": "Amministratore",
-          "es": "Administrador",
-          "pl": "Administrator",
-          "zh-cn": "管理员"
-        },
-        "desc": {
-          "en": "Can do everything with System",
-          "de": "Darf alles mit dem System machen",
-          "ru": "Может делать все с помощью системы",
-          "pt": "Pode fazer tudo com o sistema",
-          "nl": "Kan alles doen met System",
-          "fr": "Peut tout faire avec le système",
-          "it": "Può fare tutto con il sistema",
-          "es": "Puede hacer todo con System",
-          "pl": "Potrafi zrobić wszystko dzięki Systemowi",
-          "zh-cn": "可以用系统做任何事情"
-        },
-        "members": [
-          "system.user.admin"
-        ],
-        "dontDelete": true,
-        "acl": {
-          "object": {
-            "list": true,
-            "read": true,
-            "write": true,
-            "delete": true
-          },
-          "state": {
-            "list": true,
-            "read": true,
-            "write": true,
-            "create": true,
-            "delete": true
-          },
-          "users": {
-            "list": true,
-            "read": true,
-            "write": true,
-            "create": true,
-            "delete": true
-          },
-          "other": {
-            "execute": true,
-            "http": true,
-            "sendto": true
-          },
-          "file": {
-            "list": true,
-            "read": true,
-            "write": true,
-            "create": true,
-            "delete": true
-          }
-        }
-      },
-      "acl": {
-        "owner": "system.user.admin",
-        "ownerGroup": "system.group.administrator",
-        "object": 1604
-      }
-    },
-    {
-      "_id": "system.group.user",
-      "type": "group",
-      "common": {
-        "icon": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGhlaWdodD0iMjRweCIgdmlld0JveD0iMCAwIDI0IDI0IiB3aWR0aD0iMjRweCI+DQogICAgPHBhdGggZmlsbD0iY3VycmVudENvbG9yIiBkPSJNMTIgNmMxLjEgMCAyIC45IDIgMnMtLjkgMi0yIDItMi0uOS0yLTIgLjktMiAyLTJtMCAxMGMyLjcgMCA1LjggMS4yOSA2IDJINmMuMjMtLjcyIDMuMzEtMiA2LTJtMC0xMkM5Ljc5IDQgOCA1Ljc5IDggOHMxLjc5IDQgNCA0IDQtMS43OSA0LTQtMS43OS00LTQtNHptMCAxMGMtMi42NyAwLTggMS4zNC04IDR2MmgxNnYtMmMwLTIuNjYtNS4zMy00LTgtNHoiLz4NCjwvc3ZnPg==",
-        "name": {
-          "en": "User",
-          "de": "Benutzer",
-          "ru": "Пользователь",
-          "pt": "Do utilizador",
-          "nl": "Gebruiker",
-          "fr": "Utilisateur",
-          "it": "Utente",
-          "es": "Usuario",
-          "pl": "Użytkownik",
-          "zh-cn": "用户"
-        },
-        "desc": {
-          "en": "Cannot modify everything",
-          "de": "Darf nicht alles ändern",
-          "ru": "Не может изменять все",
-          "pt": "Não é possível modificar tudo",
-          "nl": "Kan niet alles wijzigen",
-          "fr": "Impossible de tout modifier",
-          "it": "Non è possibile modificare tutto",
-          "es": "No se puede modificar todo",
-          "pl": "Nie można modyfikować wszystkiego",
-          "zh-cn": "用户无法修改所有内容"
-        },
-        "members": [],
-        "dontDelete": true,
-        "acl": {
-          "object": {
-            "list": true,
-            "read": true,
-            "write": false,
-            "delete": false
-          },
-          "state": {
-            "list": true,
-            "read": true,
-            "write": true,
-            "create": true,
-            "delete": false
-          },
-          "users": {
-            "list": true,
-            "read": true,
-            "write": false,
-            "create": false,
-            "delete": false
-          },
-          "other": {
-            "execute": false,
-            "http": true,
-            "sendto": false
-          },
-          "file": {
-            "list": true,
-            "read": true,
-            "write": false,
-            "create": false,
-            "delete": false
-          }
-        }
-      },
-      "acl": {
-        "owner": "system.user.admin",
-        "ownerGroup": "system.group.administrator",
-        "object": 1604
-      }
-    },
-    {
-      "_id": "enum.rooms",
-      "common": {
-        "icon": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGhlaWdodD0iMjRweCIgdmlld0JveD0iMCAwIDI0IDI0IiB3aWR0aD0iMjRweCI+DQogICAgPHBhdGggZmlsbD0iY3VycmVudENvbG9yIiBkPSJNMTIgNS42OWw1IDQuNVYxOGgtMnYtNkg5djZIN3YtNy44MWw1LTQuNU0xMiAzTDIgMTJoM3Y4aDZ2LTZoMnY2aDZ2LThoM0wxMiAzeiIvPg0KPC9zdmc+",
-        "name": {
-          "en": "Rooms",
-          "de": "Räume",
-          "ru": "Комнаты",
-          "pt": "Quartos",
-          "nl": "Kamers",
-          "fr": "Pièces",
-          "it": "Camere",
-          "es": "Habitaciones",
-          "pl": "Pokoje",
-          "zh-cn": "客房"
-        },
-        "desc": {
-          "en": "List of the rooms",
-          "de": "Liste der Räume",
-          "ru": "Список комнат",
-          "pt": "Lista dos quartos",
-          "nl": "Lijst met kamers",
-          "fr": "Liste des chambres",
-          "it": "Elenco delle stanze",
-          "es": "Lista de las habitaciones",
-          "pl": "Lista pokoi",
-          "zh-cn": "房间清单"
-        },
-        "members": [],
-        "dontDelete": true
-      },
-      "type": "enum",
-      "acl": {
-        "owner": "system.user.admin",
-        "ownerGroup": "system.group.administrator",
-        "object": 1911
-      }
-    },
-    {
-      "_id": "enum.functions",
-      "common": {
-        "icon": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGhlaWdodD0iMjRweCIgdmlld0JveD0iMCAwIDI0IDI0IiB3aWR0aD0iMjRweCI+DQogICAgPHBhdGggZmlsbD0iY3VycmVudENvbG9yIiBkPSJNOSAyMWMwIC41NS40NSAxIDEgMWg0Yy41NSAwIDEtLjQ1IDEtMXYtMUg5djF6bTMtMTlDOC4xNCAyIDUgNS4xNCA1IDljMCAyLjM4IDEuMTkgNC40NyAzIDUuNzRWMTdjMCAuNTUuNDUgMSAxIDFoNmMuNTUgMCAxLS40NSAxLTF2LTIuMjZjMS44MS0xLjI3IDMtMy4zNiAzLTUuNzQgMC0zLjg2LTMuMTQtNy03LTd6bTIuODUgMTEuMWwtLjg1LjZWMTZoLTR2LTIuM2wtLjg1LS42QzcuOCAxMi4xNiA3IDEwLjYzIDcgOWMwLTIuNzYgMi4yNC01IDUtNXM1IDIuMjQgNSA1YzAgMS42My0uOCAzLjE2LTIuMTUgNC4xeiIvPg0KPC9zdmc+",
-        "name": {
-          "en": "Functions",
-          "de": "Funktionen",
-          "ru": "функции",
-          "pt": "Funções",
-          "nl": "functies",
-          "fr": "Les fonctions",
-          "it": "funzioni",
-          "es": "Funciones",
-          "pl": "Funkcje",
-          "zh-cn": "职能"
-        },
-        "desc": {
-          "en": "List of the functions",
-          "de": "Liste der Funktionen",
-          "ru": "Список функций",
-          "pt": "Lista das funções",
-          "nl": "Lijst met functies",
-          "fr": "Liste des fonctions",
-          "it": "Elenco delle funzioni",
-          "es": "Lista de las funciones",
-          "pl": "Lista funkcji",
-          "zh-cn": "功能列表"
-        },
-        "members": [],
-        "dontDelete": true
-      },
-      "type": "enum",
-      "acl": {
-        "owner": "system.user.admin",
-        "ownerGroup": "system.group.administrator",
-        "object": 1911
-      }
-    },
-    {
-      "_id": "system.config",
-      "type": "config",
-      "common": {
-        "name": {
-          "en": "System configuration",
-          "de": "Systemkonfiguration",
-          "ru": "Конфигурация системы",
-          "pt": "Configuração do sistema",
-          "nl": "Systeem configuratie",
-          "fr": "Configuration du système",
-          "it": "Configurazione di sistema",
-          "es": "Configuración del sistema",
-          "pl": "Konfiguracja systemu",
-          "zh-cn": "系统配置"
-        },
-        "city": "",
-        "country": "",
-        "longitude": "",
-        "latitude": "",
-        "language": "",
-        "tempUnit": "°C",
-        "currency": "",
-        "dontDelete": true,
-        "dateFormat": "DD.MM.YYYY",
-        "isFloatComma": true,
-        "licenseConfirmed": false,
-        "defaultHistory": "",
-        "expertMode": false,
-        "defaultLogLevel": "info",
-        "activeRepo": [
-          "stable"
-        ],
-        "diag": "extended",
-        "tabs": [
-          "tab-intro",
-          "tab-info",
-          "tab-adapters",
-          "tab-instances",
-          "tab-objects",
-          "tab-log",
-          "tab-scenes",
-          "tab-javascript",
-          "tab-text2command-0",
-          "tab-node-red-0"
-        ]
-      },
-      "native": {},
-      "acl": {
-        "owner": "system.user.admin",
-        "ownerGroup": "system.group.administrator",
-        "object": 1604
-      }
-    },
-    {
-      "_id": "system.repositories",
-      "type": "config",
-      "common": {
-        "name": {
-          "en": "System repositories",
-          "de": "System-Repositories",
-          "ru": "Системные репозитории",
-          "pt": "Repositórios do sistema",
-          "nl": "Systeemrepository's",
-          "fr": "Référentiels système",
-          "it": "Repository di sistema",
-          "es": "Repositorios del sistema",
-          "pl": "Repozytoria systemowe",
-          "zh-cn": "系统资料库"
-        },
-        "dontDelete": true
-      },
-      "native": {
-        "repositories": {
-          "stable": {
-            "link": "http://download.iobroker.net/sources-dist.json",
-            "json": null
-          },
-          "beta": {
-            "link": "http://download.iobroker.net/sources-dist-latest.json",
-            "json": null
-          }
-        },
-        "oldRepositories": {
-          "sources": {
-            "link": "conf/sources-dist.json",
-            "json": null
-          },
-          "online": {
-            "link": "https://raw.githubusercontent.com/ioBroker/ioBroker.repositories/master/sources-dist.json",
-            "json": null
-          }
-        }
-      },
-      "acl": {
-        "owner": "system.user.admin",
-        "ownerGroup": "system.group.administrator",
-        "object": 1604
-      }
-    },
-    {
-      "_id": "system.licenses",
-      "type": "config",
-      "common": {
-        "name": {
-          "en": "Licenses from iobroker.net",
-          "de": "Lizenzen von iobroker.net",
-          "ru": "Лицензии от iobroker.net",
-          "pt": "Licenças de iobroker.net",
-          "nl": "Licenties van iobroker.net",
-          "fr": "Licences de iobroker.net",
-          "it": "Licenze da iobroker.net",
-          "es": "Licencias de iobroker.net",
-          "pl": "Licencje z iobroker.net",
-          "zh-cn": "来自 iobroker.net 的许可证"
-        }
-      },
-      "native": {
-        "login": "",
-        "password": "",
-        "licenses": [],
-        "readTime": 0
-      },
-      "acl": {
-        "owner": "system.user.admin",
-        "ownerGroup": "system.group.administrator",
-        "object": 1604
-      }
-    },
-    {
-      "_id": "system.certificates",
-      "type": "config",
-      "common": {
-        "icon": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGhlaWdodD0iMjRweCIgdmlld0JveD0iMCAwIDI0IDI0IiB3aWR0aD0iMjRweCI+DQogICAgPHBhdGggZmlsbD0iY3VycmVudENvbG9yIiBkPSJNMTIgMUwzIDV2NmMwIDUuNTUgMy44NCAxMC43NCA5IDEyIDUuMTYtMS4yNiA5LTYuNDUgOS0xMlY1bC05LTR6bTAgMTAuOTloN2MtLjUzIDQuMTItMy4yOCA3Ljc5LTcgOC45NFYxMkg1VjYuM2w3LTMuMTF2OC44eiIvPg0KPC9zdmc+",
-        "name": {
-          "en": "System certificates",
-          "de": "Systemzertifikate",
-          "ru": "Системные сертификаты",
-          "pt": "Certificados do sistema",
-          "nl": "Systeem certificaten",
-          "fr": "Certificats système",
-          "it": "Certificati di sistema",
-          "es": "Certificados del sistema",
-          "pl": "Certyfikaty systemowe",
-          "zh-cn": "系统证书"
-        }
-      },
-      "native": {
-        "certificates": {
-          "defaultPrivate": null,
-          "defaultPublic": null
-        }
-      },
-      "acl": {
-        "owner": "system.user.admin",
-        "ownerGroup": "system.group.administrator",
-        "object": 1536
-      }
-    },
-    {
-      "_id": "alias.0",
-      "type": "meta",
-      "common": {
-        "name": {
-          "en": "root folder for Aliases",
-          "de": "Stammordner für Aliase",
-          "ru": "корневая папка для псевдонимов",
-          "pt": "pasta raiz para aliases",
-          "nl": "hoofdmap voor aliassen",
-          "fr": "dossier racine pour les alias",
-          "it": "cartella principale per gli alias",
-          "es": "carpeta raíz para alias",
-          "pl": "folder główny dla aliasów",
-          "zh-cn": "别名的根文件夹"
-        },
-        "type": "meta.folder",
-        "dontDelete": true
-      },
-      "acl": {
-        "owner": "system.user.admin",
-        "ownerGroup": "system.group.administrator",
-        "object": 1604
-      }
-    },
-    {
-      "_id": "0_userdata.0",
-      "type": "meta",
-      "common": {
-        "icon": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGhlaWdodD0iMjRweCIgdmlld0JveD0iMCAwIDI0IDI0IiB3aWR0aD0iMjRweCI+DQogICAgPGcgZmlsbD0iY3VycmVudENvbG9yIj4NCiAgICAgICAgPHBhdGggZD0iTTE5LDV2MTRINVY1SDE5IE0xOSwzSDVDMy45LDMsMywzLjksMyw1djE0YzAsMS4xLDAuOSwyLDIsMmgxNGMxLjEsMCwyLTAuOSwyLTJWNUMyMSwzLjksMjAuMSwzLDE5LDNMMTksM3oiLz4NCiAgICAgICAgPHBhdGggZD0iTTE0LDE3SDd2LTJoN1YxN3ogTTE3LDEzSDd2LTJoMTBWMTN6IE0xNyw5SDdWN2gxMFY5eiIvPg0KICAgIDwvZz4NCjwvc3ZnPg==",
-        "name": {
-          "en": "User objects and files root folder",
-          "de": "Stammordner für Benutzerobjekte und Dateien",
-          "ru": "Корневая папка пользовательских объектов и файлов",
-          "pt": "Pasta raiz de objetos e arquivos do usuário",
-          "nl": "Hoofdmap van objecten en bestanden van gebruikers",
-          "fr": "Objets utilisateur et dossier racine des fichiers",
-          "it": "Cartella principale di oggetti e file dell'utente",
-          "es": "Carpeta raíz de objetos y archivos de usuario",
-          "pl": "Folder główny obiektów i plików użytkownika",
-          "zh-cn": "用户对象和文件根文件夹"
-        },
-        "desc": {
-          "en": "Here you can upload your files or create your private objects and states",
-          "de": "Hier können eigene Dateien hochgeladen oder private Objekte und Zustände erstellt werden",
-          "ru": "Здесь вы можете загрузить свои файлы или создать свои личные объекты и состояния",
-          "pt": "Aqui você pode enviar seus arquivos ou criar seus objetos e estados particulares",
-          "nl": "Hier kunt u uw bestanden uploaden of uw privé-objecten en statussen maken",
-          "fr": "Ici, vous pouvez télécharger vos fichiers ou créer vos objets et états privés",
-          "it": "Qui puoi caricare i tuoi file o creare oggetti e stati privati",
-          "es": "Aquí puede cargar sus archivos o crear sus objetos y estados privados",
-          "pl": "Tutaj możesz przesyłać pliki lub tworzyć prywatne obiekty i stany",
-          "zh-cn": "在这里您可以上传文件或创建私有对象和状态"
-        },
-        "type": "meta.user",
-        "dontDelete": true
-      },
-      "acl": {
-        "owner": "system.user.admin",
-        "ownerGroup": "system.group.administrator",
-        "object": 1604
-      }
-    },
-    {
-      "_id": "0_userdata.0.example_state",
-      "type": "state",
-      "common": {
-        "name": "Example state",
-        "role": "indicator",
-        "def": false,
-        "type": "boolean"
-      },
-      "acl": {
-        "owner": "system.user.admin",
-        "ownerGroup": "system.group.administrator",
-        "object": 1604
-      }
-    }
-  ],
-  "notifications": [
-    {
-      "scope": "system",
-      "name": {
-        "en": "System Notifications",
-        "de": "System-Benachrichtigungen",
-        "ru": "Системные уведомления",
-        "pt": "Notificações do sistema",
-        "nl": "Systeemmeldingen",
-        "fr": "Notifications système",
-        "it": "Notifiche di sistema",
-        "es": "Notificaciones del sistema",
-        "pl": "Powiadomienia systemowe",
-        "zh-cn": "系统通知"
-      },
-      "description": {
-        "en": "These notifications are collected by the ioBroker system and point to issues you should check and fix.",
-        "de": "Diese Benachrichtigungen werden vom ioBroker-System erfasst und weisen auf Probleme hin, die überprüft und behoben werden sollten.",
-        "ru": "Эти уведомления собираются системой ioBroker и указывают на проблемы, которые вы должны проверить и исправить.",
-        "pt": "Essas notificações são coletadas pelo sistema ioBroker e apontam para problemas que você deve verificar e corrigir.",
-        "nl": "Deze meldingen worden verzameld door het ioBroker-systeem en wijzen op problemen die u moet controleren en oplossen.",
-        "fr": "Ces notifications sont collectées par le système ioBroker et indiquent des problèmes que vous devez vérifier et résoudre.",
-        "it": "Queste notifiche vengono raccolte dal sistema ioBroker e indicano problemi che dovresti controllare e correggere.",
-        "es": "Estas notificaciones son recopiladas por el sistema ioBroker y señalan problemas que debe verificar y solucionar.",
-        "pl": "Te powiadomienia są zbierane przez system ioBroker i wskazują problemy, które należy sprawdzić i naprawić.",
-        "zh-cn": "这些通知由ioBroker系统收集，并指出您应检查并修复的问题"
-      },
-      "categories": [
-        {
-          "category": "memIssues",
-          "name": {
-            "en": "Issues with RAM availability",
-            "de": "Probleme mit der Arbeitsspeicher-Verfügbarkeit",
-            "ru": "Проблемы с доступностью оперативной памяти",
-            "pt": "Problemas com disponibilidade de RAM",
-            "nl": "Problemen met de beschikbaarheid van RAM",
-            "fr": "Problèmes de disponibilité de la RAM",
-            "it": "Problemi con la disponibilità della RAM",
-            "es": "Problemas con la disponibilidad de RAM",
-            "pl": "Problemy z dostępnością pamięci RAM",
-            "zh-cn": "RAM可用性问题"
-          },
-          "severity": "alert",
-          "description": {
-            "en": "Your system is running out of memory. Please check the number of running adapters and processes or if single processes need too many memory.",
-            "de": "Es steht nicht genug Arbeitsspeicher zur Verfügung. Die Anzahl der laufenden Adapter und Prozesse sollte geprüft werden, oder ob einzelne Prozesse zuviel Speicher benötigen.",
-            "ru": "В вашей системе не хватает памяти. Пожалуйста, проверьте количество работающих адаптеров и процессов, или если отдельным процессам требуется слишком много памяти.",
-            "pt": "Seu sistema está ficando sem memória. Verifique o número de adaptadores e processos em execução ou se processos únicos precisam de muita memória.",
-            "nl": "Uw systeem heeft onvoldoende geheugen. Controleer het aantal actieve adapters en processen of als afzonderlijke processen te veel geheugen nodig hebben.",
-            "fr": "Votre système manque de mémoire. Veuillez vérifier le nombre d'adaptateurs et de processus en cours d'exécution ou si des processus uniques nécessitent trop de mémoire.",
-            "it": "Il tuo sistema sta esaurendo la memoria. Controllare il numero di adattatori e processi in esecuzione o se i singoli processi richiedono troppa memoria.",
-            "es": "Su sistema se está quedando sin memoria. Verifique el número de adaptadores y procesos en ejecución o si los procesos individuales necesitan demasiada memoria.",
-            "pl": "W Twoim systemie kończy się pamięć. Sprawdź liczbę działających adapterów i procesów lub czy pojedyncze procesy wymagają zbyt dużej ilości pamięci.",
-            "zh-cn": "您的系统内存不足。请检查正在运行的适配器和进程的数量，或者单个进程是否需要太多内存。"
-          },
-          "regex": [
-            "^Exception-Code: ENOMEM",
-            "buffer allocation failed"
-          ],
-          "limit": 10
-        },
-        {
-          "category": "fsIoErrors",
-          "name": {
-            "en": "Issues with the file system",
-            "de": "Probleme mit dem Dateisystem",
-            "ru": "Проблемы с файловой системой",
-            "pt": "Problemas com o sistema de arquivos",
-            "nl": "Problemen met het bestandssysteem",
-            "fr": "Problèmes avec le système de fichiers",
-            "it": "Problemi con il file system",
-            "es": "Problemas con el sistema de archivos",
-            "pl": "Problemy z systemem plików",
-            "zh-cn": "文件系统问题"
-          },
-          "severity": "alert",
-          "description": {
-            "en": "There is an error with the file system. Maybe the file system is corrupted or wrongly configured. A file system check is required!",
-            "de": "Es liegt ein Fehler im Dateisystem vor. Möglicherweise ist das Dateisystem beschädigt oder falsch konfiguriert. Eine Dateisystemprüfung ist erforderlich!",
-            "ru": "Ошибка файловой системы. Возможно, файловая система повреждена или неправильно настроена. Требуется проверка файловой системы!",
-            "pt": "Ocorreu um erro com o sistema de arquivos. Talvez o sistema de arquivos esteja corrompido ou configurado incorretamente. É necessária uma verificação do sistema de arquivos!",
-            "nl": "Er is een fout opgetreden met het bestandssysteem. Misschien is het bestandssysteem beschadigd of verkeerd geconfigureerd. Een bestandssysteemcontrole is vereist!",
-            "fr": "Il y a une erreur avec le système de fichiers. Le système de fichiers est peut-être corrompu ou mal configuré. Une vérification du système de fichiers est requise!",
-            "it": "C'è un errore con il file system. Forse il file system è danneggiato o configurato in modo errato. È richiesto un controllo del file system!",
-            "es": "Hay un error con el sistema de archivos. Quizás el sistema de archivos está dañado o configurado incorrectamente. Se requiere una verificación del sistema de archivos.",
-            "pl": "Wystąpił błąd w systemie plików. Być może system plików jest uszkodzony lub nieprawidłowo skonfigurowany. Wymagane jest sprawdzenie systemu plików!",
-            "zh-cn": "文件系统出错。也许文件系统已损坏或配置错误。需要文件系统检查！"
-          },
-          "regex": [
-            "^Exception-Code: EROFS",
-            "^Exception-Code: EIO",
-            "^Exception-Code: ENXIO",
-            "^Exception-Code: EMFILE",
-            "^Exception-Code: EBADF",
-            "^Exception-Code: ENFILE",
-            "^Unknown system error -117[^,]*, write"
-          ],
-          "limit": 10
-        },
-        {
-          "category": "noDiskSpace",
-          "name": {
-            "en": "Issues with free disk space",
-            "de": "Probleme mit dem freien Speicherplatz",
-            "ru": "Проблемы со свободным местом на диске",
-            "pt": "Problemas com espaço livre em disco",
-            "nl": "Problemen met vrije schijfruimte",
-            "fr": "Problèmes d'espace disque libre",
-            "it": "Problemi con lo spazio libero su disco",
-            "es": "Problemas con el espacio libre en disco",
-            "pl": "Problemy z wolnym miejscem na dysku",
-            "zh-cn": "可用磁盘空间问题"
-          },
-          "severity": "alert",
-          "description": {
-            "en": "There is not enough disk space left on the storage device. Please clean up some disk space.",
-            "de": "Es steht nicht genügend Speicherplatz auf dem Datenträger zur Verfügung. Bitte bereinigen Sie etwas Speicherplatz.",
-            "ru": "На запоминающем устройстве недостаточно места на диске. Пожалуйста, очистите место на диске.",
-            "pt": "Não há espaço em disco suficiente no dispositivo de armazenamento. Limpe algum espaço em disco.",
-            "nl": "Er is niet genoeg schijfruimte over op het opslagapparaat. Ruim wat schijfruimte op.",
-            "fr": "Il n'y a pas assez d'espace disque sur le périphérique de stockage. Veuillez nettoyer de l'espace disque.",
-            "it": "Spazio su disco insufficiente sul dispositivo di archiviazione. Si prega di pulire un po 'di spazio su disco.",
-            "es": "No queda suficiente espacio en disco en el dispositivo de almacenamiento. Limpie algo de espacio en disco.",
-            "pl": "Za mało miejsca na dysku na urządzeniu magazynującym. Proszę wyczyścić trochę miejsca na dysku.",
-            "zh-cn": "存储设备上没有足够的磁盘空间。请清理一些磁盘空间。"
-          },
-          "regex": [
-            "^Exception-Code: ENOSPC"
-          ],
-          "limit": 10
-        },
-        {
-          "category": "accessErrors",
-          "name": {
-            "en": "Issues with file access rights",
-            "de": "Probleme mit Dateizugriffsrechten",
-            "ru": "Проблемы с правами доступа к файлам",
-            "pt": "Problemas com direitos de acesso a arquivos",
-            "nl": "Problemen met toegangsrechten voor bestanden",
-            "fr": "Problèmes avec les droits d'accès aux fichiers",
-            "it": "Problemi con i diritti di accesso ai file",
-            "es": "Problemas con los derechos de acceso a archivos",
-            "pl": "Problemy z prawami dostępu do plików",
-            "zh-cn": "文件访问权限问题"
-          },
-          "severity": "alert",
-          "description": {
-            "en": "There is an issue with access rights for files on the system. Running the installation fixer can solve these issues. Alternatively check the relevant directories and files.",
-            "de": "Es liegt ein Problem mit den Zugriffsrechten für Dateien auf dem System vor. Durch Ausführen des Installationsfixers können diese behoben werden. Alternativ müssen die entsprechenden Verzeichnisse und Dateien überprüft werden.",
-            "ru": "Возникла проблема с правами доступа к файлам в системе. Эти проблемы можно решить с помощью средства исправления установки. Или проверьте соответствующие каталоги и файлы.",
-            "pt": "Há um problema com os direitos de acesso para arquivos no sistema. Executar o fixador de instalação pode resolver esses problemas. Como alternativa, verifique os diretórios e arquivos relevantes.",
-            "nl": "Er is een probleem met toegangsrechten voor bestanden op het systeem. Het uitvoeren van de installatie-fixer kan deze problemen oplossen. Als alternatief kunt u de relevante mappen en bestanden controleren.",
-            "fr": "Il y a un problème avec les droits d'accès aux fichiers sur le système. L'exécution du programme d'installation peut résoudre ces problèmes. Vous pouvez également vérifier les répertoires et fichiers concernés.",
-            "it": "Si è verificato un problema con i diritti di accesso per i file sul sistema. L'esecuzione del programma di riparazione dell'installazione può risolvere questi problemi. In alternativa, controlla le directory e i file pertinenti.",
-            "es": "Existe un problema con los derechos de acceso a los archivos del sistema. Ejecutar el reparador de instalación puede resolver estos problemas. Alternativamente, consulte los directorios y archivos relevantes.",
-            "pl": "Wystąpił problem z prawami dostępu do plików w systemie. Uruchomienie narzędzia do naprawy instalacji może rozwiązać te problemy. Alternatywnie sprawdź odpowiednie katalogi i pliki.",
-            "zh-cn": "系统上文件的访问权限存在问题。运行安装修复程序可以解决这些问题。或者，检查相关的目录和文件。"
-          },
-          "regex": [
-            "^Exception-Code: EACCESS",
-            "^Exception-Code: EPERM"
-          ],
-          "limit": 10
-        },
-        {
-          "category": "nonExistingFileErrors",
-          "name": {
-            "en": "Issues with non-existing files or directories",
-            "de": "Probleme mit nicht vorhandenen Dateien oder Verzeichnissen",
-            "ru": "Проблемы с несуществующими файлами или каталогами",
-            "pt": "Problemas com arquivos ou diretórios não existentes",
-            "nl": "Problemen met niet-bestaande bestanden of mappen",
-            "fr": "Problèmes avec des fichiers ou des répertoires non existants",
-            "it": "Problemi con file o directory inesistenti",
-            "es": "Problemas con archivos o directorios que no existen",
-            "pl": "Problemy z nieistniejącymi plikami lub katalogami",
-            "zh-cn": "文件或目录不存在的问题"
-          },
-          "severity": "alert",
-          "description": {
-            "en": "A process tries to access a non-existing file or directory.",
-            "de": "Ein Prozess versucht, auf eine nicht vorhandene Datei oder ein nicht vorhandenes Verzeichnis zuzugreifen.",
-            "ru": "Процесс пытается получить доступ к несуществующему файлу или каталогу.",
-            "pt": "Um processo tenta acessar um arquivo ou diretório não existente.",
-            "nl": "Een proces probeert toegang te krijgen tot een niet-bestaand bestand of map.",
-            "fr": "Un processus tente d'accéder à un fichier ou un répertoire inexistant.",
-            "it": "Un processo tenta di accedere a un file o una directory inesistente.",
-            "es": "Un proceso intenta acceder a un archivo o directorio que no existe.",
-            "pl": "Proces próbuje uzyskać dostęp do nieistniejącego pliku lub katalogu.",
-            "zh-cn": "进程尝试访问不存在的文件或目录。"
-          },
-          "regex": [
-            "^Exception-Code: ENOENT"
-          ],
-          "limit": 10
-        },
-        {
-          "category": "remoteHostErrors",
-          "name": {
-            "en": "Issues with remote servers",
-            "de": "Probleme mit Remote-Servern",
-            "ru": "Проблемы с удаленными серверами",
-            "pt": "Problemas com servidores remotos",
-            "nl": "Problemen met externe servers",
-            "fr": "Problèmes avec les serveurs distants",
-            "it": "Problemi con i server remoti",
-            "es": "Problemas con servidores remotos",
-            "pl": "Problemy ze zdalnymi serwerami",
-            "zh-cn": "远程服务器的问题"
-          },
-          "severity": "alert",
-          "description": {
-            "en": "Issue with remote servers that are expected to be online. Also mounted remote file systems could be unavailable and need to be checked.",
-            "de": "Problem mit Remoteservern, von denen erwartet wird, dass sie online sind. Auch gemountete Remote-Dateisysteme sind möglicherweise nicht verfügbar und müssen überprüft werden.",
-            "ru": "Проблема с удаленными серверами, которые должны быть в сети. Кроме того, смонтированные удаленные файловые системы могут быть недоступны, и их необходимо проверить.",
-            "pt": "Problema com servidores remotos que deveriam estar online. Além disso, os sistemas de arquivos remotos montados podem estar indisponíveis e precisam ser verificados.",
-            "nl": "Probleem met externe servers waarvan wordt verwacht dat ze online zijn. Ook gekoppelde externe bestandssystemen zijn mogelijk niet beschikbaar en moeten worden gecontroleerd.",
-            "fr": "Problème avec les serveurs distants censés être en ligne. Les systèmes de fichiers distants montés peuvent également être indisponibles et doivent être vérifiés.",
-            "it": "Problema con i server remoti che dovrebbero essere online. Anche i file system remoti montati potrebbero non essere disponibili e devono essere controllati.",
-            "es": "Problema con los servidores remotos que se espera que estén en línea. Además, los sistemas de archivos remotos montados pueden no estar disponibles y deben revisarse.",
-            "pl": "Problem ze zdalnymi serwerami, które powinny być w trybie online. Również zamontowane zdalne systemy plików mogą być niedostępne i należy je sprawdzić.",
-            "zh-cn": "预期会联机的远程服务器出现问题。安装的远程文件系统也可能不可用，需要进行检查。"
-          },
-          "regex": [
-            "^Exception-Code: EHOSTDOWN"
-          ],
-          "limit": 10
-        },
-        {
-          "category": "restartLoop",
-          "name": {
-            "en": "Issues with frequently crashing adapter instances",
-            "de": "Probleme mit häufig abstürzenden Adapterinstanzen",
-            "ru": "Проблемы с частыми сбоями экземпляров адаптера",
-            "pt": "Problemas com falhas frequentes de instâncias do adaptador",
-            "nl": "Problemen met vaak crashende adapterinstanties",
-            "fr": "Problèmes avec les instances d'adaptateur qui plantent fréquemment",
-            "it": "Problemi con le istanze dell'adattatore che si arrestano frequentemente",
-            "es": "Problemas con instancias de adaptador que fallan con frecuencia",
-            "pl": "Problemy z często zawieszającymi się instancjami adaptera",
-            "zh-cn": "适配器实例频繁崩溃的问题"
-          },
-          "severity": "alert",
-          "description": {
-            "en": "An adapter instance is frequently crashing on startup and was stopped because of this. The log file needs to be checked before restarting the instance.",
-            "de": "Eine Adapterinstanz stürzt beim Start häufig ab und wurde aus diesem Grund gestoppt. Die Protokolldatei muss vor dem Neustart der Instanz überprüft werden.",
-            "ru": "Экземпляр адаптера часто дает сбой при запуске и был остановлен из-за этого. Перед перезапуском экземпляра необходимо проверить файл журнала.",
-            "pt": "Uma instância do adaptador frequentemente falha na inicialização e foi interrompida por causa disso. O arquivo de log precisa ser verificado antes de reiniciar a instância.",
-            "nl": "Een adapterinstantie crasht vaak bij het opstarten en is hierdoor gestopt. Het logboekbestand moet worden gecontroleerd voordat het exemplaar opnieuw wordt opgestart.",
-            "fr": "Une instance d'adaptateur plante fréquemment au démarrage et a été arrêtée à cause de cela. Le fichier journal doit être vérifié avant de redémarrer l'instance.",
-            "it": "Un'istanza dell'adattatore si blocca spesso all'avvio ed è stata interrotta per questo motivo. Il file di registro deve essere controllato prima di riavviare l'istanza.",
-            "es": "Una instancia de adaptador falla con frecuencia al iniciarse y se detuvo debido a esto. Es necesario comprobar el archivo de registro antes de reiniciar la instancia.",
-            "pl": "Instancja adaptera często ulega awarii podczas uruchamiania i została z tego powodu zatrzymana. Plik dziennika należy sprawdzić przed ponownym uruchomieniem instancji.",
-            "zh-cn": "适配器实例在启动时经常崩溃，因此已被停止。重新启动实例之前，需要检查日志文件。"
-          },
-          "regex": [],
-          "limit": 1
-        },
-        {
-          "category": "fileToJsonl",
-          "name": {
-            "en": "Auto migration to JSONL",
-            "de": "Automatische Migration zu JSONL",
-            "ru": "Автоматическая миграция на JSONL",
-            "pt": "Migração automática para JSONL",
-            "nl": "Automatische migratie naar JSONL",
-            "fr": "Migration automatique vers JSONL",
-            "it": "Migrazione automatica a JSONL",
-            "es": "Migración automática a JSONL",
-            "pl": "Automatyczna migracja do JSONL",
-            "zh-cn": "自动迁移到 JSONL"
-          },
-          "severity": "notify",
-          "description": {
-            "en": "The used database type in your system was automatically changed from \"file\" to \"jsonl\". This means that a normal downgrade is only possible to js-controller 3.3 or higher! Additionally the database file now have \".jsonl\" as file ending. For further questions please check in our forums.",
-            "de": "Der verwendete Datenbanktyp des Systems wurde automatisch von „file“ auf „jsonl“ geändert. Das bedeutet, dass ein normales Downgrade nur auf js-controller 3.3 oder höher möglich ist! Zusätzlich hat die Datenbankdatei jetzt \".jsonl\" als Dateiendung. Weitere Fragen werden im ioBroker-Forum beantwortet.",
-            "ru": "Используемый тип базы данных в вашей системе был автоматически изменен с \"file\" на \"jsonl\". Это значит, что нормальный даунгрейд возможен только до js-controller 3.3 и выше! Кроме того, файл базы данных теперь имеет расширение «.jsonl». Если у вас возникнут дополнительные вопросы, пожалуйста, посетите наш форум.",
-            "pt": "O tipo de banco de dados usado em seu sistema foi alterado automaticamente de \"file\" para \"jsonl\". Isso significa que um downgrade normal só é possível para js-controller 3.3 ou superior! Além disso, o arquivo de banco de dados agora tem \".jsonl\" como final de arquivo. Para mais perguntas, por favor, verifique em nossos fóruns.",
-            "nl": "Het gebruikte databasetype in uw systeem is automatisch gewijzigd van \"file\" naar \"jsonl\". Dit betekent dat een normale downgrade alleen mogelijk is naar js-controller 3.3 of hoger! Bovendien heeft het databasebestand nu \".jsonl\" als bestandsuitgang. Voor verdere vragen kunt u terecht op onze forums.",
-            "fr": "Le type de base de données utilisé dans votre système a été automatiquement modifié de \"file\" à \"jsonl\". Cela signifie qu'une rétrogradation normale n'est possible que vers js-controller 3.3 ou supérieur ! De plus, le fichier de base de données a maintenant \".jsonl\" comme fin de fichier. Pour d'autres questions, veuillez consulter nos forums.",
-            "it": "Il tipo di database utilizzato nel sistema è stato automaticamente modificato da \"file\" a \"jsonl\". Ciò significa che un normale downgrade è possibile solo a js-controller 3.3 o versioni successive! Inoltre, il file di database ora ha \".jsonl\" come fine del file. Per ulteriori domande, controlla nei nostri forum.",
-            "es": "El tipo de base de datos utilizado en su sistema se cambió automáticamente de \"file\" a \"jsonl\". ¡Esto significa que una degradación normal solo es posible a js-controller 3.3 o superior! Además, el archivo de la base de datos ahora tiene \".jsonl\" como final de archivo. Si tiene más preguntas, consulte nuestros foros.",
-            "pl": "Używany typ bazy danych w twoim systemie został automatycznie zmieniony z \"file\" na \"jsonl\". Oznacza to, że normalny downgrade jest możliwy tylko do js-controller 3.3 lub nowszego! Dodatkowo plik bazy danych ma teraz końcówkę „.jsonl”. W przypadku dalszych pytań odwiedź nasze fora.",
-            "zh-cn": "您系统中使用的数据库类型已自动从“文件”更改为“jsonl”。这意味着只能正常降级到 js-controller 3.3 或更高版本！此外，数据库文件现在以“.jsonl”作为文件结尾。如有更多问题，请查看我们的论坛。"
-          },
-          "regex": [],
-          "limit": 1
-        }
-      ]
-    }
-  ]
+    }]
 }

--- a/packages/controller/lib/setup.js
+++ b/packages/controller/lib/setup.js
@@ -174,26 +174,22 @@ function initYargs() {
                 .command('[<repositoryUrl>]', 'Upgrade all adapters, optionally you can specify the repository url', {})
                 .command(
                     'all [<repositoryUrl>]',
-                    'Upgrade all adapters, optionally you can specify the repository url',
-                    {}
+                    'Upgrade all adapters, optionally you can specify the repository url', {}
                 )
                 .command(
                     'self [<repositoryUrl>]',
-                    'Upgrade js-controller, optionally you can specify the repository url',
-                    {}
+                    'Upgrade js-controller, optionally you can specify the repository url', {}
                 )
                 .command(
                     '<adapter> [<repositoryUrl>]',
-                    'Upgrade specified adapter, optionally you can specify the repository url',
-                    {}
+                    'Upgrade specified adapter, optionally you can specify the repository url', {}
                 );
         })
         .command(['upload [all|<adapter>]', 'u [all|<adapter>]'], 'Upload management', yargs => {
             yargs
                 .command(
                     `<pathToLocalFile> <pathIn${tools.appName}>`,
-                    'Upload given files to provided path to make them available for instances',
-                    {}
+                    'Upload given files to provided path to make them available for instances', {}
                 )
                 .command('all', 'Upload all adapter files to make them available for instances', {})
                 .command('<adapter>', 'Upload specified adapter files to make them available for instances', {});
@@ -204,13 +200,11 @@ function initYargs() {
                 .command('set <id> <json-value>', 'Set object with the given id by providing a new json object', {})
                 .command(
                     'set <id> propertyname=<value or json-value>',
-                    'Update part of the object by providing a new value or partial object',
-                    {}
+                    'Update part of the object by providing a new value or partial object', {}
                 )
                 .command(
                     'extend <id> <json-value>',
-                    'Extend object with the given id by providing a new json object',
-                    {}
+                    'Extend object with the given id by providing a new json object', {}
                 )
                 .command('del <id|pattern>', 'Delete object with given id or all objects matching the pattern', {
                     y: {
@@ -289,13 +283,11 @@ function initYargs() {
             yargs
                 .command(
                     `read <${tools.appName}-path-to-read> [<filesystem-path-to-write>]`,
-                    `Read file from ${tools.appName} path and optionally write to destination`,
-                    {}
+                    `Read file from ${tools.appName} path and optionally write to destination`, {}
                 )
                 .command(
                     `write <filesystem-path-to-read> <${tools.appName}-path-to-write>`,
-                    `Read file from path and write it to ${tools.appName} path`,
-                    {}
+                    `Read file from path and write it to ${tools.appName} path`, {}
                 )
                 .command(`rm <${tools.appName}-path-to-delete>`, 'Remove file', {})
                 .command('sync', 'Sync files', {});
@@ -349,8 +341,7 @@ function initYargs() {
         })
         .command('set <adapter>.<instance>', 'Change settings of adapter config', {
             customOption: {
-                describe:
-                    'Set the name of the parameter you want to change as option followed by its value, e. g. --port 80'
+                describe: 'Set the name of the parameter you want to change as option followed by its value, e. g. --port 80'
             }
         })
         .command('license <license.file or license.text>', 'Update license by given file', {})
@@ -422,8 +413,7 @@ function initYargs() {
             yargs
                 .command(
                     'enable <pluginname>',
-                    'Enables a plugin for the specified host or instance. If no host is specified, the current one is used',
-                    {
+                    'Enables a plugin for the specified host or instance. If no host is specified, the current one is used', {
                         host: {
                             describe: 'Hostname',
                             type: 'string'
@@ -436,8 +426,7 @@ function initYargs() {
                 )
                 .command(
                     'disable <pluginname>',
-                    'Disables a plugin for the specified host or instance. If no host is specified, the current one is used',
-                    {
+                    'Disables a plugin for the specified host or instance. If no host is specified, the current one is used', {
                         host: {
                             describe: 'Hostname',
                             type: 'string'
@@ -450,8 +439,7 @@ function initYargs() {
                 )
                 .command(
                     'status <pluginname>',
-                    'Checks if a plugin is enabled for the specified host or instance. If no host is specified, the current one is used',
-                    {
+                    'Checks if a plugin is enabled for the specified host or instance. If no host is specified, the current one is used', {
                         host: {
                             describe: 'Hostname',
                             type: 'string'
@@ -522,446 +510,462 @@ async function processCommand(command, args, params, callback) {
 
     switch (command) {
         case 'start':
-        case 'stop': {
-            const procCommand = new cli.command.process(commandOptions);
-            procCommand[command](args);
-            break;
-        }
+        case 'stop':
+            {
+                const procCommand = new cli.command.process(commandOptions);
+                procCommand[command](args);
+                break;
+            }
 
-        case 'debug': {
-            const debugCommand = new cli.command.debug(commandOptions);
-            debugCommand.execute(args);
-            break;
-        }
+        case 'debug':
+            {
+                const debugCommand = new cli.command.debug(commandOptions);
+                debugCommand.execute(args);
+                break;
+            }
 
         case 'status':
-        case 'isrun': {
-            const procCommand = new cli.command.process(commandOptions);
-            procCommand.status(args);
-            break;
-        }
+        case 'isrun':
+            {
+                const procCommand = new cli.command.process(commandOptions);
+                procCommand.status(args);
+                break;
+            }
 
         case 'r':
-        case 'restart': {
-            const procCommand = new cli.command.process(commandOptions);
-            procCommand.restart(args);
-            break;
-        }
+        case 'restart':
+            {
+                const procCommand = new cli.command.process(commandOptions);
+                procCommand.restart(args);
+                break;
+            }
 
         case '_restart':
             restartController();
             callback();
             break;
 
-        case 'update': {
-            Objects = getObjectsConstructor();
-            const repoUrl = args[0]; // Repo url or name
-            dbConnect(params, async (_objects, _states) => {
-                const Repo = require('./setup/setupRepo.js');
-                const repo = new Repo({
-                    objects: _objects,
-                    states: _states
+        case 'update':
+            {
+                Objects = getObjectsConstructor();
+                const repoUrl = args[0]; // Repo url or name
+                dbConnect(params, async(_objects, _states) => {
+                    const Repo = require('./setup/setupRepo.js');
+                    const repo = new Repo({
+                        objects: _objects,
+                        states: _states
+                    });
+
+                    await repo.showRepo(repoUrl, params);
+                    setTimeout(callback, 1000);
                 });
-
-                await repo.showRepo(repoUrl, params);
-                setTimeout(callback, 1000);
-            });
-            break;
-        }
-
-        case 'setup': {
-            const Setup = require('./setup/setupSetup.js');
-            const setup = new Setup({
-                dbConnect,
-                processExit: callback,
-                cleanDatabase,
-                restartController,
-                resetDbConnect,
-                params
-            });
-            if (args[0] === 'custom' || params.custom) {
-                setup.setupCustom(callback);
-            } else {
-                let isFirst;
-                let isRedis;
-
-                // we support "first" and "redis" without "--" flag
-                for (const arg of args) {
-                    if (arg === 'first') {
-                        isFirst = true;
-                    } else if (arg === 'redis') {
-                        isRedis = true;
-                    }
-                }
-
-                // and as --flag
-                isRedis = params.redis || isRedis;
-                isFirst = params.first || isFirst;
-
-                setup.setup(
-                    async () => {
-                        if (isFirst) {
-                            // Creates all instances that are needed on a fresh installation
-                            const Install = require('./setup/setupInstall.js');
-                            const install = new Install({
-                                objects,
-                                states,
-                                getRepository,
-                                processExit: callback,
-                                params
-                            });
-                            // Define the necessary instances
-                            const initialInstances = ['admin', 'discovery', 'backitup'];
-                            // And try to install each of them
-                            for (const instance of initialInstances) {
-                                try {
-                                    const adapterInstalled = !!require.resolve(`${tools.appName}.${instance}`);
-
-                                    if (adapterInstalled) {
-                                        let otherInstanceExists = false;
-                                        try {
-                                            // check if another instance exists
-                                            const res = await objects.getObjectViewAsync('system', 'instance', {
-                                                startkey: `system.adapter.${instance}`,
-                                                endkey: `system.adapter.${instance}\u9999`
-                                            });
-
-                                            otherInstanceExists = res && res.rows && res.rows.length;
-                                        } catch {
-                                            // ignore - on install we have no object views
-                                        }
-
-                                        if (!otherInstanceExists) {
-                                            await install.createInstance(instance, {
-                                                enabled: true,
-                                                ignoreIfExists: true
-                                            });
-                                        }
-                                    }
-                                } catch {
-                                    // not found, just continue
-                                }
-                            }
-
-                            await new Promise(resolve => {
-                                // Creates a fresh certificate
-                                const Cert = cli.command.cert;
-                                // Create a new instance of the cert command,
-                                // but use the resolve method as a callback
-                                const cert = new Cert(Object.assign({}, commandOptions, { callback: resolve }));
-                                cert.create();
-                            });
-                        }
-
-                        // we update existing things, in first as well as normnal setup
-                        // Rename repositories
-                        const Repo = require('./setup/setupRepo.js');
-                        const repo = new Repo({ objects, states });
-
-                        try {
-                            await repo.rename('default', 'stable', 'http://download.iobroker.net/sources-dist.json');
-                            await repo.rename(
-                                'latest',
-                                'beta',
-                                'http://download.iobroker.net/sources-dist-latest.json'
-                            );
-                        } catch (err) {
-                            console.warn(`Cannot rename: ${err.message}`);
-                        }
-
-                        // there has been a bug that user can upload js-controller
-                        try {
-                            await objects.delObjectAsync('system.adapter.js-controller');
-                        } catch {
-                            // ignore
-                        }
-
-                        try {
-                            const configFile = tools.getConfigFileName();
-
-                            const configOrig = fs.readJSONSync(configFile);
-                            const config = deepClone(configOrig);
-
-                            config.objects.options = config.objects.options || {
-                                auth_pass: null,
-                                retry_max_delay: 5000
-                            };
-                            if (
-                                config.objects.options.retry_max_delay === 15000 ||
-                                !config.objects.options.retry_max_delay
-                            ) {
-                                config.objects.options.retry_max_delay = 5000;
-                            }
-                            config.states.options = config.states.options || {
-                                auth_pass: null,
-                                retry_max_delay: 5000
-                            };
-                            if (
-                                config.states.options.retry_max_delay === 15000 ||
-                                !config.states.options.retry_max_delay
-                            ) {
-                                config.states.options.retry_max_delay = 5000;
-                            }
-
-                            let migrated = '';
-                            // We migrate file to jsonl
-                            if (config.states.type === 'file') {
-                                config.states.type = 'jsonl';
-
-                                if (dbTools.isLocalStatesDbServer('file', config.states.host)) {
-                                    // silent config change on secondaries
-                                    console.log('States DB type migrated from "file" to "jsonl"');
-                                    migrated += 'States';
-                                }
-                            }
-
-                            if (config.objects.type === 'file') {
-                                config.objects.type = 'jsonl';
-                                if (dbTools.isLocalObjectsDbServer('file', config.objects.host)) {
-                                    // silent config change on secondaries
-                                    console.log('Objects DB type migrated from "file" to "jsonl"');
-                                    migrated += migrated ? ' and Objects' : 'Objects';
-                                }
-                            }
-
-                            if (migrated) {
-                                const NotificationHandler = require('./../lib/notificationHandler');
-
-                                const hostname = tools.getHostName();
-
-                                const notificationSettings = {
-                                    states: states,
-                                    objects: objects,
-                                    log: console,
-                                    logPrefix: '',
-                                    host: hostname
-                                };
-
-                                const notificationHandler = new NotificationHandler(notificationSettings);
-
-                                try {
-                                    const ioPackage = fs.readJsonSync(path.join(__dirname, '..', 'io-package.json'));
-                                    await notificationHandler.addConfig(ioPackage.notifications);
-
-                                    await notificationHandler.addMessage(
-                                        'system',
-                                        'fileToJsonl',
-                                        `Migrated: ${migrated}`,
-                                        `system.host.${hostname}`
-                                    );
-
-                                    notificationHandler.storeNotifications();
-                                } catch (e) {
-                                    console.warn(`Could not add File-to-JSONL notification: ${e.message}`);
-                                }
-                            }
-
-                            if (!isDeepStrictEqual(config, configOrig)) {
-                                fs.writeFileSync(configFile, JSON.stringify(config, null, 2));
-                                console.log('ioBroker configuration updated');
-                            }
-                        } catch (err) {
-                            console.log(`Could not update ioBroker configuration: ${err.message}`);
-                        }
-
-                        return void callback();
-                    },
-                    isFirst,
-                    isRedis
-                );
-            }
-            break;
-        }
-
-        case 'url': {
-            Objects = getObjectsConstructor();
-
-            let url = args[0];
-            const name = args[1];
-
-            if (!url) {
-                console.log('Please provide a URL to install from and optionally a name of the adapter to install');
-                callback(EXIT_CODES.INVALID_ARGUMENTS);
+                break;
             }
 
-            if (url[0] === '"' && url[url.length - 1] === '"') {
-                url = url.substring(1, url.length - 1);
-            }
-            url = url.trim();
-
-            dbConnect(params, async () => {
-                const Install = require('./setup/setupInstall.js');
-                const install = new Install({
-                    objects,
-                    states,
-                    getRepository,
+        case 'setup':
+            {
+                const Setup = require('./setup/setupSetup.js');
+                const setup = new Setup({
+                    dbConnect,
                     processExit: callback,
+                    cleanDatabase,
+                    restartController,
+                    resetDbConnect,
                     params
                 });
+                if (args[0] === 'custom' || params.custom) {
+                    setup.setupCustom(callback);
+                } else {
+                    let isFirst;
+                    let isRedis;
 
-                try {
-                    await install.installAdapterFromUrl(url, name);
-                    return void callback(EXIT_CODES.NO_ERROR);
-                } catch (e) {
-                    console.error(`Could not install adapter from url: ${e.message}`);
-                    return void callback(EXIT_CODES.CANNOT_INSTALL_NPM_PACKET);
+                    // we support "first" and "redis" without "--" flag
+                    for (const arg of args) {
+                        if (arg === 'first') {
+                            isFirst = true;
+                        } else if (arg === 'redis') {
+                            isRedis = true;
+                        }
+                    }
+
+                    // and as --flag
+                    isRedis = params.redis || isRedis;
+                    isFirst = params.first || isFirst;
+
+                    setup.setup(
+                        async() => {
+                            if (isFirst) {
+                                // Creates all instances that are needed on a fresh installation
+                                const Install = require('./setup/setupInstall.js');
+                                const install = new Install({
+                                    objects,
+                                    states,
+                                    getRepository,
+                                    processExit: callback,
+                                    params
+                                });
+                                // Define the necessary instances
+                                const initialInstances = ['admin', 'discovery', 'backitup'];
+                                // And try to install each of them
+                                for (const instance of initialInstances) {
+                                    try {
+                                        const adapterInstalled = !!require.resolve(`${tools.appName}.${instance}`);
+
+                                        if (adapterInstalled) {
+                                            let otherInstanceExists = false;
+                                            try {
+                                                // check if another instance exists
+                                                const res = await objects.getObjectViewAsync('system', 'instance', {
+                                                    startkey: `system.adapter.${instance}`,
+                                                    endkey: `system.adapter.${instance}\u9999`
+                                                });
+
+                                                otherInstanceExists = res && res.rows && res.rows.length;
+                                            } catch {
+                                                // ignore - on install we have no object views
+                                            }
+
+                                            if (!otherInstanceExists) {
+                                                await install.createInstance(instance, {
+                                                    enabled: true,
+                                                    ignoreIfExists: true
+                                                });
+                                            }
+                                        }
+                                    } catch {
+                                        // not found, just continue
+                                    }
+                                }
+
+                                await new Promise(resolve => {
+                                    // Creates a fresh certificate
+                                    const Cert = cli.command.cert;
+                                    // Create a new instance of the cert command,
+                                    // but use the resolve method as a callback
+                                    const cert = new Cert(Object.assign({}, commandOptions, { callback: resolve }));
+                                    cert.create();
+                                });
+                            }
+
+                            // we update existing things, in first as well as normnal setup
+                            // Rename repositories
+                            const Repo = require('./setup/setupRepo.js');
+                            const repo = new Repo({ objects, states });
+
+                            try {
+                                await repo.rename(
+                                    'default',
+                                    'stable',
+                                    'http://download.iobroker.net/sources-dist.json',
+                                    'https://repo.iobroker.live/sources-dist.json'
+                                );
+                                await repo.rename(
+                                    'latest',
+                                    'beta',
+                                    'http://download.iobroker.net/sources-dist-latest.json',
+                                    'https://repo.iobroker.live/sources-dist-latest.json'
+                                );
+                            } catch (err) {
+                                console.warn(`Cannot rename: ${err.message}`);
+                            }
+
+                            // there has been a bug that user can upload js-controller
+                            try {
+                                await objects.delObjectAsync('system.adapter.js-controller');
+                            } catch {
+                                // ignore
+                            }
+
+                            try {
+                                const configFile = tools.getConfigFileName();
+
+                                const configOrig = fs.readJSONSync(configFile);
+                                const config = deepClone(configOrig);
+
+                                config.objects.options = config.objects.options || {
+                                    auth_pass: null,
+                                    retry_max_delay: 5000
+                                };
+                                if (
+                                    config.objects.options.retry_max_delay === 15000 ||
+                                    !config.objects.options.retry_max_delay
+                                ) {
+                                    config.objects.options.retry_max_delay = 5000;
+                                }
+                                config.states.options = config.states.options || {
+                                    auth_pass: null,
+                                    retry_max_delay: 5000
+                                };
+                                if (
+                                    config.states.options.retry_max_delay === 15000 ||
+                                    !config.states.options.retry_max_delay
+                                ) {
+                                    config.states.options.retry_max_delay = 5000;
+                                }
+
+                                let migrated = '';
+                                // We migrate file to jsonl
+                                if (config.states.type === 'file') {
+                                    config.states.type = 'jsonl';
+
+                                    if (dbTools.isLocalStatesDbServer('file', config.states.host)) {
+                                        // silent config change on secondaries
+                                        console.log('States DB type migrated from "file" to "jsonl"');
+                                        migrated += 'States';
+                                    }
+                                }
+
+                                if (config.objects.type === 'file') {
+                                    config.objects.type = 'jsonl';
+                                    if (dbTools.isLocalObjectsDbServer('file', config.objects.host)) {
+                                        // silent config change on secondaries
+                                        console.log('Objects DB type migrated from "file" to "jsonl"');
+                                        migrated += migrated ? ' and Objects' : 'Objects';
+                                    }
+                                }
+
+                                if (migrated) {
+                                    const NotificationHandler = require('./../lib/notificationHandler');
+
+                                    const hostname = tools.getHostName();
+
+                                    const notificationSettings = {
+                                        states: states,
+                                        objects: objects,
+                                        log: console,
+                                        logPrefix: '',
+                                        host: hostname
+                                    };
+
+                                    const notificationHandler = new NotificationHandler(notificationSettings);
+
+                                    try {
+                                        const ioPackage = fs.readJsonSync(path.join(__dirname, '..', 'io-package.json'));
+                                        await notificationHandler.addConfig(ioPackage.notifications);
+
+                                        await notificationHandler.addMessage(
+                                            'system',
+                                            'fileToJsonl',
+                                            `Migrated: ${migrated}`,
+                                            `system.host.${hostname}`
+                                        );
+
+                                        notificationHandler.storeNotifications();
+                                    } catch (e) {
+                                        console.warn(`Could not add File-to-JSONL notification: ${e.message}`);
+                                    }
+                                }
+
+                                if (!isDeepStrictEqual(config, configOrig)) {
+                                    fs.writeFileSync(configFile, JSON.stringify(config, null, 2));
+                                    console.log('ioBroker configuration updated');
+                                }
+                            } catch (err) {
+                                console.log(`Could not update ioBroker configuration: ${err.message}`);
+                            }
+
+                            return void callback();
+                        },
+                        isFirst,
+                        isRedis
+                    );
                 }
-            });
-            break;
-        }
+                break;
+            }
 
-        case 'info': {
-            Objects = getObjectsConstructor();
-            dbConnect(params, async objects => {
-                try {
-                    const data = await tools.getHostInfo(objects);
-                    const formatters = require('./formatters');
-                    const formatInfo = {
-                        Uptime: formatters.formatSeconds,
-                        'System uptime': formatters.formatSeconds,
-                        RAM: formatters.formatRam,
-                        Speed: formatters.formatSpeed,
-                        'Disk size': formatters.formatBytes,
-                        'Disk free': formatters.formatBytes
-                    };
+        case 'url':
+            {
+                Objects = getObjectsConstructor();
 
-                    for (const attr of Object.keys(data)) {
-                        console.log(
-                            `${attr}${attr.length < 16 ? new Array(16 - attr.length).join(' ') : ''}: ${
+                let url = args[0];
+                const name = args[1];
+
+                if (!url) {
+                    console.log('Please provide a URL to install from and optionally a name of the adapter to install');
+                    callback(EXIT_CODES.INVALID_ARGUMENTS);
+                }
+
+                if (url[0] === '"' && url[url.length - 1] === '"') {
+                    url = url.substring(1, url.length - 1);
+                }
+                url = url.trim();
+
+                dbConnect(params, async() => {
+                    const Install = require('./setup/setupInstall.js');
+                    const install = new Install({
+                        objects,
+                        states,
+                        getRepository,
+                        processExit: callback,
+                        params
+                    });
+
+                    try {
+                        await install.installAdapterFromUrl(url, name);
+                        return void callback(EXIT_CODES.NO_ERROR);
+                    } catch (e) {
+                        console.error(`Could not install adapter from url: ${e.message}`);
+                        return void callback(EXIT_CODES.CANNOT_INSTALL_NPM_PACKET);
+                    }
+                });
+                break;
+            }
+
+        case 'info':
+            {
+                Objects = getObjectsConstructor();
+                dbConnect(params, async objects => {
+                    try {
+                        const data = await tools.getHostInfo(objects);
+                        const formatters = require('./formatters');
+                        const formatInfo = {
+                            Uptime: formatters.formatSeconds,
+                            'System uptime': formatters.formatSeconds,
+                            RAM: formatters.formatRam,
+                            Speed: formatters.formatSpeed,
+                            'Disk size': formatters.formatBytes,
+                            'Disk free': formatters.formatBytes
+                        };
+
+                        for (const attr of Object.keys(data)) {
+                            console.log(
+                                `${attr}${attr.length < 16 ? new Array(16 - attr.length).join(' ') : ''}: ${
                                 formatInfo[attr] ? formatInfo[attr](data[attr]) : data[attr] || ''
                             }`
-                        );
+                            );
+                        }
+                    } catch (err) {
+                        console.error('Cannot read host info: ' + (typeof err === 'object' ? JSON.stringify(err) : err));
+                        return callback(EXIT_CODES.CANNOT_GET_HOST_INFO);
                     }
-                } catch (err) {
-                    console.error('Cannot read host info: ' + (typeof err === 'object' ? JSON.stringify(err) : err));
-                    return callback(EXIT_CODES.CANNOT_GET_HOST_INFO);
-                }
 
-                return void callback();
-            });
-            break;
-        }
+                    return void callback();
+                });
+                break;
+            }
 
         case 'a':
         case 'add':
         case 'install':
-        case 'i': {
-            Objects = getObjectsConstructor();
+        case 'i':
+            {
+                Objects = getObjectsConstructor();
 
-            let name = args[0];
-            let instance = args[1];
-            let repoUrl = args[2];
+                let name = args[0];
+                let instance = args[1];
+                let repoUrl = args[2];
 
-            if (instance === 0) {
-                instance = '0';
-            }
-            if (repoUrl === 0) {
-                repoUrl = '0';
-            }
-
-            if (parseInt(instance, 10).toString() !== (instance || '').toString()) {
-                repoUrl = instance;
-                instance = null;
-            }
-            if (parseInt(repoUrl, 10).toString() === (repoUrl || '').toString()) {
-                const temp = instance;
-                instance = repoUrl;
-                repoUrl = temp;
-            }
-            if (parseInt(instance, 10).toString() === (instance || '').toString()) {
-                instance = parseInt(instance, 10);
-                params.instance = instance;
-            }
-
-            // If user accidentally wrote tools.appName.adapter => remove adapter
-            name = cli.tools.normalizeAdapterName(name);
-
-            const parsedName = cli.tools.splitAdapterOrInstanceIdentifierWithVersion(name);
-            if (!parsedName) {
-                console.log('Invalid adapter name for install');
-                showHelp();
-                return void callback(EXIT_CODES.INVALID_ADAPTER_ID);
-            }
-
-            // split the adapter into its parts if necessary
-            if (parsedName.instance !== null) {
-                params.instance = parsedName.instance;
-            }
-            name = parsedName.name;
-            const installName = parsedName.nameWithVersion;
-
-            const adapterDir = tools.getAdapterDir(name);
-
-            dbConnect(params, async () => {
-                const Install = require('./setup/setupInstall.js');
-                const install = new Install({
-                    objects,
-                    states,
-                    getRepository,
-                    processExit: callback,
-                    params
-                });
-
-                if (params.host && params.host !== tools.getHostName()) {
-                    // if host argument provided we should check, that host actually exists in mh environment
-                    let obj;
-                    try {
-                        obj = await objects.getObjectAsync(`system.host.${params.host}`);
-                    } catch (err) {
-                        console.warn(`Could not check existence of host "${params.host}": ${err.message}`);
-                    }
-
-                    if (!obj) {
-                        console.error(`Cannot add instance to non-existing host "${params.host}"`);
-                        return void callback(EXIT_CODES.NON_EXISTING_HOST);
-                    }
+                if (instance === 0) {
+                    instance = '0';
+                }
+                if (repoUrl === 0) {
+                    repoUrl = '0';
                 }
 
-                if (!fs.existsSync(adapterDir)) {
-                    try {
-                        const { stoppedList } = await install.downloadPacket(repoUrl, installName);
-                        await install.installAdapter(installName, repoUrl);
-                        await install.enableInstances(stoppedList, true); // even if unlikely make sure to reenable disabled instances
-                        if (command !== 'install' && command !== 'i') {
-                            await install.createInstance(name, params);
+                if (parseInt(instance, 10).toString() !== (instance || '').toString()) {
+                    repoUrl = instance;
+                    instance = null;
+                }
+                if (parseInt(repoUrl, 10).toString() === (repoUrl || '').toString()) {
+                    const temp = instance;
+                    instance = repoUrl;
+                    repoUrl = temp;
+                }
+                if (parseInt(instance, 10).toString() === (instance || '').toString()) {
+                    instance = parseInt(instance, 10);
+                    params.instance = instance;
+                }
+
+                // If user accidentally wrote tools.appName.adapter => remove adapter
+                name = cli.tools.normalizeAdapterName(name);
+
+                const parsedName = cli.tools.splitAdapterOrInstanceIdentifierWithVersion(name);
+                if (!parsedName) {
+                    console.log('Invalid adapter name for install');
+                    showHelp();
+                    return void callback(EXIT_CODES.INVALID_ADAPTER_ID);
+                }
+
+                // split the adapter into its parts if necessary
+                if (parsedName.instance !== null) {
+                    params.instance = parsedName.instance;
+                }
+                name = parsedName.name;
+                const installName = parsedName.nameWithVersion;
+
+                const adapterDir = tools.getAdapterDir(name);
+
+                dbConnect(params, async() => {
+                    const Install = require('./setup/setupInstall.js');
+                    const install = new Install({
+                        objects,
+                        states,
+                        getRepository,
+                        processExit: callback,
+                        params
+                    });
+
+                    if (params.host && params.host !== tools.getHostName()) {
+                        // if host argument provided we should check, that host actually exists in mh environment
+                        let obj;
+                        try {
+                            obj = await objects.getObjectAsync(`system.host.${params.host}`);
+                        } catch (err) {
+                            console.warn(`Could not check existence of host "${params.host}": ${err.message}`);
                         }
-                        return void callback();
-                    } catch (err) {
-                        console.error(`adapter "${name}" cannot be installed: ${err.message}`);
-                        return void callback(EXIT_CODES.UNKNOWN_ERROR);
-                    }
-                } else if (command !== 'install' && command !== 'i') {
-                    try {
-                        await install.createInstance(name, params);
-                        return void callback();
-                    } catch (err) {
-                        console.error(`adapter "${name}" cannot be installed: ${err.message}`);
-                        return void callback(EXIT_CODES.UNKNOWN_ERROR);
-                    }
-                } else {
-                    console.log(`adapter "${name}" already installed. Use "upgrade" to upgrade to a newer version.`);
-                    return void callback(EXIT_CODES.ADAPTER_ALREADY_INSTALLED);
-                }
-            });
-            break;
-        }
 
-        case 'rebuild': {
-            const options = { debug: process.argv.includes('--debug') };
+                        if (!obj) {
+                            console.error(`Cannot add instance to non-existing host "${params.host}"`);
+                            return void callback(EXIT_CODES.NON_EXISTING_HOST);
+                        }
+                    }
 
-            if (commandOptions.path) {
-                if (path.isAbsolute(commandOptions.path)) {
-                    options.cwd = commandOptions.path;
-                } else {
-                    console.log('Path argument needs to be an absolute path!');
-                    return void processExit(EXIT_CODES.INVALID_ARGUMENTS);
-                }
+                    if (!fs.existsSync(adapterDir)) {
+                        try {
+                            const { stoppedList } = await install.downloadPacket(repoUrl, installName);
+                            await install.installAdapter(installName, repoUrl);
+                            await install.enableInstances(stoppedList, true); // even if unlikely make sure to reenable disabled instances
+                            if (command !== 'install' && command !== 'i') {
+                                await install.createInstance(name, params);
+                            }
+                            return void callback();
+                        } catch (err) {
+                            console.error(`adapter "${name}" cannot be installed: ${err.message}`);
+                            return void callback(EXIT_CODES.UNKNOWN_ERROR);
+                        }
+                    } else if (command !== 'install' && command !== 'i') {
+                        try {
+                            await install.createInstance(name, params);
+                            return void callback();
+                        } catch (err) {
+                            console.error(`adapter "${name}" cannot be installed: ${err.message}`);
+                            return void callback(EXIT_CODES.UNKNOWN_ERROR);
+                        }
+                    } else {
+                        console.log(`adapter "${name}" already installed. Use "upgrade" to upgrade to a newer version.`);
+                        return void callback(EXIT_CODES.ADAPTER_ALREADY_INSTALLED);
+                    }
+                });
+                break;
             }
 
-            if (commandOptions.module) {
-                options.module = commandOptions.module;
-                console.log(
-                    `Rebuilding native module "${commandOptions.module}"${options.cwd ? ` in ${options.cwd}` : ''} ...`
+        case 'rebuild':
+            {
+                const options = { debug: process.argv.includes('--debug') };
+
+                if (commandOptions.path) {
+                    if (path.isAbsolute(commandOptions.path)) {
+                        options.cwd = commandOptions.path;
+                    } else {
+                        console.log('Path argument needs to be an absolute path!');
+                        return void processExit(EXIT_CODES.INVALID_ARGUMENTS);
+                    }
+                }
+
+                if (commandOptions.module) {
+                    options.module = commandOptions.module;
+                    console.log(
+                            `Rebuilding native module "${commandOptions.module}"${options.cwd ? ` in ${options.cwd}` : ''} ...`
                 );
             } else {
                 console.log(`Rebuilding native modules${options.cwd ? ` in ${options.cwd}` : ''} ...`);

--- a/packages/controller/lib/setup/setupRepo.js
+++ b/packages/controller/lib/setup/setupRepo.js
@@ -17,11 +17,11 @@ function Repo(options) {
         native: {
             repositories: {
                 stable: {
-                    link: 'http://download.iobroker.net/sources-dist.json',
+                    link: 'https://repo.iobroker.live/sources-dist.json',
                     json: null
                 },
                 beta: {
-                    link: 'http://download.iobroker.net/sources-dist-latest.json',
+                    link: 'https://repo.iobroker.live/sources-dist-latest.json',
                     json: null
                 }
             }
@@ -58,8 +58,7 @@ function Repo(options) {
         const hashUrl = urlOrPath.replace(/\.json$/, '-hash.json');
         let hash;
 
-        if (
-            !force &&
+        if (!force &&
             oldRepos.native.repositories[repoName].hash &&
             oldRepos.native.repositories[repoName].json &&
             (urlOrPath.startsWith('http://') || urlOrPath.startsWith('https://'))
@@ -131,7 +130,7 @@ function Repo(options) {
         return oldRepos.native.repositories[repoName].json;
     }
 
-    this.showRepo = async function (repoUrl, flags) {
+    this.showRepo = async function(repoUrl, flags) {
         function showRepoResult(_name, sources) {
             const installed = tools.getInstalledInfo();
             const adapters = Object.keys(sources).sort();
@@ -272,7 +271,7 @@ function Repo(options) {
         }
     }
 
-    this.showRepoStatus = async function () {
+    this.showRepoStatus = async function() {
         try {
             const obj = await objects.getObjectAsync('system.repositories');
             if (!obj) {
@@ -301,7 +300,7 @@ function Repo(options) {
         }
     };
 
-    this.add = async function (repoName, repoUrl) {
+    this.add = async function(repoName, repoUrl) {
         let obj = await objects.getObjectAsync('system.repositories');
         obj = obj || defaultSystemRepo;
 
@@ -318,7 +317,7 @@ function Repo(options) {
         }
     };
 
-    this.del = async function (repoName) {
+    this.del = async function(repoName) {
         const obj = await objects.getObjectAsync('system.config');
         if (
             (obj.common.activeRepo &&
@@ -342,7 +341,7 @@ function Repo(options) {
         }
     };
 
-    this.setActive = async function (repoName) {
+    this.setActive = async function(repoName) {
         let obj = await objects.getObjectAsync('system.repositories');
         obj = obj || defaultSystemRepo;
 
@@ -362,7 +361,7 @@ function Repo(options) {
         }
     };
 
-    this.setInactive = async function (repoName) {
+    this.setInactive = async function(repoName) {
         const confObj = await objects.getObjectAsync('system.config');
         if (typeof confObj.common.activeRepo === 'string') {
             confObj.common.activeRepo = [confObj.common.activeRepo];
@@ -384,7 +383,7 @@ function Repo(options) {
      * @param {string} matchingLink - hyperlink of the repository
      * @returns {Promise<void>}
      */
-    this.rename = async function (oldName, newName, matchingLink) {
+    this.rename = async function(oldName, newName, matchingLink) {
         let repoObj;
         let sysConfigObj;
         try {
@@ -415,7 +414,7 @@ function Repo(options) {
                     sysConfigObj &&
                     sysConfigObj.common &&
                     ((typeof sysConfigObj.common.activeRepo === 'string' &&
-                        sysConfigObj.common.activeRepo === oldName) ||
+                            sysConfigObj.common.activeRepo === oldName) ||
                         (Array.isArray(sysConfigObj.common.activeRepo) &&
                             sysConfigObj.common.activeRepo.includes(oldName)))
                 ) {

--- a/packages/controller/test/lib/objects.json
+++ b/packages/controller/test/lib/objects.json
@@ -26,11 +26,11 @@
         "native": {
             "repositories": {
                 "stable": {
-                    "link": "http://download.iobroker.net/sources-dist.json",
+                    "link": "https://repo.iobroker.live/sources-dist.json",
                     "json": null
                 },
                 "beta": {
-                    "link": "http://download.iobroker.net/sources-dist-latest.json",
+                    "link": "https://repo.iobroker.live/sources-dist-latest.json",
                     "json": null
                 },
                 "sources": {
@@ -384,8 +384,7 @@
             "dontDelete": true,
             "enabled": true
         },
-        "native": {
-        },
+        "native": {},
         "_id": "system.user.admin"
     },
     "system.meta.uuid": {
@@ -443,11 +442,9 @@
                 "hobbyquaker <hq@ccu.io>",
                 "bluefox <bluefox@ccu.io>"
             ],
-            "dependencies": [
-                {
-                    "js-controller": ">=0.8.0"
-                }
-            ],
+            "dependencies": [{
+                "js-controller": ">=0.8.0"
+            }],
             "type": "common adapters",
             "license": "MIT",
             "logTransporter": true,
@@ -581,11 +578,9 @@
                 "hobbyquaker <hq@ccu.io>",
                 "bluefox <bluefox@ccu.io>"
             ],
-            "dependencies": [
-                {
-                    "js-controller": ">=0.8.0"
-                }
-            ],
+            "dependencies": [{
+                "js-controller": ">=0.8.0"
+            }],
             "type": "common adapters",
             "license": "MIT",
             "logTransporter": true,
@@ -613,8 +608,7 @@
             "name": "admin",
             "type": "admin"
         },
-        "native": {
-        },
+        "native": {},
         "_id": "test.admin"
     },
     "system.adapter.test.upload": {
@@ -672,11 +666,9 @@
                 "test",
                 "communication"
             ],
-            "dependencies": [
-                {
-                    "js-controller": ">=0.9.0"
-                }
-            ],
+            "dependencies": [{
+                "js-controller": ">=0.9.0"
+            }],
             "config": {
                 "width ": 1224,
                 "height": 520
@@ -698,8 +690,7 @@
             "role": "indicator.state",
             "unit": "seconds"
         },
-        "native": {
-        }
+        "native": {}
     },
     "system.adapter.test.0.memRss": {
         "_id": "system.adapter.test.0.memRss",
@@ -722,8 +713,7 @@
             "role": "indicator.state",
             "unit": "MB"
         },
-        "native": {
-        }
+        "native": {}
     },
     "system.adapter.test.0.memHeapUsed": {
         "_id": "system.adapter.test.0.memHeapUsed",
@@ -734,8 +724,7 @@
             "role": "indicator.state",
             "unit": "MB"
         },
-        "native": {
-        }
+        "native": {}
     },
     "system.adapter.test.0.connected": {
         "_id": "system.adapter.test.0.connected",
@@ -745,8 +734,7 @@
             "type": "boolean",
             "role": "indicator.state"
         },
-        "native": {
-        }
+        "native": {}
     },
     "system.adapter.test.0.alive": {
         "_id": "system.adapter.test.0.alive",
@@ -800,11 +788,9 @@
                 "test",
                 "communication"
             ],
-            "dependencies": [
-                {
-                    "js-controller": ">=0.9.0"
-                }
-            ],
+            "dependencies": [{
+                "js-controller": ">=0.9.0"
+            }],
             "config": {
                 "width ": 1224,
                 "height": 520


### PR DESCRIPTION
Not sure this is still intentional, but it seems obvious to me that the dedicated subdomain and TLS-secured repo URL (which is also CDN powered) makes more sense to use.

This also improves security as also the redirect from http://download.iobroker.net to https://repo.iobroker.live still leaves room for MITM attacks to sneak in other adapters or potentially redirect to a different source.

This PR will upgrade to the new URL, seems like a pretty minor patch to me that might have simply been forgotten somewhere in the past when repo.iobroker.live was set up.