### PR TITLE
Fix backup file system edge case issues

### DIFF
--- a/packages/cli/src/lib/setup/setupBackup.ts
+++ b/packages/cli/src/lib/setup/setupBackup.ts
@@ -195,7 +195,11 @@ export class BackupRestore {
         // 2021_10_25 BF (TODO): store letsencrypt files too
         const letsEncrypt = `${this.configDir}/letsencrypt`;
         if (fs.existsSync(letsEncrypt)) {
-            this.copyFolderRecursiveSync(letsEncrypt, `${tmpDir}/backup`);
+            try {
+                this.copyFolderRecursiveSync(letsEncrypt, `${tmpDir}/backup`);
+            } catch (e) {
+                console.error(`host.${hostname} Could not backup "${letsEncrypt}" directory: ${e.message}`);
+            }
         }
 
         return new Promise(resolve => {
@@ -392,7 +396,13 @@ export class BackupRestore {
                     }
 
                     if (fs.existsSync(dataFolderPath)) {
-                        this.copyFolderRecursiveSync(dataFolderPath, `${tmpDir}/backup`);
+                        try {
+                            this.copyFolderRecursiveSync(dataFolderPath, `${tmpDir}/backup`);
+                        } catch (e) {
+                            console.error(
+                                `host.${hostname} Could not backup "${dataFolderPath}" directory: ${e.message}`
+                            );
+                        }
                     }
                 }
             }

--- a/packages/common/src/lib/common/tools.ts
+++ b/packages/common/src/lib/common/tools.ts
@@ -280,39 +280,6 @@ function getAppName(): string {
 
 export const appName = getAppName();
 
-export function rmdirRecursiveSync(path: string): void {
-    if (fs.existsSync(path)) {
-        fs.readdirSync(path).forEach(file => {
-            const curPath = `${path}/${file}`;
-            try {
-                if (fs.statSync(curPath).isDirectory()) {
-                    // recurse
-                    rmdirRecursiveSync(curPath);
-                } else {
-                    // delete file
-                    fs.unlinkSync(curPath);
-                }
-            } catch (e) {
-                if (e.code !== 'ENOENT') {
-                    console.log(`Cannot delete file ${path}: ${e.message}`);
-                } else {
-                    throw e;
-                }
-            }
-        });
-        // delete (hopefully) empty folder
-        try {
-            fs.rmdirSync(path);
-        } catch (e) {
-            if (e.code !== 'ENOENT') {
-                console.log(`Cannot delete directory ${path}: ${e.message}`);
-            } else {
-                throw e;
-            }
-        }
-    }
-}
-
 export function findIPs(): string[] {
     if (!lastCalculationOfIps || Date.now() - lastCalculationOfIps > 10000) {
         lastCalculationOfIps = Date.now();


### PR DESCRIPTION
- using ensureDir instead of !exists/mkdir
- use fs-extra method to rm dirs recursively ignoring non existence errors (goal reached)
- closes #2130
- catch errors on lstat and file moving