### PR TITLE
[fix]: Fix session

### DIFF
--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -5,6 +5,7 @@ export { password } from '@/lib/common/password.js';
 export { logger } from '@/lib/common/logger.js';
 export { defaultRedisInterview } from '@/lib/common/interview.js';
 export * as constants from '@/lib/common/constants.js';
+export { createAdapterStore as session } from '@/lib/common/session.js';
 
 /** This is a backward compatibility shim, if all adapters are on adapter-core 2.6.11 or 3.1.4 remove this */
 export const letsencrypt = null;

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -5,3 +5,6 @@ export { password } from '@/lib/common/password.js';
 export { logger } from '@/lib/common/logger.js';
 export { defaultRedisInterview } from '@/lib/common/interview.js';
 export * as constants from '@/lib/common/constants.js';
+
+/** This is a backward compatibility shim, if all adapters are on adapter-core 2.6.11 or 3.1.4 remove this */
+export const letsencrypt = null;

--- a/packages/common/src/lib/common/session.ts
+++ b/packages/common/src/lib/common/session.ts
@@ -1,10 +1,26 @@
-export default function createAdapterStore(session, defaultTtl = 3600) {
+type Session = any;
+
+// TODO: in the long term move this file somewhere where we have types access it is nowhere used in controller itself and just exported for adapters so it should go to js-controller-adapter package
+interface AdapterStoreOptions {
+    /** The ioBroker adapter */
+    adapter: any;
+    /** The cookie */
+    cookie: any;
+}
+
+/**
+ * Function to create an AdapterStore constructor
+ *
+ * @param session The session object
+ * @param defaultTtl the default time to live
+ * @returns the constructor to create a new AdapterStore
+ */
+export function createAdapterStore(session: Session, defaultTtl = 3600): any {
     const Store = session.Store;
 
     class AdapterStore extends Store {
-        constructor(options) {
+        constructor(options: AdapterStoreOptions) {
             super(options);
-            // const that = this;
 
             this.adapter = options.adapter;
 
@@ -18,12 +34,11 @@ export default function createAdapterStore(session, defaultTtl = 3600) {
         /**
          * Attempt to fetch session by the given `sid`.
          *
-         * @param {String} sid Session ID
-         * @param {Function} fn callback
-         * @api public
+         * @param sid Session ID
+         * @param fn callback
          */
-        get(sid, fn) {
-            this.adapter.getSession(sid, obj => {
+        get(sid: string, fn: (err?: any, obj?: any) => void): void {
+            this.adapter.getSession(sid, (obj: any) => {
                 if (obj) {
                     if (fn) {
                         return fn(null, obj);
@@ -39,13 +54,12 @@ export default function createAdapterStore(session, defaultTtl = 3600) {
         /**
          * Commit the given `sess` object associated with the given `sid`.
          *
-         * @param {String} sid Session ID
-         * @param {Number} ttl Time to live
-         * @param {Session} sess
-         * @param {Function} fn callback
-         * @api public
+         * @param sid Session ID
+         * @param ttl Time to live
+         * @param sess the session
+         * @param fn callback
          */
-        set(sid, ttl, sess, fn) {
+        set(sid: string, ttl: number, sess: Session, fn: (args: any) => void): void {
             if (typeof ttl === 'object') {
                 fn = sess;
                 sess = ttl;
@@ -57,6 +71,8 @@ export default function createAdapterStore(session, defaultTtl = 3600) {
             }
             ttl = ttl || defaultTtl;
             this.adapter.setSession(sid, ttl, sess, function () {
+                // @ts-expect-error fix later
+                // eslint-disable-next-line prefer-rest-params
                 fn && fn.apply(this, arguments);
             }); // do not use here => !!!
         }
@@ -64,11 +80,10 @@ export default function createAdapterStore(session, defaultTtl = 3600) {
         /**
          * Destroy the session associated with the given `sid`.
          *
-         * @param {String} sid Session ID
-         * @param {Function} fn callback
-         * @api public
+         * @param sid Session ID
+         * @param fn callback
          */
-        destroy(sid, fn) {
+        destroy(sid: string, fn: () => void): void {
             this.adapter.destroySession(sid, fn);
         }
     }


### PR DESCRIPTION
**Link the issue which is closed by this PR**
<!--
    If the PR closes the issue add a `closes #issue-no`. If no issue exists yet, please create an issue first.
-->
During alpha test it occured, that session is no longer a function itself as it would now need to be called `session.default()` due to ESM 

**Implementation details**
<!--
    What has been changed?
-->
it is not used in controller itself just exported for other adapters, hence we moved it to tools where adapter-core can access it and we re-export it from there, in the long term it should move to adapter package as it is only existing for adapters purpose

**Tests**
- [ ] I have added tests to avoid a recursion of this bug
- [x] It is not possible to test for this bug

**If no tests added, please specify why it was not possible**
<!--
    E.g. the bug is only reproducible if the system runs out of disk space.
-->

Just a moved export needs to be tested in adapter-core