### PR TITLE
[fix]: Prevent multiple publishes of alias states if subscribed more than once

### DIFF
--- a/packages/adapter/src/lib/adapter/adapter.ts
+++ b/packages/adapter/src/lib/adapter/adapter.ts
@@ -10969,7 +10969,7 @@ export class AdapterClass extends EventEmitter {
                             }
                         }
                     }
-                } else if (this.adapterReady && this.aliases.has(id)) {
+                } else if (!this._stopInProgress && this.adapterReady && this.aliases.has(id)) {
                     // If adapter is ready and for this ID exist some alias links
                     const alias = this.aliases.get(id);
                     /** Prevent multiple publishes if multiple pattern contain this alias id */
@@ -10997,7 +10997,7 @@ export class AdapterClass extends EventEmitter {
                               })
                             : null;
 
-                        if (!this._stopInProgress && (aState || !state)) {
+                        if (aState || !state) {
                             if (typeof this._options.stateChange === 'function') {
                                 this._options.stateChange(targetId, aState);
                             } else {

--- a/packages/adapter/src/lib/adapter/adapter.ts
+++ b/packages/adapter/src/lib/adapter/adapter.ts
@@ -10972,8 +10972,19 @@ export class AdapterClass extends EventEmitter {
                 } else if (this.adapterReady && this.aliases.has(id)) {
                     // If adapter is ready and for this ID exist some alias links
                     const alias = this.aliases.get(id);
-                    alias!.targets.forEach(target => {
+                    /** Prevent multiple publishes if multiple pattern contain this alias id */
+                    const uniqueTargets = new Set<string>();
+
+                    for (const target of alias!.targets) {
+                        const targetId = target.id;
+                        if (uniqueTargets.has(targetId)) {
+                            continue;
+                        }
+
+                        uniqueTargets.add(targetId);
+
                         const source = alias!.source!;
+
                         const aState = state
                             ? tools.formatAliasValue({
                                   sourceCommon: source,
@@ -10982,11 +10993,9 @@ export class AdapterClass extends EventEmitter {
                                   logger: this._logger,
                                   logNamespace: this.namespaceLog,
                                   sourceId: id,
-                                  targetId: target.id
+                                  targetId
                               })
                             : null;
-
-                        const targetId = target.id;
 
                         if (!this._stopInProgress && (aState || !state)) {
                             if (typeof this._options.stateChange === 'function') {
@@ -10996,7 +11005,7 @@ export class AdapterClass extends EventEmitter {
                                 setImmediate(() => this.emit('stateChange', targetId, aState));
                             }
                         }
-                    });
+                    }
                 }
             },
             changeUser: (id, state) => {

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -5,6 +5,7 @@ export { password } from '@/lib/common/password.js';
 export { logger } from '@/lib/common/logger.js';
 export { defaultRedisInterview } from '@/lib/common/interview.js';
 export * as constants from '@/lib/common/constants.js';
+export { createAdapterStore as session } from '@/lib/common/session.js';
 
 /** This is a backward compatibility shim, if all adapters are on adapter-core 2.6.11 or 3.1.4 remove this */
 export const letsencrypt = null;

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -5,3 +5,6 @@ export { password } from '@/lib/common/password.js';
 export { logger } from '@/lib/common/logger.js';
 export { defaultRedisInterview } from '@/lib/common/interview.js';
 export * as constants from '@/lib/common/constants.js';
+
+/** This is a backward compatibility shim, if all adapters are on adapter-core 2.6.11 or 3.1.4 remove this */
+export const letsencrypt = null;

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -8,4 +8,4 @@ export * as constants from '@/lib/common/constants.js';
 export { createAdapterStore as session } from '@/lib/common/session.js';
 
 /** This is a backward compatibility shim, if all adapters are on adapter-core 2.6.11 or 3.1.4 remove this */
-export const letsencrypt = null;
+export const letsencrypt = true;

--- a/packages/common/src/lib/common/session.ts
+++ b/packages/common/src/lib/common/session.ts
@@ -1,10 +1,26 @@
-export default function createAdapterStore(session, defaultTtl = 3600) {
+type Session = any;
+
+// TODO: in the long term move this file somewhere where we have types access it is nowhere used in controller itself and just exported for adapters so it should go to js-controller-adapter package
+interface AdapterStoreOptions {
+    /** The ioBroker adapter */
+    adapter: any;
+    /** The cookie */
+    cookie: any;
+}
+
+/**
+ * Function to create an AdapterStore constructor
+ *
+ * @param session The session object
+ * @param defaultTtl the default time to live
+ * @returns the constructor to create a new AdapterStore
+ */
+export function createAdapterStore(session: Session, defaultTtl = 3600): any {
     const Store = session.Store;
 
     class AdapterStore extends Store {
-        constructor(options) {
+        constructor(options: AdapterStoreOptions) {
             super(options);
-            // const that = this;
 
             this.adapter = options.adapter;
 
@@ -18,12 +34,11 @@ export default function createAdapterStore(session, defaultTtl = 3600) {
         /**
          * Attempt to fetch session by the given `sid`.
          *
-         * @param {String} sid Session ID
-         * @param {Function} fn callback
-         * @api public
+         * @param sid Session ID
+         * @param fn callback
          */
-        get(sid, fn) {
-            this.adapter.getSession(sid, obj => {
+        get(sid: string, fn: (err?: any, obj?: any) => void): void {
+            this.adapter.getSession(sid, (obj: any) => {
                 if (obj) {
                     if (fn) {
                         return fn(null, obj);
@@ -39,13 +54,12 @@ export default function createAdapterStore(session, defaultTtl = 3600) {
         /**
          * Commit the given `sess` object associated with the given `sid`.
          *
-         * @param {String} sid Session ID
-         * @param {Number} ttl Time to live
-         * @param {Session} sess
-         * @param {Function} fn callback
-         * @api public
+         * @param sid Session ID
+         * @param ttl Time to live
+         * @param sess the session
+         * @param fn callback
          */
-        set(sid, ttl, sess, fn) {
+        set(sid: string, ttl: number, sess: Session, fn: (args: any) => void): void {
             if (typeof ttl === 'object') {
                 fn = sess;
                 sess = ttl;
@@ -57,6 +71,8 @@ export default function createAdapterStore(session, defaultTtl = 3600) {
             }
             ttl = ttl || defaultTtl;
             this.adapter.setSession(sid, ttl, sess, function () {
+                // @ts-expect-error fix later
+                // eslint-disable-next-line prefer-rest-params
                 fn && fn.apply(this, arguments);
             }); // do not use here => !!!
         }
@@ -64,11 +80,10 @@ export default function createAdapterStore(session, defaultTtl = 3600) {
         /**
          * Destroy the session associated with the given `sid`.
          *
-         * @param {String} sid Session ID
-         * @param {Function} fn callback
-         * @api public
+         * @param sid Session ID
+         * @param fn callback
          */
-        destroy(sid, fn) {
+        destroy(sid: string, fn: () => void): void {
             this.adapter.destroySession(sid, fn);
         }
     }

--- a/packages/controller/src/main.ts
+++ b/packages/controller/src/main.ts
@@ -1996,7 +1996,7 @@ async function processMessage(msg: ioBroker.SendableMessage): Promise<null | voi
             break;
 
         case 'cmdExec': {
-            const mainFile = path.join(thisDir, '..', `${tools.appName.toLowerCase()}.js`);
+            const mainFile = path.join(tools.getControllerDir(), `${tools.appName.toLowerCase()}.js`);
             const args = [...getDefaultNodeArgs(mainFile), mainFile];
             if (!msg.message.data || typeof msg.message.data !== 'string') {
                 logger.warn(

--- a/packages/controller/src/main.ts
+++ b/packages/controller/src/main.ts
@@ -3436,7 +3436,7 @@ function installAdapters(): void {
             );
         }
 
-        const mainFile = path.join(thisDir, '..', `${tools.appName.toLowerCase()}.js`);
+        const mainFile = path.join(tools.getControllerDir(), `${tools.appName.toLowerCase()}.js`);
         const installArgs = [];
         const installOptions = { windowsHide: true };
         if (!task.rebuild && task.installedFrom && proc.downloadRetry < 3) {
@@ -3543,7 +3543,7 @@ function installAdapters(): void {
             });
             child.on('error', err => {
                 logger.error(
-                    `${hostLogPrefix} Cannot execute "${thisDir}/${tools.appName.toLowerCase()}.js ${commandScope} ${name}: ${
+                    `${hostLogPrefix} Cannot execute "${tools.getControllerDir()}/${tools.appName.toLowerCase()}.js ${commandScope} ${name}: ${
                         err.message
                     }`
                 );
@@ -3554,7 +3554,7 @@ function installAdapters(): void {
             });
         } catch (err) {
             logger.error(
-                `${hostLogPrefix} Cannot execute "${thisDir}/${tools.appName.toLowerCase()}.js ${commandScope} ${name}: ${err}`
+                `${hostLogPrefix} Cannot execute "${tools.getControllerDir()}/${tools.appName.toLowerCase()}.js ${commandScope} ${name}: ${err}`
             );
             setTimeout(() => {
                 installQueue.shift();

--- a/packages/controller/test/lib/testAliases.ts
+++ b/packages/controller/test/lib/testAliases.ts
@@ -509,8 +509,6 @@ export function register(it: Mocha.TestFunction, expect: Chai.ExpectStatic, cont
 
         await context.states.setState(gid, 10);
         await wait(500);
-        console.log('111111111');
-        console.log(noTriggered);
 
         expect(noTriggered).to.equal(1);
     }).timeout(3_000);


### PR DESCRIPTION
**Link the issue which is closed by this PR**
<!--
    If the PR closes the issue add a `closes #issue-no`. If no issue exists yet, please create an issue first.
-->
- closes #2753 

**Implementation details**
<!--
    What has been changed?
-->
Introduced a set to check if the alias has already been published once for this adapter if it is affected by multiple subscribes

**Tests**
- [x] I have added tests to avoid a recursion of this bug
- [ ] It is not possible to test for this bug
