### PR TITLE
fix: do not override monorepo package.json in dev-server

### DIFF
--- a/packages/controller/src/main.ts
+++ b/packages/controller/src/main.ts
@@ -5564,12 +5564,11 @@ function init(compactGroupId?: number): void {
         logger.info(`${hostLogPrefix} ip addresses: ${tools.findIPs().join(' ')}`);
 
         // create package.json for npm >= 3.x if not exists
-        if (
-            controllerDir
-                .replace(/\\/g, '/')
-                .toLowerCase()
-                .includes('/node_modules/' + title.toLowerCase())
-        ) {
+        const isInNodeModules = controllerDir
+            .toLowerCase()
+            .includes(`${path.sep}node_modules${path.sep}${title.toLowerCase()}`);
+        const isDevServer = require.main?.path.includes(`${path.sep}.dev-server${path.sep}`);
+        if (isInNodeModules && !isDevServer) {
             try {
                 if (!fs.existsSync(`${controllerDir}/../../package.json`)) {
                     fs.writeFileSync(


### PR DESCRIPTION
Without checking for this, the `package.json` in the monorepo root will get overwritten with
```json
{
    name: 'iobroker.core',
    version: '1.0.0',
    private: true
}
```