### PR TITLE
[fix]: optimize setState promise types

### DIFF
--- a/packages/adapter/src/lib/adapter/adapter.ts
+++ b/packages/adapter/src/lib/adapter/adapter.ts
@@ -7634,7 +7634,7 @@ export class AdapterClass extends EventEmitter {
      * ack, options and callback are optional
      *
      * @param id object ID of the state.
-     * @param state simple value or object with attribues.
+     * @param state simple value or object with attributes.
      *  If state is object and ack exists too as function argument, function argument has priority.
      *  ```js
      *      {

--- a/packages/adapter/src/lib/adapter/adapter.ts
+++ b/packages/adapter/src/lib/adapter/adapter.ts
@@ -7605,26 +7605,26 @@ export class AdapterClass extends EventEmitter {
         id: string | ioBroker.IdObject,
         state: ioBroker.State | ioBroker.StateValue | ioBroker.SettableState,
         callback?: T
-    ): T extends ioBroker.SetStateCallback ? void : ioBroker.SetStatePromise;
-    setState<T extends ioBroker.SetStateCallback>(
+    ): T extends unknown ? ioBroker.SetStatePromise : void;
+    setState<T extends ioBroker.SetStateCallback | undefined>(
         id: string | ioBroker.IdObject,
         state: ioBroker.State | ioBroker.StateValue | ioBroker.SettableState,
         ack: boolean,
         callback?: T
-    ): T extends ioBroker.SetStateCallback ? void : ioBroker.SetStatePromise;
-    setState<T extends ioBroker.SetStateCallback>(
+    ): T extends unknown ? ioBroker.SetStatePromise : void;
+    setState<T extends ioBroker.SetStateCallback | undefined>(
         id: string | ioBroker.IdObject,
         state: ioBroker.State | ioBroker.StateValue | ioBroker.SettableState,
         options?: Partial<GetUserGroupsOptions> | null,
         callback?: T
-    ): T extends ioBroker.SetStateCallback ? void : ioBroker.SetStatePromise;
-    setState<T extends ioBroker.SetStateCallback>(
+    ): T extends unknown ? ioBroker.SetStatePromise : void;
+    setState<T extends ioBroker.SetStateCallback | undefined>(
         id: string | ioBroker.IdObject,
         state: ioBroker.State | ioBroker.StateValue | ioBroker.SettableState,
         ack: boolean,
         options?: Partial<GetUserGroupsOptions> | null,
         callback?: T
-    ): T extends ioBroker.SetStateCallback ? void : ioBroker.SetStatePromise;
+    ): T extends unknown ? ioBroker.SetStatePromise : void;
 
     /**
      * Writes value into states DB.

--- a/packages/types-public/index.test-d.ts
+++ b/packages/types-public/index.test-d.ts
@@ -144,6 +144,12 @@ adapter.setState('state.name', { val: 'value', ack: true, q: adapter.constants.S
 // @ts-expect-error invalid quality
 adapter.setState('state.name', { val: 'value', ack: true, q: 1234 });
 
+// setState without callback is returning a promise
+adapter.setState('state.name', true, true).then(id => id.toLowerCase());
+adapter.setState('state.name', true).then(id => id.toLowerCase());
+adapter.setState('state.name', true, {}).then(id => id.toLowerCase());
+adapter.setState('state.name', true, true, {}).then(id => id.toLowerCase());
+
 adapter.setStateAsync('state.name', 'value').then(id => id.toLowerCase());
 adapter.setStateAsync('state.name', 'value', true).then(id => id.toLowerCase());
 adapter.setStateAsync('state.name', { val: 'value', ack: true }).then(id => id.toLowerCase());


### PR DESCRIPTION
**Link the issue which is closed by this PR**
<!--
    If the PR closes the issue add a `closes #issue-no`. If no issue exists yet, please create an issue first.
-->
Came up in TG by @mcm1957 

**Implementation details**
<!--
    What has been changed?
-->
Make the default generic `T` also allow to be undefined and make the generic check vice versa so the return type is correctly inferred, also added tests for this

**Tests**
- [x] I have added tests to avoid a recursion of this bug
- [ ] It is not possible to test for this bug
