### PR TITLE
[fix]: make setTimeout/setInterval args generic to actually typecheck them

### DIFF
--- a/packages/adapter/src/lib/_Types.ts
+++ b/packages/adapter/src/lib/_Types.ts
@@ -343,7 +343,7 @@ export interface InternalGetEncryptedConfigOptions {
     callback?: GetEncryptedConfigCallback;
 }
 
-export type TimeoutCallback = (args?: any[]) => void;
+export type TimeoutCallback = (...args: any[]) => void;
 
 export interface InternalSetObjectOptions {
     id: string;

--- a/packages/adapter/src/lib/adapter/adapter.ts
+++ b/packages/adapter/src/lib/adapter/adapter.ts
@@ -2598,7 +2598,11 @@ export class AdapterClass extends EventEmitter {
     }
 
     // external signature
-    setTimeout(cb: TimeoutCallback, timeout: number, ...args: any[]): ioBroker.Timeout | undefined;
+    setTimeout<TCallback extends TimeoutCallback>(
+        cb: TCallback,
+        timeout: number,
+        ...args: Parameters<TCallback>
+    ): ioBroker.Timeout | undefined;
     /**
      * Same as setTimeout,
      * but it clears the running timers during the unload process
@@ -2685,7 +2689,11 @@ export class AdapterClass extends EventEmitter {
     }
 
     // external signature
-    setInterval(cb: TimeoutCallback, timeout: number, ...args: any[]): ioBroker.Interval | undefined;
+    setInterval<TCallback extends TimeoutCallback>(
+        cb: TCallback,
+        timeout: number,
+        ...args: Parameters<TCallback>
+    ): ioBroker.Interval | undefined;
 
     /**
      * Same as setInterval

--- a/packages/types-public/index.test-d.ts
+++ b/packages/types-public/index.test-d.ts
@@ -688,6 +688,16 @@ if (typeof state.common.smartName === 'object' && state.common.smartName !== nul
 declare let enumObj: ioBroker.EnumObject;
 enumObj.common.members && enumObj.common.members.map(() => 1);
 
+adapter.setInterval((_param1: number, _param2: string) => {}, 100, 100, '');
+// @ts-expect-error missing required parameter _param2
+adapter.setInterval((_param1: number, _param2: string) => {}, 100, 100);
+// @ts-expect-error wrong type of _param2
+adapter.setInterval((_param1: number, _param2: string) => {}, 100, 100, 1);
+adapter.setTimeout((_param1: number, _param2: string) => {}, 100, 100, '');
+// @ts-expect-error missing required parameter _param2
+adapter.setTimeout((_param1: number, _param2: string) => {}, 100, 100);
+// @ts-expect-error wrong type of _param2
+adapter.setTimeout((_param1: number, _param2: string) => {}, 100, 100, 1);
 // Adapter.clearTimeout and clearInterval are not compatible with the builtins
 adapter.clearTimeout(adapter.setTimeout(() => {}, 10));
 adapter.clearInterval(adapter.setInterval(() => {}, 10));


### PR DESCRIPTION
**Link the issue which is closed by this PR**
<!--
    If the PR closes the issue add a `closes #issue-no`. If no issue exists yet, please create an issue first.
-->
- closes #2733

**Implementation details**
<!--
    What has been changed?
-->
The `args` are now actually inferred from the parameters of the passed callback function

**Tests**
- [x] I have added tests to avoid a recursion of this bug
- [ ] It is not possible to test for this bug
