### PR TITLE
no longer assume all states which end in .logging

### DIFF
--- a/packages/adapter/src/lib/adapter/adapter.ts
+++ b/packages/adapter/src/lib/adapter/adapter.ts
@@ -113,7 +113,7 @@ import type {
     IoPackageInstanceObject
 } from '../_Types';
 import { UserInterfaceMessagingController } from './userInterfaceMessagingController';
-import { SYSTEM_ADAPTER_PREFIX } from '@iobroker/js-controller-common/build/lib/common/constants';
+import { SYSTEM_ADAPTER_PREFIX } from '@iobroker/js-controller-common/constants';
 
 tools.ensureDNSOrder();
 

--- a/packages/adapter/src/lib/adapter/adapter.ts
+++ b/packages/adapter/src/lib/adapter/adapter.ts
@@ -113,6 +113,7 @@ import type {
     IoPackageInstanceObject
 } from '../_Types';
 import { UserInterfaceMessagingController } from './userInterfaceMessagingController';
+import { SYSTEM_ADAPTER_PREFIX } from '@iobroker/js-controller-common/build/lib/common/constants';
 
 tools.ensureDNSOrder();
 
@@ -10636,8 +10637,8 @@ export class AdapterClass extends EventEmitter {
         }
 
         // Read current state of all log subscribers
-        adapterStates.getKeys('*.logging', (err, keys) => {
-            if (keys && keys.length) {
+        adapterStates.getKeys(`${SYSTEM_ADAPTER_PREFIX}*.logging`, (err, keys) => {
+            if (keys?.length) {
                 if (!adapterStates) {
                     // if adapterState was destroyed, we can not continue
                     return;
@@ -10690,8 +10691,8 @@ export class AdapterClass extends EventEmitter {
             return;
         }
 
-        adapterStates.getKeys('*.logging', (err, keys) => {
-            if (keys && keys.length) {
+        adapterStates.getKeys(`${SYSTEM_ADAPTER_PREFIX}*.logging`, (err, keys) => {
+            if (keys?.length) {
                 if (!adapterStates) {
                     // if adapterState was destroyed, we can not continue
                     return;
@@ -10868,7 +10869,7 @@ export class AdapterClass extends EventEmitter {
     private _initStates(cb: () => void): void {
         this._logger.silly(`${this.namespaceLog} objectDB connected`);
 
-        this._config.states.maxQueue = this._config.states.maxQueue || 1000;
+        this._config.states.maxQueue = this._config.states.maxQueue || 1_000;
 
         this._initializeTimeout = setTimeout(() => {
             this._initializeTimeout = null;
@@ -11034,7 +11035,7 @@ export class AdapterClass extends EventEmitter {
                 }
 
                 // If someone want to have log messages
-                if (id.endsWith('.logging')) {
+                if (id.startsWith(SYSTEM_ADAPTER_PREFIX) && id.endsWith('.logging')) {
                     const instance = id.substring(0, id.length - '.logging'.length);
 
                     this._logger.silly(`${this.namespaceLog} ${instance}: logging ${state ? state.val : false}`);
@@ -11652,7 +11653,7 @@ export class AdapterClass extends EventEmitter {
                     }
 
                     // Monitor logging state
-                    adapterStates.subscribe('*.logging');
+                    adapterStates.subscribe(`${SYSTEM_ADAPTER_PREFIX}*.logging`);
 
                     if (
                         typeof this._options.message === 'function' &&

--- a/packages/controller/src/main.ts
+++ b/packages/controller/src/main.ts
@@ -438,7 +438,7 @@ function createStates(onConnect: () => void): void {
                 return logger.error(`${hostLogPrefix} change event with no ID: ${JSON.stringify(stateOrMessage)}`);
             }
             // If some log transporter activated or deactivated
-            if (id.endsWith('.logging')) {
+            if (id.startsWith(SYSTEM_ADAPTER_PREFIX) && id.endsWith('.logging')) {
                 const state = stateOrMessage as ioBroker.State;
                 logRedirect(state ? (state.val as boolean) : false, id.substring(0, id.length - '.logging'.length), id);
             } else if (!compactGroupController && id === `messagebox.${hostObjectPrefix}`) {
@@ -3126,7 +3126,7 @@ async function processMessage(msg: ioBroker.SendableMessage): Promise<null | voi
                 logs.push(`Actual Loglist - ${JSON.stringify(logList)}`);
 
                 // Read the current state of all log subscribers
-                states!.getKeys('*.logging', (err, keys) => {
+                states!.getKeys(`${SYSTEM_ADAPTER_PREFIX}*.logging`, (err, keys) => {
                     if (keys?.length) {
                         states!.getStates(keys, (err, objs) => {
                             if (objs) {
@@ -3140,7 +3140,7 @@ async function processMessage(msg: ioBroker.SendableMessage): Promise<null | voi
                                         if (obj.val === true) {
                                             logs.push(`Subscriber - ${id} ENABLED`);
                                         } else {
-                                            logs && logs.push(`Subscriber - ${id} (disabled)`);
+                                            logs.push(`Subscriber - ${id} (disabled)`);
                                         }
                                     }
                                 }
@@ -5844,7 +5844,7 @@ export function init(compactGroupId?: number): void {
                 connectTimeout = null;
             }
             // Subscribe for all logging objects
-            states!.subscribe('*.logging');
+            states!.subscribe(`${SYSTEM_ADAPTER_PREFIX}*.logging`);
 
             // Subscribe for all logging objects
             states!.subscribe(`${SYSTEM_ADAPTER_PREFIX}*.alive`);
@@ -5898,7 +5898,7 @@ export function init(compactGroupId?: number): void {
 
             try {
                 // Read the current state of all log subscribers
-                keys = (await states!.getKeys('*.logging'))!;
+                keys = (await states!.getKeys(`${SYSTEM_ADAPTER_PREFIX}*.logging`))!;
             } catch {
                 // ignore
             }


### PR DESCRIPTION
- are actually log subscribers, only the correct ones in `system.adapter.*`
- closes #2470