### PR TITLE
Corrected repo update if more than one repository

### DIFF
--- a/packages/controller/src/main.ts
+++ b/packages/controller/src/main.ts
@@ -53,7 +53,6 @@ import {
     getDefaultNodeArgs,
     type HostInfo,
     isAdapterEsmModule,
-    type RepositoryFile
 } from '@iobroker/js-controller-common-db/tools';
 import type { UpgradeArguments } from '@/lib/upgradeManager.js';
 import { AdapterUpgradeManager } from '@/lib/adapterUpgradeManager.js';

--- a/packages/controller/src/main.ts
+++ b/packages/controller/src/main.ts
@@ -2134,27 +2134,23 @@ async function processMessage(msg: ioBroker.SendableMessage): Promise<null | voi
                                     `${hostLogPrefix} Updating repository "${repoUrl}" under "${currentRepo.link}"`
                                 );
                                 try {
-                                    let result: ioBroker.RepositoryInformation | RepositoryFile;
-                                    // prevent the request of repos by multiple admin adapters at start
                                     if (
-                                        currentRepo.json &&
-                                        currentRepo.time &&
-                                        currentRepo.hash &&
-                                        Date.now() - new Date(currentRepo.time).getTime() < 30_000
+                                        !currentRepo.json ||
+                                        !currentRepo.time ||
+                                        !currentRepo.hash ||
+                                        // prevent the request of repos by multiple admin adapters at start
+                                        Date.now() - new Date(currentRepo.time).getTime() >= 30_000
                                     ) {
-                                        result = currentRepo;
-                                    } else {
-                                        result = await tools.getRepositoryFileAsync(
+                                        const result = await tools.getRepositoryFileAsync(
                                             currentRepo.link,
                                             currentRepo.hash,
                                             updateRepo,
                                             currentRepo.json
                                         );
 
-                                        changed = changed || (result?.json && result.changed);
-
                                         // If repo was really changed
                                         if (result?.json && result.changed) {
+                                            changed = true;
                                             currentRepo.json = result.json;
                                             currentRepo.hash = result.hash || '';
                                             currentRepo.time = new Date().toISOString();

--- a/packages/controller/src/main.ts
+++ b/packages/controller/src/main.ts
@@ -2151,11 +2151,11 @@ async function processMessage(msg: ioBroker.SendableMessage): Promise<null | voi
                                             currentRepo.json
                                         );
 
-                                        changed = result.json && result.changed;
+                                        changed = changed || (result?.json && result.changed);
                                     }
 
                                     // If repo was really changed
-                                    if (changed) {
+                                    if (result?.json && result.changed) {
                                         currentRepo.json = result.json;
                                         currentRepo.hash = result.hash || '';
                                         currentRepo.time = new Date().toISOString();
@@ -2181,8 +2181,10 @@ async function processMessage(msg: ioBroker.SendableMessage): Promise<null | voi
                         }
                     }
 
-                    if (changed) {
+                    if (changed || updateRepo) {
                         try {
+                            // we must update the repository object, as admin will retry every time by restart
+                            systemRepos.ts = Date.now();
                             await objects!.setObjectAsync(SYSTEM_REPOSITORIES_ID, systemRepos);
                         } catch (e) {
                             logger.warn(`${hostLogPrefix} Repository object could not be updated: ${e.message}`);

--- a/packages/controller/src/main.ts
+++ b/packages/controller/src/main.ts
@@ -52,7 +52,7 @@ import {
     getHostObject,
     getDefaultNodeArgs,
     type HostInfo,
-    isAdapterEsmModule,
+    isAdapterEsmModule
 } from '@iobroker/js-controller-common-db/tools';
 import type { UpgradeArguments } from '@/lib/upgradeManager.js';
 import { AdapterUpgradeManager } from '@/lib/adapterUpgradeManager.js';

--- a/packages/controller/src/main.ts
+++ b/packages/controller/src/main.ts
@@ -2152,13 +2152,13 @@ async function processMessage(msg: ioBroker.SendableMessage): Promise<null | voi
                                         );
 
                                         changed = changed || (result?.json && result.changed);
-                                    }
 
-                                    // If repo was really changed
-                                    if (result?.json && result.changed) {
-                                        currentRepo.json = result.json;
-                                        currentRepo.hash = result.hash || '';
-                                        currentRepo.time = new Date().toISOString();
+                                        // If repo was really changed
+                                        if (result?.json && result.changed) {
+                                            currentRepo.json = result.json;
+                                            currentRepo.hash = result.hash || '';
+                                            currentRepo.time = new Date().toISOString();
+                                        }
                                     }
 
                                     // Make sure, that time is stored too to prevent the frequent access to repo server


### PR DESCRIPTION
Bug: If we have more than one active repo and the second repo never changes, then the first repo will not be saved too