### PR TITLE
do not apply default octet to non binary content on writeFile

### DIFF
--- a/packages/adapter/src/lib/adapter/adapter.ts
+++ b/packages/adapter/src/lib/adapter/adapter.ts
@@ -4664,7 +4664,7 @@ export class AdapterClass extends EventEmitter {
     }
 
     // external signatures
-    subscribeForeignFiles(id: string, pattern: string | string[], options: unknown): void;
+    subscribeForeignFiles(id: string, pattern: string | string[], options?: unknown): void;
 
     /**
      * Subscribe for the changes of files in specific instance.

--- a/packages/cli/src/lib/setup/setupBackup.ts
+++ b/packages/cli/src/lib/setup/setupBackup.ts
@@ -94,8 +94,8 @@ export class BackupRestore {
             // @ts-expect-error #1917
             const data = await this.objects.readFileAsync(id, srcPath);
             if (data) {
-                if (data.data !== undefined) {
-                    fs.writeFileSync(destPath, data.data);
+                if (data.file !== undefined) {
+                    fs.writeFileSync(destPath, data.file);
                 } else {
                     // @ts-expect-error #1917 revisit
                     fs.writeFileSync(destPath, data);

--- a/packages/cli/src/lib/setup/setupVisDebug.ts
+++ b/packages/cli/src/lib/setup/setupVisDebug.ts
@@ -167,9 +167,8 @@ FALLBACK:
         }
 
         if (widgetset) {
-            const { data } = await this.objects.readFile('vis', 'js/config.js', null);
-            // Or types are wrong and data is always string?
-            let content = typeof data === 'string' ? data : data.toString();
+            const { file } = await this.objects.readFile('vis', 'js/config.js', null);
+            let content = typeof file === 'string' ? file : file.toString();
 
             content = content.replace(/[\r\n]/g, '');
             const json: Record<string, any> = JSON.parse(content.match(/"widgetSets":\s(.*)};/)![1]);

--- a/packages/controller/test/_Types.ts
+++ b/packages/controller/test/_Types.ts
@@ -6,4 +6,6 @@ export interface TestContext extends Mocha.Context {
     adapter: AdapterClass;
     states: StatesInRedisClient;
     objects: ObjectsInRedisClient;
+    onAdapterStateChanged: ioBroker.StateChangeHandler;
+    onAdapterFileChanged: ioBroker.FileChangeHandler;
 }

--- a/packages/controller/test/lib/testFiles.js
+++ b/packages/controller/test/lib/testFiles.js
@@ -134,7 +134,7 @@ function register(it, expect, context) {
         expect(state.toString('utf-8')).to.be.equal('1234');
     });
 
-    it(testName + 'writeFile', async () => {
+    it(testName + 'writeFile with binary content and subscription', async () => {
         const objId = `vis.0`;
         const fileName = 'testFile.bin';
         const dataBinary = Buffer.from('1234');
@@ -168,6 +168,31 @@ function register(it, expect, context) {
 
         expect(mimeType).to.be.equal('application/octet-stream');
         expect(file.toString('utf8')).to.be.equal(dataBinary.toString('utf8'));
+    });
+
+    it(testName + 'writeFile with textual content', async () => {
+        const objId = `vis.0`;
+        /** unknown extension but string content should lead to plain text */
+        const fileName = 'testFile.fn';
+        const dataText = "these are not the droids you're looking for";
+        // create an object of type file first
+        await context.adapter.setForeignObjectAsync(objId, {
+            type: 'meta',
+            common: {
+                type: 'meta.user'
+            },
+            native: {}
+        });
+
+        // now we write a file state
+        await context.adapter.writeFileAsync(objId, fileName, dataText);
+
+        await context.adapter.unsubscribeForeignFiles(objId, '*');
+
+        const { file, mimeType } = await context.adapter.readFileAsync(objId, fileName);
+
+        expect(mimeType).to.be.equal('text/plain');
+        expect(file).to.be.equal(dataText);
     });
 
     it(testName + 'deleteFile', async () => {

--- a/packages/controller/test/lib/testFiles.ts
+++ b/packages/controller/test/lib/testFiles.ts
@@ -1,10 +1,6 @@
-/* jshint -W097 */
-/* jshint strict:false */
-/* jslint node:true */
-/* jshint expr:true */
-'use strict';
+import type { TestContext } from '../_Types';
 
-function register(it, expect, context) {
+export function register(it: Mocha.TestFunction, expect: Chai.ExpectStatic, context: TestContext): void {
     const testName = `${context.name} ${context.adapterShortName} files: `;
     // chmodFile
     // readDir
@@ -19,6 +15,7 @@ function register(it, expect, context) {
         await context.adapter.setForeignObjectAsync(objId, {
             type: 'state',
             common: {
+                role: 'state',
                 name: objId,
                 read: true,
                 write: true,
@@ -34,13 +31,14 @@ function register(it, expect, context) {
     it(testName + 'setBinaryState', async () => {
         const objId = `${context.adapter.namespace}.testSetBinaryState`;
 
-        const receivedPromise = new Promise(resolve => {
+        const receivedPromise = new Promise<void>(resolve => {
             context.onAdapterStateChanged = (id, state) => {
                 if (id === objId) {
                     if (typeof state !== 'object') {
                         throw new Error(`Expected object, but got ${typeof state}`);
                     }
-                    if (!state.binary) {
+                    // @ts-expect-error binary states will be removed soon
+                    if (!state?.binary) {
                         throw new Error(`Binary flag does not set`);
                     }
                     if (state.val !== null) {
@@ -56,6 +54,7 @@ function register(it, expect, context) {
         await context.adapter.setForeignObjectAsync(objId, {
             type: 'state',
             common: {
+                role: 'state',
                 name: objId,
                 read: true,
                 write: true,
@@ -75,7 +74,7 @@ function register(it, expect, context) {
     it(testName + 'delBinaryState', async () => {
         const objId = `${context.adapter.namespace}.testSetBinaryState`;
 
-        const receivedPromise = new Promise(resolve => {
+        const receivedPromise = new Promise<void>(resolve => {
             context.onAdapterStateChanged = (id, state) => {
                 if (id === objId) {
                     expect(state).to.be.equal(null);
@@ -98,6 +97,7 @@ function register(it, expect, context) {
         await context.adapter.setForeignObjectAsync(objId, {
             type: 'state',
             common: {
+                role: 'state',
                 name: objId,
                 read: true,
                 write: true,
@@ -108,9 +108,8 @@ function register(it, expect, context) {
 
         // now we write a binary state
         await context.adapter.setForeignBinaryStateAsync(objId, Buffer.from('1234'));
-        /** @type Buffer */
         const state = await context.adapter.getForeignBinaryStateAsync(objId);
-        expect(state.toString('utf-8')).to.be.equal('1234');
+        expect(state!.toString('utf-8')).to.be.equal('1234');
     });
 
     it(testName + 'getBinaryState', async () => {
@@ -119,6 +118,7 @@ function register(it, expect, context) {
         await context.adapter.setForeignObjectAsync(objId, {
             type: 'state',
             common: {
+                role: 'state',
                 name: objId,
                 read: true,
                 write: true,
@@ -131,7 +131,7 @@ function register(it, expect, context) {
         await context.adapter.setBinaryStateAsync(objId, Buffer.from('1234'));
         /** @type Buffer */
         const state = await context.adapter.getBinaryStateAsync(objId);
-        expect(state.toString('utf-8')).to.be.equal('1234');
+        expect(state!.toString('utf-8')).to.be.equal('1234');
     });
 
     it(testName + 'writeFile with binary content and subscription', async () => {
@@ -142,6 +142,7 @@ function register(it, expect, context) {
         await context.adapter.setForeignObjectAsync(objId, {
             type: 'meta',
             common: {
+                name: 'Files and more',
                 type: 'meta.user'
             },
             native: {}
@@ -149,7 +150,7 @@ function register(it, expect, context) {
 
         await context.adapter.subscribeForeignFiles(objId, '*');
 
-        const receivedPromise = new Promise(resolve => {
+        const receivedPromise = new Promise<void>(resolve => {
             context.onAdapterFileChanged = (id, _fileName, size) => {
                 if (id === objId && fileName === _fileName) {
                     expect(size).to.be.equal(dataBinary.byteLength);
@@ -163,7 +164,6 @@ function register(it, expect, context) {
 
         await context.adapter.unsubscribeForeignFiles(objId, '*');
 
-        /** @type Buffer */
         const { file, mimeType } = await context.adapter.readFileAsync(objId, fileName);
 
         expect(mimeType).to.be.equal('application/octet-stream');
@@ -179,6 +179,7 @@ function register(it, expect, context) {
         await context.adapter.setForeignObjectAsync(objId, {
             type: 'meta',
             common: {
+                name: 'Files and more',
                 type: 'meta.user'
             },
             native: {}
@@ -201,7 +202,7 @@ function register(it, expect, context) {
 
         await context.adapter.subscribeForeignFiles(objId, '*');
 
-        const receivedPromise = new Promise(resolve => {
+        const receivedPromise = new Promise<void>(resolve => {
             context.onAdapterFileChanged = (id, _fileName, size) => {
                 if (id === objId && fileName === _fileName) {
                     expect(size).to.be.equal(null);
@@ -213,7 +214,6 @@ function register(it, expect, context) {
         // now we write a file state
         await Promise.all([receivedPromise, context.adapter.unlinkAsync(objId, fileName)]);
 
-        /** @type Buffer */
         try {
             await context.adapter.readFileAsync(objId, fileName);
         } catch (error) {

--- a/packages/controller/test/lib/testFiles.ts
+++ b/packages/controller/test/lib/testFiles.ts
@@ -188,8 +188,6 @@ export function register(it: Mocha.TestFunction, expect: Chai.ExpectStatic, cont
         // now we write a file state
         await context.adapter.writeFileAsync(objId, fileName, dataText);
 
-        await context.adapter.unsubscribeForeignFiles(objId, '*');
-
         const { file, mimeType } = await context.adapter.readFileAsync(objId, fileName);
 
         expect(mimeType).to.be.equal('text/plain');

--- a/packages/db-objects-redis/src/lib/objects/objectsInRedisClient.ts
+++ b/packages/db-objects-redis/src/lib/objects/objectsInRedisClient.ts
@@ -1202,7 +1202,7 @@ export class ObjectsInRedisClient {
             buffer = buffer.toString();
         }
 
-        return { data: buffer, mimeType: mimeType };
+        return { file: buffer, mimeType: mimeType };
     }
 
     // User has provided no callback, we will return the Promise
@@ -1252,8 +1252,8 @@ export class ObjectsInRedisClient {
                 return tools.maybeCallbackWithError(callback, err);
             } else {
                 try {
-                    const { data, mimeType } = await this._readFile(id, name, meta);
-                    return tools.maybeCallbackWithError(callback, null, data, mimeType);
+                    const { file, mimeType } = await this._readFile(id, name, meta);
+                    return tools.maybeCallbackWithError(callback, null, file, mimeType);
                 } catch (e) {
                     return tools.maybeCallbackWithError(callback, e);
                 }

--- a/packages/types-dev/index.d.ts
+++ b/packages/types-dev/index.d.ts
@@ -420,7 +420,7 @@ declare global {
         type ReadDirPromise = Promise<NonNullCallbackReturnTypeOf<ReadDirCallback>>;
 
         type ReadFileCallback = (err?: NodeJS.ErrnoException | null, data?: Buffer | string, mimeType?: string) => void;
-        type ReadFilePromise = Promise<{ data: string | Buffer; mimeType?: string }>;
+        type ReadFilePromise = Promise<{ file: string | Buffer; mimeType?: string }>;
 
         /** Contains the return values of chownFile */
         interface ChownFileResult {


### PR DESCRIPTION
- fixes #2193
- see defaults https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types
- port file tests to ts and fix upcoming issues
- promisified version of `readFile` returns property file instead of data
- subscribeforeignfiles third prop is optional