### PR TITLE
fixed upgrade manager crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 	Placeholder for the next version (at the beginning of the line):
 	## __WORK IN PROGRESS__
 -->
-## 5.0.9 (2023-07-26) - Jana
+## __WORK IN PROGRESS__ - Jana
 **BREAKING CHANGES**
 * Support for Node.js 12 and 14 is dropped! Supported are Node.js 16.4.0+ and 18.x
 * Backups created with the new js-controller version cannot be restored on hosts with lower js-controller version!

--- a/packages/controller/src/main.ts
+++ b/packages/controller/src/main.ts
@@ -6061,7 +6061,7 @@ async function _getNumberOfInstances(): Promise<
         if (config.system.compact) {
             for (const row of instancesView!.rows) {
                 const state = await states!.getStateAsync(`${row.id}.compactMode`);
-                if (state && state.val) {
+                if (state?.val) {
                     noCompactInstances++;
                 }
             }


### PR DESCRIPTION
- do not call setHeader after writeHead
- and stream unhandled errors and rejections to the logfile