### PR TITLE
[feature]: provide methods to list node modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,14 @@ if (result.success) {
 }
 ```
 
+To list all installed node modules by your adapter:
+
+```typescript
+const installedNodeModules = await adapter.listInstalledNodeModules();
+
+adapter.log.info(`Installed modules are: ${installedNodeModules.join(', ')}`);
+```
+
 ### Per host `adapter` objects
 **Feature status:** New in 6.0.0
 

--- a/packages/adapter/src/lib/adapter/adapter.ts
+++ b/packages/adapter/src/lib/adapter/adapter.ts
@@ -15,7 +15,8 @@ import {
     encryptArray,
     getSupportedFeatures,
     isMessageboxSupported,
-    getAdapterScopedPackageIdentifier
+    getAdapterScopedPackageIdentifier,
+    listInstalledNodeModules
 } from '@/lib/adapter/utils.js';
 // @ts-expect-error no ts file
 import extend from 'node.extend';
@@ -1254,6 +1255,13 @@ export class AdapterClass extends EventEmitter {
 
         const internalModuleName = getAdapterScopedPackageIdentifier({ moduleName, namespace: this.namespace });
         return tools.installNodeModule(`${internalModuleName}@npm:${moduleName}@${version}`);
+    }
+
+    /**
+     * List all additional installed node modules from this adapter
+     */
+    listInstalledNodeModules(): Promise<string[]> {
+        return listInstalledNodeModules(this.namespace);
     }
 
     uninstallNodeModule(moduleName: string): Promise<CommandResult>;

--- a/packages/adapter/src/lib/adapter/utils.ts
+++ b/packages/adapter/src/lib/adapter/utils.ts
@@ -9,8 +9,6 @@ import {
 import { SUPPORTED_FEATURES, type SupportedFeature } from '@/lib/adapter/constants.js';
 import path from 'node:path';
 import fs from 'fs-extra';
-import { Rule } from 'eslint';
-import Node = Rule.Node;
 
 interface EncryptArrayOptions {
     /** The objects whose values should be en/decrypted */

--- a/packages/adapter/src/lib/adapter/utils.ts
+++ b/packages/adapter/src/lib/adapter/utils.ts
@@ -3,9 +3,14 @@ import {
     isControllerUiUpgradeSupported,
     encrypt,
     decrypt,
-    appNameLowerCase
+    appNameLowerCase,
+    getRootDir
 } from '@iobroker/js-controller-common/tools';
 import { SUPPORTED_FEATURES, type SupportedFeature } from '@/lib/adapter/constants.js';
+import path from 'node:path';
+import fs from 'fs-extra';
+import { Rule } from 'eslint';
+import Node = Rule.Node;
 
 interface EncryptArrayOptions {
     /** The objects whose values should be en/decrypted */
@@ -97,4 +102,28 @@ export function getAdapterScopedPackageIdentifier(options: GetScopedPackageIdent
     }
 
     return `@${appNameLowerCase}-${namespace}/${internalModuleName}`;
+}
+
+/**
+ * List all packages installed in the given adapter namespace
+ *
+ * @param namespace namespace to check installed modules for
+ */
+export async function listInstalledNodeModules(namespace: string): Promise<string[]> {
+    const packJson = (await fs.readJson(path.join(getRootDir(), 'package.json'))) as {
+        dependencies: Record<string, string>;
+    };
+    const dependencies: string[] = [];
+
+    for (const [dependency, versionInfo] of Object.entries(packJson.dependencies)) {
+        if (!dependency.startsWith(`@${appNameLowerCase}-${namespace}/`)) {
+            continue;
+        }
+
+        // remove npm: and version after last @
+        const realDependencyName = versionInfo.substring(4, versionInfo.lastIndexOf('@'));
+        dependencies.push(realDependencyName);
+    }
+
+    return dependencies;
 }


### PR DESCRIPTION
**Link the feature issue which is closed by this PR**
<!--
If the PR closes an issue add a `closes #issue-no`. If no issue exists yet, please create an issue first to discuss with the core team if this feature is desirable.
-->
See discussion in https://github.com/ioBroker/ioBroker.javascript/issues/1554

**Implementation details**
<!--
    What has been changed?
-->

Added a method on adapter level to also list the node modules installed by the own adapter

**Tests**
- [ ] I have added tests to test this feature
- [x] It is not possible to test this feature

**Documentation**
<!--
    New features should be documented in the `README.md` file under `Feature Overview`. If a host message was added, please document it under `Feature Overview/js-controller Host Messages`.
-->
- [x] I have documented the new feature

**If no tests added, please specify why it was not possible**
<!--
    E.g. the feature is only triggered if the system runs low on memory.
-->

Not worth the effort lets test on recursion!