### PR TITLE
Extend isDocker check/ detection

### DIFF
--- a/packages/common/src/lib/common/tools.ts
+++ b/packages/common/src/lib/common/tools.ts
@@ -375,6 +375,7 @@ function getMac(callback: (e?: Error | null, mac?: string) => void) {
  */
 export function isDocker(): boolean {
     try {
+        // deprecated, works only with docker daemon
         fs.statSync('/.dockerenv');
         return true;
     } catch {
@@ -382,7 +383,15 @@ export function isDocker(): boolean {
     }
 
     try {
-        // check docker group
+        // ioBroker docker image specific, will be created during build process
+        fs.statSync('/opt/scripts/.docker_config/.thisisdocker');
+        return true;
+    } catch {
+        // ignore error
+    }
+
+    try {
+        // check docker group, works in most cases, but not on arm
         return fs.readFileSync('/proc/self/cgroup', 'utf8').includes('docker');
     } catch {
         return false;


### PR DESCRIPTION
Hi,
as discussed [here](https://github.com/ioBroker/ioBroker/issues/380#issuecomment-1082736036) there seems to be no reliable way to check if a process is runing in a docker environment or not. 
So the only way might be to combine [different checks](https://www.baeldung.com/linux/is-process-running-inside-container). To get the best results I tried to combine the "/.dockerenv", the "cgroups" and my [".thisisdocker-file"-check](https://docs.buanet.de/iobroker-docker-image/docs/#detecting-docker-environment).
Hopefully this will cover up all cases.

Regards,
André