### PR TITLE
fix: avoid huge DB files by compressing daily

### DIFF
--- a/packages/db-objects-jsonl/src/lib/objects/objectsInMemJsonlDB.js
+++ b/packages/db-objects-jsonl/src/lib/objects/objectsInMemJsonlDB.js
@@ -29,8 +29,12 @@ function normalizeJsonlOptions(conf = {}) {
     /** @type {import("@alcalzone/jsonl-db").JsonlDBOptions<any>} */
     const ret = {
         autoCompress: {
+            // Compress when the number of uncompressed entries has grown a lot
             sizeFactor: 2,
-            sizeFactorMinimumSize: 25000
+            sizeFactorMinimumSize: 25000,
+            // Compress at least daily to avoid a huge file when DBs have few objects
+            // but big objects are updated regularly (e.g. the repositories)
+            intervalMs: 1000 * 60 * 60 * 24
         },
         ignoreReadErrors: true,
         throttleFS: {

--- a/packages/db-states-jsonl/src/lib/states/statesInMemJsonlDB.js
+++ b/packages/db-states-jsonl/src/lib/states/statesInMemJsonlDB.js
@@ -51,8 +51,12 @@ function normalizeJsonlOptions(conf = {}) {
     /** @type {import("@alcalzone/jsonl-db").JsonlDBOptions<any>} */
     const ret = {
         autoCompress: {
+            // Compress when the number of uncompressed entries has grown a lot
             sizeFactor: 10,
-            sizeFactorMinimumSize: 50000
+            sizeFactorMinimumSize: 50000,
+            // Compress at least daily to avoid a huge file when DBs have few objects
+            // but big binary states are updated regularly
+            intervalMs: 1000 * 60 * 60 * 24
         },
         ignoreReadErrors: true,
         throttleFS: {


### PR DESCRIPTION
This should avoid runaway huge DB files with few actual entries that never get compressed because they are below the limit.