### PR TITLE
[fix]: also allow device as top level object type for instance

### DIFF
--- a/packages/adapter/src/lib/adapter/adapter.ts
+++ b/packages/adapter/src/lib/adapter/adapter.ts
@@ -11799,8 +11799,14 @@ export class AdapterClass extends EventEmitter {
             for (const instObj of instanceObj.instanceObjects) {
                 const obj: IoPackageInstanceObject & { state?: unknown } = instObj;
 
+                const allowedTopLevelTypes: ioBroker.ObjectType[] = ['meta', 'device'];
+
                 // the object comes from non-checked io-package, so treat the id as unknown
-                if (!obj || typeof (obj._id as unknown) !== 'string' || (!obj._id && obj.type !== 'meta')) {
+                if (
+                    !obj ||
+                    typeof (obj._id as unknown) !== 'string' ||
+                    (obj._id === '' && !allowedTopLevelTypes.includes(obj.type))
+                ) {
                     this._logger.error(
                         `${this.namespaceLog} ${this.namespace} invalid instance object: ${JSON.stringify(obj)}`
                     );


### PR DESCRIPTION
**Link the issue which is closed by this PR**
<!--
    If the PR closes the issue add a `closes #issue-no`. If no issue exists yet, please create an issue first.
-->
Came up during alpha test

**Implementation details**
<!--
    What has been changed?
-->
We had an exception to only allow `meta` but of course also `device` is fine

**Tests**
- [ ] I have added tests to avoid a recursion of this bug
- [x] It is not possible to test for this bug

**If no tests added, please specify why it was not possible**
<!--
    E.g. the bug is only reproducible if the system runs out of disk space.
-->
Needed to be done on adapter level