### PR TITLE
[fix]: fix os package upgrade when restart is used

### DIFF
--- a/packages/controller/package.json
+++ b/packages/controller/package.json
@@ -98,7 +98,8 @@
       "types": "./build/esm/main.d.ts"
     },
     "./package.json": "./package.json",
-    "./io-package.json": "./io-package.json"
+    "./io-package.json": "./io-package.json",
+    "./iobroker.js": "./iobroker.js"
   },
   "license": "MIT",
   "files": [

--- a/packages/controller/package.json
+++ b/packages/controller/package.json
@@ -93,8 +93,8 @@
   "types": "build/esm/main.d.ts",
   "exports": {
     ".": {
-      "import": "./build/esm/index.js",
-      "require": "./build/cjs/index.js",
+      "import": "./build/esm/main.js",
+      "require": "./build/cjs/main.js",
       "types": "./build/esm/main.d.ts"
     },
     "./package.json": "./package.json",

--- a/packages/controller/src/main.ts
+++ b/packages/controller/src/main.ts
@@ -2976,7 +2976,7 @@ async function processMessage(msg: ioBroker.SendableMessage): Promise<null | voi
         }
 
         case 'upgradeOsPackages': {
-            const { packages, restart } = msg.message;
+            const { packages, restart: restartRequired } = msg.message;
 
             try {
                 await upgradeOsPackages(packages);
@@ -2991,7 +2991,7 @@ async function processMessage(msg: ioBroker.SendableMessage): Promise<null | voi
                 logger.warn(`${hostLogPrefix} Could not check for new OS updates after upgrade: ${e.message}`);
             }
 
-            if (restart) {
+            if (restartRequired) {
                 await wait(200);
                 restart(() => !isStopping && stop(false));
             }


### PR DESCRIPTION
**Link the issue which is closed by this PR**
<!--
    If the PR closes the issue add a `closes #issue-no`. If no issue exists yet, please create an issue first.
-->
Feature not yet live

**Implementation details**
<!--
    What has been changed?
-->
there was a name conflict that the scoped variable had the same name as the restart function

**Tests**
- [ ] I have added tests to avoid a recursion of this bug
- [x] It is not possible to test for this bug

**If no tests added, please specify why it was not possible**
<!--
    E.g. the bug is only reproducible if the system runs out of disk space.
-->
Feature not yet live