### PR TITLE
If controller is started with `--preserve-symlinks`, pass flags to adapters

### DIFF
--- a/packages/common/src/lib/common/tools.ts
+++ b/packages/common/src/lib/common/tools.ts
@@ -3198,10 +3198,16 @@ export async function resolveAdapterMainFile(adapter: string): Promise<string> {
  * @returns default node args for cli
  */
 export function getDefaultNodeArgs(mainFile: string): string[] {
+    const ret: string[] = [];
+    // Support executing TypeScript files directly
     if (mainFile.endsWith('.ts')) {
-        return ['-r', '@alcalzone/esbuild-register'];
+        ret.push('-r', '@alcalzone/esbuild-register');
     }
-    return [];
+    // If JS-controller was started with --preserve-symlinks, do the same for adapters
+    if (process.execArgv.includes('--preserve-symlinks')) {
+        ret.push('--preserve-symlinks-main', '--preserve-symlinks');
+    }
+    return ret;
 }
 
 /** This is used for the short github URL format that NPM accepts (<githubname>/<githubrepo>[#<commit-ish>]) */


### PR DESCRIPTION
I'm trying to get `dev-server` to work with symlinks, instead of having to `npm pack` the current adapter on every change. In order for the adapter and adapter-core to find js-controller, we need to pass the adapter process these flags.

My plan is to do it only when js-controller is explicitly started with the `--preserve-symlinks` flag, so we can control this from the outside.