### PR TITLE
[fix]: allow other scopes than system but provide completion for system scope

### DIFF
--- a/packages/types-dev/index.d.ts
+++ b/packages/types-dev/index.d.ts
@@ -319,6 +319,7 @@ declare global {
                 | 'remoteHostErrors'
                 | 'restartLoop'
                 | 'fileToJsonl';
+            [other: string]: string;
         }
         interface AdapterConfig {
             // This is a stub to be augmented in every adapter

--- a/packages/types-public/index.test-d.ts
+++ b/packages/types-public/index.test-d.ts
@@ -991,10 +991,13 @@ async () => {
 };
 
 // Test registerNotification
-// @ts-expect-error
-adapter.registerNotification('foobar', 'accessErrors', 'This is a problem!');
+// @ts-expect-error known scope can only have defined category
+adapter.registerNotification('system', 'unknown', 'This is a problem!');
 adapter.registerNotification('system', 'accessErrors', 'This is a problem!');
 adapter.registerNotification('system', null, 'This is a problem!');
+// unknown scopes can have any category null | string
+adapter.registerNotification('someAdapter', null, 'This is a notification!');
+adapter.registerNotification('someAdapter', 'unknown', 'This is a notification!');
 
 // https://github.com/ioBroker/adapter-core/issues/429
 adapter.namespace === 'foo-bar.0';


### PR DESCRIPTION
**Link the issue which is closed by this PR**
<!--
    If the PR closes the issue add a `closes #issue-no`. If no issue exists yet, please create an issue first.
-->
- closes #2731

**Implementation details**
<!--
    What has been changed?
-->
We extended the definition of the `NotificationScope` to allow other unknown scopes with any category as long as type is `string | null`

**Tests**
- [x] I have added tests to avoid a recursion of this bug
- [ ] It is not possible to test for this bug