### PR TITLE
support TypeScript debugging with dev-server

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,37 @@
+{
+	"configurations": [
+		{
+			"name": "Debug with dev-server",
+			"port": 9229,
+			"request": "attach",
+			"skipFiles": [
+				"<node_internals>/**"
+			],
+			"type": "node",
+			"sourceMaps": true,
+			"resolveSourceMapLocations": [
+				"${workspaceFolder}/packages/**",
+				// We need to look for source maps in .dev-server
+				"${workspaceFolder}/.dev-server/**",
+				// and the node_modules/@iobroker directories, which are symlinked to the packages/ subdirs
+				"${workspaceFolder}/node_modules/@iobroker/**",
+				// Do not look multiple levels deep though
+				"!${workspaceFolder}/node_modules/@iobroker/**/node_modules/**",
+			],
+			"sourceMapPathOverrides": {
+				"~/adapter/*": "${workspaceFolder}/packages/adapter/src/*",
+				"~/cli/*": "${workspaceFolder}/packages/cli/src/*",
+				"~/common-db/*": "${workspaceFolder}/packages/common-db/src/*",
+				"~/common/*": "${workspaceFolder}/packages/common/src/*",
+				"~/controller/*": "${workspaceFolder}/packages/controller/src/*",
+				"~/db-base/*": "${workspaceFolder}/packages/db-base/src/*",
+				"~/db-objects-file/*": "${workspaceFolder}/packages/db-objects-file/src/*",
+				"~/db-objects-jsonl/*": "${workspaceFolder}/packages/db-objects-jsonl/src/*",
+				"~/db-objects-redis/*": "${workspaceFolder}/packages/db-objects-redis/src/*",
+				"~/db-states-file/*": "${workspaceFolder}/packages/db-states-file/src/*",
+				"~/db-states-jsonl/*": "${workspaceFolder}/packages/db-states-jsonl/src/*",
+				"~/db-states-redis/*": "${workspaceFolder}/packages/db-states-redis/src/*",
+			}
+		}
+	]
+}

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -2,7 +2,9 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "outDir": "build",
-    "rootDir": "src"
+    "rootDir": "src",
+    // This is needed to make sourcemaps work for debugging
+    "sourceRoot": "~/cli/"
   },
   "references": [
     {

--- a/packages/common-db/tsconfig.json
+++ b/packages/common-db/tsconfig.json
@@ -3,7 +3,9 @@
   "compilerOptions": {
     "outDir": "build",
     "rootDir": "src",
-    "noEmit": false
+    "noEmit": false,
+    // This is needed to make sourcemaps work for debugging
+    "sourceRoot": "~/common-db/"
   },
   "references": [
     {

--- a/packages/common/tsconfig.json
+++ b/packages/common/tsconfig.json
@@ -2,7 +2,9 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "outDir": "build",
-    "rootDir": "src"
+    "rootDir": "src",
+    // This is needed to make sourcemaps work for debugging
+    "sourceRoot": "~/common/"
   },
   "include": [
     "src/**/*.ts"

--- a/packages/controller/tsconfig.json
+++ b/packages/controller/tsconfig.json
@@ -2,7 +2,9 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "outDir": "build",
-    "rootDir": "src"
+    "rootDir": "src",
+    // This is needed to make sourcemaps work for debugging
+    "sourceRoot": "~/controller/"
   },
   "references": [
     {

--- a/packages/db-base/tsconfig.json
+++ b/packages/db-base/tsconfig.json
@@ -2,7 +2,9 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "outDir": "build",
-    "rootDir": "src"
+    "rootDir": "src",
+    // This is needed to make sourcemaps work for debugging
+    "sourceRoot": "~/db-base/"
   },
   "references": [
     {

--- a/packages/db-objects-file/tsconfig.json
+++ b/packages/db-objects-file/tsconfig.json
@@ -3,7 +3,9 @@
   "compilerOptions": {
     "outDir": "build",
     "rootDir": "src",
-    "noEmit": false
+    "noEmit": false,
+    // This is needed to make sourcemaps work for debugging
+    "sourceRoot": "~/db-objects-file/"
   },
   "references": [
     {

--- a/packages/db-objects-jsonl/tsconfig.json
+++ b/packages/db-objects-jsonl/tsconfig.json
@@ -3,7 +3,9 @@
   "compilerOptions": {
     "outDir": "build",
     "rootDir": "src",
-    "noEmit": false
+    "noEmit": false,
+    // This is needed to make sourcemaps work for debugging
+    "sourceRoot": "~/db-objects-jsonl/"
   },
   "references": [
     {

--- a/packages/db-objects-redis/tsconfig.json
+++ b/packages/db-objects-redis/tsconfig.json
@@ -2,7 +2,9 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "outDir": "build",
-    "rootDir": "src"
+    "rootDir": "src",
+    // This is needed to make sourcemaps work for debugging
+    "sourceRoot": "~/db-objects-redis/"
   },
   "references": [
     {

--- a/packages/db-states-file/tsconfig.json
+++ b/packages/db-states-file/tsconfig.json
@@ -3,7 +3,9 @@
   "compilerOptions": {
     "outDir": "build",
     "rootDir": "src",
-    "noEmit": false
+    "noEmit": false,
+    // This is needed to make sourcemaps work for debugging
+    "sourceRoot": "~/db-states-file/"
   },
   "references": [
     {

--- a/packages/db-states-jsonl/tsconfig.json
+++ b/packages/db-states-jsonl/tsconfig.json
@@ -3,7 +3,9 @@
   "compilerOptions": {
     "outDir": "build",
     "rootDir": "src",
-    "noEmit": false
+    "noEmit": false,
+    // This is needed to make sourcemaps work for debugging
+    "sourceRoot": "~/db-states-jsonl/"
   },
   "references": [
     {

--- a/packages/db-states-redis/tsconfig.json
+++ b/packages/db-states-redis/tsconfig.json
@@ -2,7 +2,9 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "outDir": "build",
-    "rootDir": "src"
+    "rootDir": "src",
+    // This is needed to make sourcemaps work for debugging
+    "sourceRoot": "~/db-states-redis/"
   },
   "references": [
     {


### PR DESCRIPTION
Works for me now. The Webstorm users will need to translate the launch.json to something Webstorm understands.
Probably needs the "remote urls for local files" setting here: https://www.jetbrains.com/help/webstorm/run-debug-configuration-node-js-remote-debug.html#ws_node_specific_attach_to_chrome_settings