### PR TITLE
filter out empty string packages if apt outputs empty lines

### DIFF
--- a/packages/cli/src/lib/setup/setupPacketManager.ts
+++ b/packages/cli/src/lib/setup/setupPacketManager.ts
@@ -235,7 +235,7 @@ export class PacketManager {
             return [];
         }
 
-        const packagesList = res.split('\n');
+        const packagesList = res.split('\n').filter(packageName => packageName !== '');
         // first line is no package, just Listing...
         packagesList.shift();
 


### PR DESCRIPTION
**Link the issue which is closed by this PR**
<!--
    If the PR closes the issue add a `closes #issue-no`. If no issue exists yet, please create an issue first.
-->
- closes #2722

**Implementation details**
<!--
    What has been changed?
-->
If apt update outputs additional empty lines we filter them out


**Tests**
- [ ] I have added tests to avoid a recursion of this bug
- [x] It is not possible to test for this bug

**If no tests added, please specify why it was not possible**
<!--
    E.g. the bug is only reproducible if the system runs out of disk space.
-->
Would need refactoring of the method into a smaller submethod like `getPackagesFromStdout` which would then be testable as a unit test, but this would then be private or not exported so ugly to test currently. Maybe we will have a setup after testing has been extended to test such things nicely. Skipping for now.

