### PR TITLE
[feature]: Next approach for ensuring compatible dapter core package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -791,6 +791,15 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@iobroker/adapter-core": {
+      "version": "2.6.11",
+      "resolved": "https://registry.npmjs.org/@iobroker/adapter-core/-/adapter-core-2.6.11.tgz",
+      "integrity": "sha512-jUEdxDbPU05FCA2PnSwrETVg8Og0p15vFZGToAGxU0xbHXFRvCc9UZtOw+J+Z8E9Yn9O/8Nv4whXbmMVDffvqw==",
+      "peer": true,
+      "dependencies": {
+        "@types/iobroker": "^4.0.5"
+      }
+    },
     "node_modules/@iobroker/db-base": {
       "resolved": "packages/db-base",
       "link": true
@@ -2185,6 +2194,15 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/iobroker": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/iobroker/-/iobroker-4.0.5.tgz",
+      "integrity": "sha512-D1tJwuDQEQQQ/cZVFjFjFUhUuMxJbfrz5U2UooiZwhgs69D/t8IowMvBI6Lk4ZR8HnCSxYwWHVRKyQnEMNgJPA==",
+      "peer": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/ioredis": {
       "version": "4.28.10",
       "dev": true,
@@ -2247,7 +2265,6 @@
       "version": "18.19.31",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.31.tgz",
       "integrity": "sha512-ArgCD39YpyyrtFKIqMDvjz79jto5fcI/SVUs2HwB+f0dAzq68yqOdyaSivLiLugSziTpNXLQrVb7RZFmdZzbhA==",
-      "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -13010,8 +13027,7 @@
     "node_modules/undici-types": {
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "dev": true
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
     "node_modules/unique-filename": {
       "version": "3.0.0",
@@ -13874,6 +13890,9 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@iobroker/adapter-core": "2.6.11"
       }
     },
     "packages/db-base": {
@@ -14517,6 +14536,15 @@
       "resolved": "https://registry.npmjs.org/@hutson/parse-repository-url/-/parse-repository-url-3.0.2.tgz",
       "integrity": "sha512-H9XAx3hc0BQHY6l+IFSWHDySypcXsvsuLhgYLUGywmJ5pswRVQJUHpOsobnLYp2ZUaUlKiKDrgWWhosOwAEM8Q==",
       "dev": true
+    },
+    "@iobroker/adapter-core": {
+      "version": "2.6.11",
+      "resolved": "https://registry.npmjs.org/@iobroker/adapter-core/-/adapter-core-2.6.11.tgz",
+      "integrity": "sha512-jUEdxDbPU05FCA2PnSwrETVg8Og0p15vFZGToAGxU0xbHXFRvCc9UZtOw+J+Z8E9Yn9O/8Nv4whXbmMVDffvqw==",
+      "peer": true,
+      "requires": {
+        "@types/iobroker": "^4.0.5"
+      }
     },
     "@iobroker/db-base": {
       "version": "file:packages/db-base",
@@ -15747,6 +15775,15 @@
         "@types/node": "*"
       }
     },
+    "@types/iobroker": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/iobroker/-/iobroker-4.0.5.tgz",
+      "integrity": "sha512-D1tJwuDQEQQQ/cZVFjFjFUhUuMxJbfrz5U2UooiZwhgs69D/t8IowMvBI6Lk4ZR8HnCSxYwWHVRKyQnEMNgJPA==",
+      "peer": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/ioredis": {
       "version": "4.28.10",
       "dev": true,
@@ -15804,7 +15841,6 @@
       "version": "18.19.31",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.31.tgz",
       "integrity": "sha512-ArgCD39YpyyrtFKIqMDvjz79jto5fcI/SVUs2HwB+f0dAzq68yqOdyaSivLiLugSziTpNXLQrVb7RZFmdZzbhA==",
-      "dev": true,
       "requires": {
         "undici-types": "~5.26.4"
       }
@@ -23259,8 +23295,7 @@
     "undici-types": {
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "dev": true
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
     "unique-filename": {
       "version": "3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -792,12 +792,12 @@
       }
     },
     "node_modules/@iobroker/adapter-core": {
-      "version": "2.6.11",
-      "resolved": "https://registry.npmjs.org/@iobroker/adapter-core/-/adapter-core-2.6.11.tgz",
-      "integrity": "sha512-jUEdxDbPU05FCA2PnSwrETVg8Og0p15vFZGToAGxU0xbHXFRvCc9UZtOw+J+Z8E9Yn9O/8Nv4whXbmMVDffvqw==",
+      "version": "2.6.12",
+      "resolved": "https://registry.npmjs.org/@iobroker/adapter-core/-/adapter-core-2.6.12.tgz",
+      "integrity": "sha512-vM3EO8ZvZFuIcRfNYOeoY+e4GP/BHBeMrrZNQegSwIywHZNZR3ZlFbkhSTwnf6qREIpLo8zJ2r1wHMJWD5ENkw==",
       "peer": true,
       "dependencies": {
-        "@types/iobroker": "^4.0.5"
+        "@iobroker/types": "*"
       }
     },
     "node_modules/@iobroker/db-base": {
@@ -2194,15 +2194,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/iobroker": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@types/iobroker/-/iobroker-4.0.5.tgz",
-      "integrity": "sha512-D1tJwuDQEQQQ/cZVFjFjFUhUuMxJbfrz5U2UooiZwhgs69D/t8IowMvBI6Lk4ZR8HnCSxYwWHVRKyQnEMNgJPA==",
-      "peer": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/ioredis": {
       "version": "4.28.10",
       "dev": true,
@@ -2265,6 +2256,7 @@
       "version": "18.19.31",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.31.tgz",
       "integrity": "sha512-ArgCD39YpyyrtFKIqMDvjz79jto5fcI/SVUs2HwB+f0dAzq68yqOdyaSivLiLugSziTpNXLQrVb7RZFmdZzbhA==",
+      "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -13027,7 +13019,8 @@
     "node_modules/undici-types": {
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
     },
     "node_modules/unique-filename": {
       "version": "3.0.0",
@@ -13892,7 +13885,7 @@
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "@iobroker/adapter-core": "2.6.11"
+        "@iobroker/adapter-core": "^2.6.12"
       }
     },
     "packages/db-base": {
@@ -14538,12 +14531,12 @@
       "dev": true
     },
     "@iobroker/adapter-core": {
-      "version": "2.6.11",
-      "resolved": "https://registry.npmjs.org/@iobroker/adapter-core/-/adapter-core-2.6.11.tgz",
-      "integrity": "sha512-jUEdxDbPU05FCA2PnSwrETVg8Og0p15vFZGToAGxU0xbHXFRvCc9UZtOw+J+Z8E9Yn9O/8Nv4whXbmMVDffvqw==",
+      "version": "2.6.12",
+      "resolved": "https://registry.npmjs.org/@iobroker/adapter-core/-/adapter-core-2.6.12.tgz",
+      "integrity": "sha512-vM3EO8ZvZFuIcRfNYOeoY+e4GP/BHBeMrrZNQegSwIywHZNZR3ZlFbkhSTwnf6qREIpLo8zJ2r1wHMJWD5ENkw==",
       "peer": true,
       "requires": {
-        "@types/iobroker": "^4.0.5"
+        "@iobroker/types": "*"
       }
     },
     "@iobroker/db-base": {
@@ -15775,15 +15768,6 @@
         "@types/node": "*"
       }
     },
