### PR TITLE
[fix]: if alias points to nowhere or object does not exist return null

### DIFF
--- a/packages/adapter/src/lib/adapter/adapter.ts
+++ b/packages/adapter/src/lib/adapter/adapter.ts
@@ -7823,7 +7823,7 @@ export class AdapterClass extends EventEmitter {
                     return tools.maybeCallbackWithError(callback, e);
                 }
             } else {
-                this._logger.warn(`${this.namespaceLog} ${`Alias ${fixedId} has no target 2`}`);
+                this._logger.warn(`${this.namespaceLog} Alias ${fixedId} has no target 2`);
                 return tools.maybeCallbackWithError(callback, `Alias ${fixedId} has no target`);
             }
         } else {
@@ -8578,7 +8578,7 @@ export class AdapterClass extends EventEmitter {
                         callback
                     );
                 } else {
-                    this._logger.warn(`${this.namespaceLog} Alias ${id} has no target 4`);
+                    this._logger.warn(`${this.namespaceLog} Alias ${id} has no target 3`);
                     return tools.maybeCallbackWithError(callback, `Alias ${id} has no target`);
                 }
             } else {
@@ -8660,7 +8660,7 @@ export class AdapterClass extends EventEmitter {
                         callback
                     );
                 } else {
-                    this._logger.warn(`${this.namespaceLog} Alias ${id} has no target 5`);
+                    this._logger.warn(`${this.namespaceLog} Alias ${id} has no target 4`);
                     return tools.maybeCallbackWithError(callback, `Alias ${id} has no target`);
                 }
             } else {
@@ -8939,7 +8939,6 @@ export class AdapterClass extends EventEmitter {
         }
 
         if (id.startsWith(ALIAS_STARTS_WITH)) {
-            // TODO: optimize alias GET performance
             if (obj?.common?.alias?.id) {
                 // id can be string or can have attribute id.read
                 const aliasId = tools.isObject(obj.common.alias.id) ? obj.common.alias.id.read : obj.common.alias.id;
@@ -8991,8 +8990,8 @@ export class AdapterClass extends EventEmitter {
                     );
                 }
             } else {
-                this._logger.warn(`${this.namespaceLog} Alias ${id} has no target 8`);
-                return tools.maybeCallbackWithError(callback, `Alias ${id} has no target`);
+                // alias object non-existing or points to nowhere -> handle it like a non-existing state
+                return tools.maybeCallbackWithError(callback, null, null);
             }
         } else {
             if (this.oStates && this.oStates[id]) {
@@ -9651,8 +9650,8 @@ export class AdapterClass extends EventEmitter {
             }
         } else if (aliasObj && aliasObj.type === 'state') {
             // if state and no id given -> if no state just ignore it
-            this._logger.warn(`${this.namespaceLog} Alias ${aliasObj._id} has no target 12`);
-            return tools.maybeCallbackWithError(callback, new Error(`Alias ${aliasObj._id} has no target 12`));
+            this._logger.warn(`${this.namespaceLog} Alias ${aliasObj._id} has no target 5`);
+            return tools.maybeCallbackWithError(callback, new Error(`Alias ${aliasObj._id} has no target`));
         } else {
             return tools.maybeCallback(callback);
         }

--- a/packages/controller/test/lib/testAliases.ts
+++ b/packages/controller/test/lib/testAliases.ts
@@ -1093,4 +1093,12 @@ export function register(it: Mocha.TestFunction, expect: Chai.ExpectStatic, cont
             context.adapter.getForeignStateAsync(nonAliasId, { user: 'system.user.userD' })
         ).to.be.eventually.rejectedWith('permissionError', 'Should have thrown a permission error');
     });
+
+    it(testName + 'Non-existing alias should return a null value just like other state', async () => {
+        const normalState = await context.adapter.getForeignStateAsync(`${gid}.isNotExisting`);
+        const aliasState = await context.adapter.getForeignStateAsync(`${gAliasID}.isNotExisting`);
+
+        expect(normalState).to.be.null;
+        expect(aliasState).to.be.equal(normalState);
+    });
 }


### PR DESCRIPTION
<!--
    Please adjust the PR title with prefix '[fix]:' or [feature]:' and delete the non-matching content below
-->

**Link the issue which is closed by this PR**
<!--
    If the PR closes the issue add a `closes #issue-no`. If no issue exists yet, please create an issue first.
-->
- closes #2611

**Implementation details**
<!--
    What has been changed?
-->
- Instead of throwing an error on `getState` we return `null` if getting an alias which has either no object at all or has no id configured, as this is like we try to get a non-existing id
- I have rearranged these alias numbers which hint to the place where the log came from, it was numbered till 12 but there are actually only 5 cases
- In one case it added the number to the error which was not consistent with the other occurrences, removed this

**Tests**
- [x] I have added tests to avoid a recursion of this bug
- [ ] It is not possible to test for this bug