### PR TITLE
fix: add missing dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17674,7 +17674,8 @@
         },
         "node_modules/winston-transport": {
             "version": "4.5.0",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.5.0.tgz",
+            "integrity": "sha512-YpZzcUzBedhlTAfJg6vJDlyEai/IFMIVcaEZZyl3UXIl4gmqRpU7AE89AHLkbzLUsv0NVmw7ts+iztqKxxPW1Q==",
             "dependencies": {
                 "logform": "^2.3.2",
                 "readable-stream": "^3.6.0",
@@ -18230,7 +18231,8 @@
                 "readline": "^1.3.0",
                 "semver": "^7.3.7",
                 "winston": "^3.7.2",
-                "winston-daily-rotate-file": "^4.7.1"
+                "winston-daily-rotate-file": "^4.7.1",
+                "winston-transport": "^4.5.0"
             },
             "engines": {
                 "node": ">=12.0.0"
@@ -18914,7 +18916,8 @@
                 "semver": "^7.3.7",
                 "winston": "^3.7.2",
                 "winston-daily-rotate-file": "^4.7.1",
-                "winston-syslog": "^2.6.0"
+                "winston-syslog": "^2.6.0",
+                "winston-transport": "*"
             },
             "dependencies": {
                 "ci-info": {
@@ -31327,6 +31330,8 @@
         },
         "winston-transport": {
             "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.5.0.tgz",
+            "integrity": "sha512-YpZzcUzBedhlTAfJg6vJDlyEai/IFMIVcaEZZyl3UXIl4gmqRpU7AE89AHLkbzLUsv0NVmw7ts+iztqKxxPW1Q==",
             "requires": {
                 "logform": "^2.3.2",
                 "readable-stream": "^3.6.0",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -23,7 +23,8 @@
         "readline": "^1.3.0",
         "semver": "^7.3.7",
         "winston": "^3.7.2",
-        "winston-daily-rotate-file": "^4.7.1"
+        "winston-daily-rotate-file": "^4.7.1",
+        "winston-transport": "^4.5.0"
     },
     "keywords": [
         "ioBroker"


### PR DESCRIPTION
I was playing around with different `npm install` strategies and got an error in one of the new ones, because https://github.com/ioBroker/ioBroker.js-controller/blob/2bfe0a8fedd208fa8076e6cefa9d1fe87c765acc/packages/common/src/lib/common/logger.ts#L7-L8 was using `winston-transport` without having it as a dependency (it is implictly included in `winston`, but these kinds of things cause headaches).
