### PR TITLE
 [fix]: added adapter-core peer dependency

### DIFF
--- a/packages/controller/package.json
+++ b/packages/controller/package.json
@@ -39,6 +39,9 @@
     "semver": "^7.5.2",
     "tar": "^6.2.1"
   },
+  "peerDependencies": {
+    "@iobroker/adapter-core": "^2.6.11 || ^3.1.4"
+  },
   "homepage": "https://www.iobroker.com",
   "description": "Updated by reinstall.js on 2018-06-11T15:19:56.688Z",
   "keywords": [


### PR DESCRIPTION
**Link the issue which is closed by this PR**
<!--
    If the PR closes the issue add a `closes #issue-no`. If no issue exists yet, please create an issue first.
-->

- closes #2739

**Implementation details**
<!--
    What has been changed?
-->
`^2.6.11` and `^3.1.4` added as peer dependency to ensure correct version is installed which does no longer require non-existing Lets Encrypt export

**Tests**
- [ ] I have added tests to avoid a recursion of this bug
- [x] It is not possible to test for this bug

**If no tests added, please specify why it was not possible**
<!--
    E.g. the bug is only reproducible if the system runs out of disk space.
-->
just added a dependency, hard to test this as it is about interaction between adapter packages and controller and likely we do not need it to be tested
