### PR TITLE
set `require` paths, data dir and npm install `cwd` correctly for dev-server

### DIFF
--- a/packages/cli/src/lib/setup.ts
+++ b/packages/cli/src/lib/setup.ts
@@ -627,7 +627,9 @@ async function processCommand(
                             // And try to install each of them
                             for (const instance of initialInstances) {
                                 try {
-                                    const adapterInstalled = !!require.resolve(`${tools.appName}.${instance}`);
+                                    const adapterInstalled = !!require.resolve(`${tools.appName}.${instance}`, {
+                                        paths: tools.getDefaultRequireResolvePaths(module)
+                                    });
 
                                     if (adapterInstalled) {
                                         let otherInstanceExists = false;

--- a/packages/common/src/lib/common/tools.ts
+++ b/packages/common/src/lib/common/tools.ts
@@ -1450,7 +1450,9 @@ export function getAdapterDir(adapter: string): string | null {
             adapterPath = `${__dirname}/../../${possibility}`;
         } else {
             try {
-                adapterPath = require.resolve(possibility);
+                adapterPath = require.resolve(possibility, {
+                    paths: getDefaultRequireResolvePaths(module)
+                });
             } catch {
                 // not found
             }
@@ -1571,7 +1573,7 @@ async function detectPackageManagerWithFallback(cwd?: string): Promise<PackageMa
                   { cwd }
                 : // Otherwise try to find the ioBroker root dir
                   {
-                      cwd: __dirname,
+                      cwd: (isDevServerInstallation() && require.main?.path) || __dirname,
                       setCwdToPackageRoot: true
                   }
         );
@@ -2094,11 +2096,22 @@ export function getControllerDir(): string {
     throw new Error('Could not determine controller directory');
 }
 
+/** Returns whether the current process is executed via dev-server */
+export function isDevServerInstallation(): boolean {
+    return !!require.main?.path.includes(`${path.sep}.dev-server${path.sep}`);
+}
+
 /**
  * All paths are returned always relative to /node_modules/' + appName + '.js-controller
  * the result has always "/" as last symbol
  */
 export function getDefaultDataDir(): string {
+    // Allow overriding the data directory with an environment variable
+    const envDataDir = process.env[`${appName.toUpperCase()}_DATA_DIR`];
+    if (envDataDir) {
+        return envDataDir;
+    }
+
     if (_isDevInstallation()) {
         // dev install
         return './data/';
@@ -2120,6 +2133,13 @@ export function getDefaultDataDir(): string {
  */
 export function getConfigFileName(): string {
     const _appName = appName.toLowerCase();
+
+    // Allow overriding the config file location with an environment variable
+    const envDataDir = process.env[`${appName.toUpperCase()}_DATA_DIR`];
+    if (envDataDir) {
+        return path.join(envDataDir, `${_appName}.json`);
+    }
+
     let devConfigDir;
 
     if (_isDevInstallation()) {
@@ -3144,6 +3164,22 @@ export function getDefaultNodeArgs(mainFile: string): string[] {
     // If JS-controller was started with --preserve-symlinks, do the same for adapters
     if (process.execArgv.includes('--preserve-symlinks')) {
         ret.push('--preserve-symlinks-main', '--preserve-symlinks');
+    }
+    return ret;
+}
+
+/**
+ * Returns the default paths used to resolve modules using `require.resolve()`
+ * @param callerModule The module that wants to resolve another module
+ */
+export function getDefaultRequireResolvePaths(callerModule: NodeModule): string[] {
+    const ret: string[] = [
+        // This is the default for require.resolve
+        ...callerModule.paths
+    ];
+    // If JS-controller was started with --preserve-symlinks, start looking where the process entry point was
+    if (process.execArgv.includes('--preserve-symlinks') && require.main) {
+        ret.unshift(...require.main.paths);
     }
     return ret;
 }

--- a/packages/common/src/lib/common/tools.ts
+++ b/packages/common/src/lib/common/tools.ts
@@ -2107,8 +2107,11 @@ export function isDevServerInstallation(): boolean {
  */
 export function getDefaultDataDir(): string {
     // Allow overriding the data directory with an environment variable
-    const envDataDir = process.env[`${appName.toUpperCase()}_DATA_DIR`];
+    let envDataDir = process.env[`${appName.toUpperCase()}_DATA_DIR`];
     if (envDataDir) {
+        if (path.isAbsolute(envDataDir)) {
+            envDataDir = path.relative(getControllerDir(), envDataDir);
+        }
         return envDataDir;
     }
 
@@ -2135,8 +2138,11 @@ export function getConfigFileName(): string {
     const _appName = appName.toLowerCase();
 
     // Allow overriding the config file location with an environment variable
-    const envDataDir = process.env[`${appName.toUpperCase()}_DATA_DIR`];
+    let envDataDir = process.env[`${appName.toUpperCase()}_DATA_DIR`];
     if (envDataDir) {
+        if (!path.isAbsolute(envDataDir)) {
+            envDataDir = path.join(getControllerDir(), envDataDir);
+        }
         return path.join(envDataDir, `${_appName}.json`);
     }
 

--- a/packages/controller/src/main.ts
+++ b/packages/controller/src/main.ts
@@ -5593,8 +5593,7 @@ function init(compactGroupId?: number): void {
         const isInNodeModules = controllerDir
             .toLowerCase()
             .includes(`${path.sep}node_modules${path.sep}${title.toLowerCase()}`);
-        const isDevServer = require.main?.path.includes(`${path.sep}.dev-server${path.sep}`);
-        if (isInNodeModules && !isDevServer) {
+        if (isInNodeModules && !tools.isDevServerInstallation()) {
             try {
                 if (!fs.existsSync(`${controllerDir}/../../package.json`)) {
                     fs.writeFileSync(


### PR DESCRIPTION
I noticed that there were a few paths wrong when using dev-server with symlinks. This PR should fix all of those:
1. By passing the `${APPNAME}_DATA_DIR` env variable, we can now overwrite where the `dataDir` is located
2. `require.resolve` of non-controller modules considers the paths of the main entrypoint when symlinks are used. Without this, the adapterDir is searched for in the monorepo, not in `.dev-server/<profilename>`
3. `pak` gets passed the correct `cwd` now when resolving the project root inside `.dev-server/`