### PR TITLE
[fix]: Added letsencrypt shim

### DIFF
--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -5,3 +5,6 @@ export { password } from '@/lib/common/password.js';
 export { logger } from '@/lib/common/logger.js';
 export { defaultRedisInterview } from '@/lib/common/interview.js';
 export * as constants from '@/lib/common/constants.js';
+
+/** This is a backward compatibility shim, if all adapters are on adapter-core 2.6.11 or 3.1.4 remove this */
+export const letsencrypt = null;


### PR DESCRIPTION
as we cannot ensure adapter-core version 2.6.11 we add a simple shim to avoid the crashes

This should then trigger https://github.com/ioBroker/adapter-core/blob/48d330f6a4d2722f34d3fe6909dcbffab8c96343/src/controllerTools.ts#L68 and avoid the crash