### PR TITLE
Fix description for messagebox at io-package.json schema

### DIFF
--- a/schemas/io-package.json
+++ b/schemas/io-package.json
@@ -115,7 +115,7 @@
           "$ref": "#/definitions/multilingual"
         },
         "messagebox": {
-          "description": "true if messagebox supported. Hence, the adapter can receive sendTo messages. Up from controller v5, please use common.supportedMessages.notifications.custom = true",
+          "description": "true if messagebox supported. Hence, the adapter can receive sendTo messages. Up from controller v5, please use common.supportedMessages.custom = true",
           "type": "boolean"
         },
         "blockedVersions": {


### PR DESCRIPTION
At io-package schema the description for messagebox states to user ```common.supportedMessages.notifications.custom``` starting with js-controller 5

I'm quite sure, this should read ```common.supportedMessages.custom``` as I could nozt detect a property ```common.supportedMessages.notifications.custom```

@foxriver76 
Please double check before merging