### PR TITLE
[fix]: do not crash if sentryObj is undefined

### DIFF
--- a/packages/controller/src/main.ts
+++ b/packages/controller/src/main.ts
@@ -3011,15 +3011,13 @@ async function processMessage(msg: ioBroker.SendableMessage): Promise<null | voi
             const level: string = msg.message.level;
             const extraInfo: Record<string, unknown> = msg.message.extraInfo;
 
-            const sentryInstance = pluginHandler.getPluginInstance('sentry');
+            // @ts-expect-error Plugin is not well typed and SentryPlugin has no types at all currently
+            const sentryObj = pluginHandler.getPluginInstance('sentry')?.getSentryObject();
 
-            if (!sentryInstance) {
+            if (!sentryObj) {
                 logger.debug(`${hostLogPrefix} Do not send message "${message}" to Sentry, because it is disabled`);
                 return;
             }
-
-            // @ts-expect-error Plugin is not well typed and SentryPlugin has no types at all currently
-            const sentryObj = sentryInstance.getSentryObject();
 
             sentryObj.withScope((scope: any) => {
                 scope.setLevel(level);


### PR DESCRIPTION
**Link the issue which is closed by this PR**
<!--
    If the PR closes the issue add a `closes #issue-no`. If no issue exists yet, please create an issue first.
-->
- closes #2737

**Implementation details**
<!--
    What has been changed?
-->
also check if the sentry object is undefined before calling methods on it

**Tests**
- [ ] I have added tests to avoid a recursion of this bug
- [x] It is not possible to test for this bug

**If no tests added, please specify why it was not possible**
<!--
    E.g. the bug is only reproducible if the system runs out of disk space.
-->
It would be better to type the plugin in the future to avoid this 