### PR TITLE
on ui upgrade

### DIFF
--- a/packages/controller/src/lib/upgradeManager.ts
+++ b/packages/controller/src/lib/upgradeManager.ts
@@ -303,9 +303,14 @@ class UpgradeManager {
         await this.startShutdownTimeout();
     }
 
+    /**
+     * Start a timeout which starts controller and shuts down the app if expired
+     */
     async startShutdownTimeout(): Promise<void> {
         this.shutdownAbortController = new AbortController();
         await wait(this.SHUTDOWN_TIMEOUT, null, { signal: this.shutdownAbortController.signal });
+
+        this.log('Timeout expired, initializing shutdown');
         this.shutdownApp();
     }
 }

--- a/packages/controller/src/lib/upgradeManager.ts
+++ b/packages/controller/src/lib/upgradeManager.ts
@@ -65,7 +65,7 @@ class UpgradeManager {
         stdout: []
     };
     /** Used to stop the stop shutdown timeout */
-    private shutdownAbortController: undefined | AbortController;
+    private shutdownAbortController?: AbortController;
 
     /** The server used for communicating upgrade status */
     private server?: https.Server | http.Server;


### PR DESCRIPTION
- pass all logs to the frontend not only those from npm install
- if final message is not delivered in 10 seconds, start controller and end the process anyway