### PR TITLE
fixed bug that only local address would be shown in multihost discover

### DIFF
--- a/packages/cli/src/lib/setup.ts
+++ b/packages/cli/src/lib/setup.ts
@@ -2671,15 +2671,14 @@ async function processCommand(
                         mh.status();
                         return void callback();
                     } else if (cmd === 'b' || cmd === 'browse') {
-                        mh.browse((err: any, list: any) => {
-                            if (err) {
-                                console.error(err);
-                                return void callback(EXIT_CODES.CANNOT_CREATE_USER_OR_GROUP);
-                            } else {
-                                mh.showHosts(list);
-                                return void callback();
-                            }
-                        });
+                        try {
+                            const list = await mh.browse();
+                            mh.showHosts(list);
+                            return void callback();
+                        } catch (e) {
+                            console.error(e.message);
+                            return void callback(EXIT_CODES.CANNOT_CREATE_USER_OR_GROUP);
+                        }
                     } else if (cmd === 'e' || cmd === 'enable') {
                         mh.enable(true, async (err: any) => {
                             if (err) {

--- a/packages/cli/src/lib/setup/setupMultihost.ts
+++ b/packages/cli/src/lib/setup/setupMultihost.ts
@@ -74,18 +74,15 @@ export class Multihost {
 
     /**
      * Start MH browsing
-     *
-     * @param callback
      */
-    browse(callback: (err?: Error | undefined, list?: BrowseResultEntry[]) => void): void {
+    async browse(): Promise<BrowseResultEntry[]> {
         const mhClient = new MHClient();
-        mhClient.browse(2_000, !!this.params.debug, (err, list) => {
-            if (err) {
-                callback(new Error(`Multihost discovery client: Cannot browse: ${err.message}`));
-            } else {
-                callback(undefined, list);
-            }
-        });
+        try {
+            const res = await mhClient.browse(2_000, !!this.params.debug);
+            return res;
+        } catch (e) {
+            throw new Error(`Multihost discovery client: Cannot browse: ${e.message}`);
+        }
     }
 
     /**
@@ -351,11 +348,11 @@ export class Multihost {
      * @param pass password
      * @param callback
      */
-    connect(
+    async connect(
         index: number | null,
         pass: string | null,
         callback: (err?: Error, list?: BrowseResultEntry[]) => void
-    ): void {
+    ): Promise<void> {
         if (typeof pass === 'function') {
             callback = pass;
             pass = null;
@@ -366,57 +363,57 @@ export class Multihost {
         }
 
         const mhClient = new MHClient();
+        let list: BrowseResultEntry[];
 
-        mhClient.browse(2_000, !!this.params.debug, (err, list) => {
-            if (err) {
-                callback(new Error(`Cannot browse: ${err.message}`));
-            } else {
-                this.showHosts(list);
+        try {
+            list = await mhClient.browse(2_000, !!this.params.debug);
+        } catch (e) {
+            callback(new Error(`Cannot browse: ${e.message}`));
+            return;
+        }
 
-                if (index !== null && index !== undefined && index > 0) {
-                    if (list && index < list.length + 1) {
-                        if (!pass) {
-                            callback(
-                                new Error('No password defined: please use "multihost connect <NUMBER> <PASSWORD>"')
-                            );
-                        } else {
-                            this.connectHelper(mhClient, list[index - 1].ip!, pass, callback);
-                        }
-                    } else {
-                        callback(new Error(`Invalid index: ${index}`));
-                    }
-                } else if (list && list.length) {
-                    const rl = readline.createInterface({
-                        input: process.stdin,
-                        output: process.stdout
-                    });
-                    rl.question('Please select host [1]: ', answer => {
-                        if (answer === '' || answer === null || answer === undefined) {
-                            index = 1;
-                        }
-                        index = parseInt(answer, 10) - 1;
-                        const listEntry = list[index];
-                        if (!listEntry) {
-                            rl.close();
-                            callback(new Error(`Invalid index: ${answer}`));
-                        } else {
-                            if (listEntry.auth) {
-                                this.readPassword(password => {
-                                    if (password) {
-                                        this.connectHelper(mhClient, listEntry.ip!, password, callback);
-                                    } else {
-                                        callback(new Error('No password entered!'));
-                                    }
-                                });
-                            } else {
-                                this.connectHelper(mhClient, listEntry.ip!, '', callback);
-                            }
-                        }
-                    });
+        this.showHosts(list);
+
+        if (index !== null && index !== undefined && index > 0) {
+            if (list && index < list.length + 1) {
+                if (!pass) {
+                    callback(new Error('No password defined: please use "multihost connect <NUMBER> <PASSWORD>"'));
                 } else {
-                    callback(undefined, list);
+                    this.connectHelper(mhClient, list[index - 1].ip!, pass, callback);
                 }
+            } else {
+                callback(new Error(`Invalid index: ${index}`));
             }
-        });
+        } else if (list && list.length) {
+            const rl = readline.createInterface({
+                input: process.stdin,
+                output: process.stdout
+            });
+            rl.question('Please select host [1]: ', answer => {
+                if (answer === '' || answer === null || answer === undefined) {
+                    index = 1;
+                }
+                index = parseInt(answer, 10) - 1;
+                const listEntry = list[index];
+                if (!listEntry) {
+                    rl.close();
+                    callback(new Error(`Invalid index: ${answer}`));
+                } else {
+                    if (listEntry.auth) {
+                        this.readPassword(password => {
+                            if (password) {
+                                this.connectHelper(mhClient, listEntry.ip!, password, callback);
+                            } else {
+                                callback(new Error('No password entered!'));
+                            }
+                        });
+                    } else {
+                        this.connectHelper(mhClient, listEntry.ip!, '', callback);
+                    }
+                }
+            });
+        } else {
+            callback(undefined, list);
+        }
     }
 }


### PR DESCRIPTION
- except when used with debug flag

<!--
    Please adjust the PR title with prefix '[fix]:' or [feature]:' and delete the non-matching content below
-->

### For Bugfixes:

**Link the issue which is closed by this PR**
- closes #2706
<!--
    If the PR closes the issue add a `closes #issue-no`. If no issue exists yet, please create an issue first.
-->

**Implementation details**
<!--
    What has been changed?
-->
There was a bug which filtered for local address because it was missing a `!` in front
https://github.com/ioBroker/ioBroker.js-controller/pull/2707/files#diff-d0d6311d56a1b9b1cbe04b61256860a29d0b0b451609816859f0881272a2a761R155

This was added and a little bit of callback hell was removed

In 5.0.19 some can still use `mh browse` but needs to add `--debug` to get correct output

**Tests**
- [ ] I have added tests to avoid a recursion of this bug
- [x] It is not possible to test for this bug

**If no tests added, please specify why it was not possible**
<!--
    E.g. the bug is only reproducible if the system runs out of disk space.
-->

Would need a more complex setup with two iobroker hosts or we start to mock some internal methods in the future but should not be part of this PR