-    "@types/iobroker": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@types/iobroker/-/iobroker-4.0.5.tgz",
-      "integrity": "sha512-D1tJwuDQEQQQ/cZVFjFjFUhUuMxJbfrz5U2UooiZwhgs69D/t8IowMvBI6Lk4ZR8HnCSxYwWHVRKyQnEMNgJPA==",
-      "peer": true,
-      "requires": {
-        "@types/node": "*"
-      }
-    },
     "@types/ioredis": {
       "version": "4.28.10",
       "dev": true,
@@ -15841,6 +15825,7 @@
       "version": "18.19.31",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.31.tgz",
       "integrity": "sha512-ArgCD39YpyyrtFKIqMDvjz79jto5fcI/SVUs2HwB+f0dAzq68yqOdyaSivLiLugSziTpNXLQrVb7RZFmdZzbhA==",
+      "dev": true,
       "requires": {
         "undici-types": "~5.26.4"
       }
@@ -23295,7 +23280,8 @@
     "undici-types": {
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
     },
     "unique-filename": {
       "version": "3.0.0",

--- a/packages/cli/src/lib/setup/setupSetup.ts
+++ b/packages/cli/src/lib/setup/setupSetup.ts
@@ -192,9 +192,6 @@ export class Setup {
             console.error(`Could not ensure that adapters object for this host exists: ${e.message}`);
         }
 
-        if (!process.env.CI) {
-            await this._updatePackages();
-        }
         await this._cleanupInstallation();
 
         // special methods which are only there on objects server
@@ -1196,21 +1193,6 @@ Please DO NOT copy files manually into ioBroker storage directories!`
             await this._cleanupForbiddenIds();
         } catch (e) {
             console.error(`Cannot clean up objects and states with forbidden IDs: ${e.message}`);
-        }
-    }
-
-    /**
-     * Performs `npm update` to ensure adapters deps are updated to the newest available packages in-range
-     * This allows e.g. hot fixing in adapter-core and backport of critical fixes
-     */
-    private async _updatePackages(): Promise<void> {
-        console.log('Updating dependencies...');
-
-        try {
-            const pakManager = await tools.detectPackageManagerWithFallback(tools.getRootDir());
-            await pakManager.update();
-        } catch (e) {
-            console.error(`Could not update dependencies: ${e.message}`);
         }
     }
 

--- a/packages/controller/package.json
+++ b/packages/controller/package.json
@@ -9,7 +9,7 @@
     "iobroker": "./iobroker.js"
   },
   "peerDependencies": {
-    "@iobroker/adapter-core": "^2.6.11"
+    "@iobroker/adapter-core": "^2.6.12"
   },
   "dependencies": {
     "@alcalzone/esbuild-register": "^2.5.1-1",

--- a/packages/controller/package.json
+++ b/packages/controller/package.json
@@ -8,6 +8,9 @@
   "bin": {
     "iobroker": "./iobroker.js"
   },
+  "peerDependencies": {
+    "@iobroker/adapter-core": "^2.6.11"
+  },
   "dependencies": {
     "@alcalzone/esbuild-register": "^2.5.1-1",
     "@iobroker/db-objects-file": "file:../db-objects-file",


### PR DESCRIPTION
**Link the feature issue which is closed by this PR**
<!--
If the PR closes an issue add a `closes #issue-no`. If no issue exists yet, please create an issue first to discuss with the core team if this feature is desirable.
-->
still trying to ensure outdated adapter core versions get updated

**Implementation details**
<!--
    What has been changed?
-->
As the approach with `or` isn't working as normally `3.1.4` is already satisfied, we explicity only require `2.9.11` to get the adapters without frequent updates updated


**Tests**
- [ ] I have added tests to test this feature
- [x] It is not possible to test this feature

**Documentation**
<!--
    New features should be documented in the `README.md` file under `Feature Overview`. If a host message was added, please document it under `Feature Overview/js-controller Host Messages`.
-->
- [ ] I have documented the new feature

**If no tests added, please specify why it was not possible**
<!--
    E.g. the feature is only triggered if the system runs low on memory.
-->
nothing to test