### PR TITLE
fix: make VSCode use the workspace TypeScript version, not the bundled

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+	"typescript.tsdk": "node_modules/typescript/lib"
+}


### PR DESCRIPTION
Found in discussion on Telegram. Without this configuration, VSCode defaults to TS 4.9.4 which is currently complaining about some of our types (fix pending).
In general we should have the TS compiler on the CLI and the language service match, or we'll have to investigate "ghost" issues in the future again.