### PR TITLE
[fix]: do not reinstall same version on auto upgrade check

### DIFF
--- a/packages/controller/src/lib/adapterAutoUpgradeManager.ts
+++ b/packages/controller/src/lib/adapterAutoUpgradeManager.ts
@@ -106,7 +106,7 @@ export class AdapterAutoUpgradeManager {
                 continue;
             }
 
-            if (semver.gt(adapterConfig.version, repoAdapterInfo.version)) {
+            if (semver.gte(adapterConfig.version, repoAdapterInfo.version)) {
                 continue;
             }
 


### PR DESCRIPTION
**Link the issue which is closed by this PR**
<!--
    If the PR closes the issue add a `closes #issue-no`. If no issue exists yet, please create an issue first.
-->
Came up while I was alpha testing the feature

**Implementation details**
<!--
    What has been changed?
-->
Previously we performed the auto upgrade when version was the same, leading to undesired reinstall of an adapter.

**Tests**
- [ ] I have added tests to avoid a recursion of this bug
- [x] It is not possible to test for this bug

**If no tests added, please specify why it was not possible**
<!--
    E.g. the bug is only reproducible if the system runs out of disk space.
-->
needs adapters