### PR TITLE
Fix edge case where async `this._extendObject` can reject

### DIFF
--- a/packages/adapter/src/lib/adapter/adapter.ts
+++ b/packages/adapter/src/lib/adapter/adapter.ts
@@ -3079,6 +3079,9 @@ export class AdapterClass extends EventEmitter {
             Validator.assertObject(options, 'options');
         }
 
+        if (typeof callback === 'function') {
+            return this._extendObject({ id, obj: obj as ioBroker.SettableObject, options, callback }).catch(callback);
+        }
         return this._extendObject({ id, obj: obj as ioBroker.SettableObject, options, callback });
     }
 


### PR DESCRIPTION
Came across this, when importing a new Homematic entity. Saw this failure in my logs:

```
Caught by controller[0]: This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). The promise rejected with the reason:
TypeError: Cannot use 'in' operator to search for 'repositories' in -3 at HomematicRpc._extendObject (/opt/iobroker/node_modules/@iobroker/js-controller-adapter/src/lib/adapter/adapter.ts:3137:54)
instance system.adapter.hm-rpc.0 terminated with code 6 (UNCAUGHT_EXCEPTION)
```

It's probably a bug in Homematic as well. Though `_extendObject` can reject since it's `async`, in which case the instance stops, since that is never caught.

In case it's not intended to tear down the instance, I guess it makes sense to catch the error and delegate to the `callback` function.