### PR TITLE
update apt sources before installing os dependencies

### DIFF
--- a/packages/cli/src/lib/setup/setupInstall.ts
+++ b/packages/cli/src/lib/setup/setupInstall.ts
@@ -672,6 +672,7 @@ export class Install {
         if (osPlatform in osDependencies) {
             try {
                 this.packetManager = this.packetManager || new PacketManager();
+                await this.packetManager.update();
                 // @ts-expect-error we have checked that platform is a valid key
                 await this.packetManager.install(osDependencies[osPlatform]);
             } catch (err) {


### PR DESCRIPTION
- closes #1976
- we only do this for apt, as `yum` seems to actually performs upgrades when calling `update`