### PR TITLE
on windows setup first replace the root controller.js with the current content

### DIFF
--- a/packages/cli/src/lib/setup/setupSetup.ts
+++ b/packages/cli/src/lib/setup/setupSetup.ts
@@ -193,6 +193,7 @@ export class Setup {
         }
 
         if (process.platform === 'win32') {
+            // TODO: remove this fix after controller v6
             await this._fixWindowsControllerJs();
         }
 

--- a/packages/cli/src/lib/setup/setupSetup.ts
+++ b/packages/cli/src/lib/setup/setupSetup.ts
@@ -192,6 +192,10 @@ export class Setup {
             console.error(`Could not ensure that adapters object for this host exists: ${e.message}`);
         }
 
+        if (process.platform === 'win32') {
+            await this._fixWindowsControllerJs();
+        }
+
         await this._cleanupInstallation();
 
         // special methods which are only there on objects server
@@ -1153,6 +1157,20 @@ Please DO NOT copy files manually into ioBroker storage directories!`
             }
 
             await setupUpload.upgradeAdapterObjects(name);
+        }
+    }
+
+    /**
+     * Replace the `controller.js` file in the root directory to work with ESM
+     */
+    async _fixWindowsControllerJs(): Promise<void> {
+        const content = `import('./node_modules/iobroker.js-controller/controller.js');`;
+        const filePath = path.join(tools.getRootDir(), 'controller.js');
+
+        try {
+            await fs.writeFile(filePath, content, { encoding: 'utf-8' });
+        } catch (e) {
+            console.error(`Could not fix "${filePath}": ${e.message}`);
         }
     }
 


### PR DESCRIPTION
**Link the feature issue which is closed by this PR**
<!--
If the PR closes an issue add a `closes #issue-no`. If no issue exists yet, please create an issue first to discuss with the core team if this feature is desirable.
-->
Came up during alpha test

Else after update of existing installations via `npm i iobroker.js-controller` users need to run the fixer to update the file

**Implementation details**
<!--
    What has been changed?
-->
On `setup first` we override the `rootDir/controller.js` with ESM compatible `import` 

**Tests**
- [ ] I have added tests to test this feature
- [x] It is not possible to test this feature

**Documentation**
<!--
    New features should be documented in the `README.md` file under `Feature Overview`. If a host message was added, please document it under `Feature Overview/js-controller Host Messages`.
-->
- [ ] I have documented the new feature
not needed

**If no tests added, please specify why it was not possible**
<!--
    E.g. the feature is only triggered if the system runs low on memory.
-->
only do on occurrence of problems