### PR TITLE
Switching from alias to full path for start/stop commands during js-controller upgrade via Admin UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,10 @@
 * (bluefox) Added CLI option to restart/start/stop all instances of an adapter (e.g. `iob stop admin` now also works)
 * (foxriver76) Allow to use `iob host oldname` command when new host already exists but has no instances
 * (foxriver76) Added an admin notification if redis is misconfigured and info how to fix it
-* (foxriver76) Enable upgrade of js-controller via Admin UI (Linux only)
+* (foxriver76) Enable upgrade of js-controller via Admin UI (Linux/Docker only)
 
 **Optimizations and Fixes**
+* (buanet) Fix start/stop js-controller during upgrade via Admin UI in Docker
 * (foxriver76) Speedup "getStates" calls with many IDs often used by visualizations: JSONL 17 times faster, Redis 23 times faster
 * (foxriver76) significantly reduce backup size
 * (foxriver76) Enhance CLI help for list command to show all possible types to list

--- a/packages/common/src/lib/common/tools.ts
+++ b/packages/common/src/lib/common/tools.ts
@@ -73,7 +73,7 @@ const VENDOR_FILE = '/etc/iob-vendor.json';
 /** This file contains the version string in an official docker image */
 const OFFICIAL_DOCKER_FILE = '/opt/scripts/.docker_config/.thisisdocker';
 /** Version of official Docker image which started to support UI upgrade */
-const DOCKER_VERSION_UI_UPGRADE = '8.0.0';
+const DOCKER_VERSION_UI_UPGRADE = '8.1.0';
 
 let lastCalculationOfIps: number;
 let ownIpArr: string[] = [];

--- a/packages/controller/src/lib/upgradeManager.ts
+++ b/packages/controller/src/lib/upgradeManager.ts
@@ -136,7 +136,7 @@ class UpgradeManager {
      */
     async stopController(): Promise<void> {
         if (tools.isDocker()) {
-            await execAsync('m on -kbn');
+            await execAsync('/opt/scripts/maintenance.sh on -kbn');
         } else {
             await execAsync(`${tools.appNameLowerCase} stop`);
         }
@@ -148,7 +148,7 @@ class UpgradeManager {
      */
     startController(): ChildProcessPromise {
         if (tools.isDocker()) {
-            return execAsync('m off -y');
+            return execAsync('/opt/scripts/maintenance.sh off -y');
         }
 
         return execAsync(`${tools.appNameLowerCase} start`);


### PR DESCRIPTION
After some testing I got the js-controller upgrade via Admin UI running on Docker. Support will be added to the Docker image in upcoming v8.1.0. 
We need to switch from alias to full path of the Docker image's maintenance script for js-controller start/stop during upgrade.  