### PR TITLE
added log info for non-npm and version also outside of adapter process

### DIFF
--- a/packages/adapter/src/lib/adapter/adapter.ts
+++ b/packages/adapter/src/lib/adapter/adapter.ts
@@ -14,7 +14,8 @@ import {
     tools,
     EXIT_CODES,
     password,
-    logger
+    logger,
+    isInstalledFromNpm
 } from '@iobroker/js-controller-common';
 import {
     decryptArray,
@@ -686,7 +687,7 @@ export class AdapterClass extends EventEmitter {
     /** contents of package.json */
     pack?: Record<string, any>;
     /** contents of io-package.json */
-    ioPack: Record<string, any>; // contents of io-package.json TODO difference to adapterConfig?
+    ioPack: ioBroker.InstanceObject;
     private _initializeTimeout?: NodeJS.Timeout | null;
     private inited?: boolean;
     /** contents of iobroker.json if required via AdapterOptions */
@@ -11628,11 +11629,10 @@ export class AdapterClass extends EventEmitter {
                       ? this.ioPack.common.version
                       : 'unknown';
                 // display if it's a non-official version - only if installedFrom is explicitly given and differs it's not npm
-                const isNpmVersion =
-                    !this.ioPack ||
-                    !this.ioPack.common ||
-                    typeof this.ioPack.common.installedFrom !== 'string' ||
-                    this.ioPack.common.installedFrom.startsWith(`${tools.appName.toLowerCase()}.${this.name}`);
+                const isNpmVersion = isInstalledFromNpm({
+                    adapterName: this.name,
+                    installedFrom: this.ioPack.common.installedFrom
+                });
 
                 this._logger.info(
                     `${this.namespaceLog} starting. Version ${this.version} ${
@@ -11651,7 +11651,7 @@ export class AdapterClass extends EventEmitter {
                     this.#states.setState(`${id}.compactMode`, {
                         ack: true,
                         from: id,
-                        val: !!this.startedInCompactMode
+                        val: this.startedInCompactMode
                     });
 
                     this.outputCount++;
@@ -12014,6 +12014,37 @@ export class AdapterClass extends EventEmitter {
         await this.#states.pushMessage(`system.host.${this.host}`, obj as any);
     }
 
+    /**
+     * Initialize the plugin handler for this adapter
+     */
+    private _initPluginHandler(): void {
+        if (!this.ioPack.common.plugins) {
+            return;
+        }
+
+        const pluginSettings: PluginHandlerSettings = {
+            scope: 'adapter',
+            namespace: `system.adapter.${this.namespace}`,
+            logNamespace: this.namespaceLog,
+            // @ts-expect-error
+            log: this._logger,
+            iobrokerConfig: this._config,
+            // @ts-expect-error
+            parentPackage: this.pack,
+            controllerVersion
+        };
+
+        this.pluginHandler = new PluginHandler(pluginSettings);
+        try {
+            this.pluginHandler.addPlugins(this.ioPack.common.plugins, [this.adapterDir, thisDir]); // first resolve from adapter directory, else from js-controller
+        } catch (e) {
+            this._logger.error(`Could not add plugins: ${e.message}`);
+        }
+    }
+
+    /**
+     * Initializes the adapter
+     */
     private async _init(): Promise<void> {
         /**
          * Initiates the databases
@@ -12087,24 +12118,7 @@ export class AdapterClass extends EventEmitter {
         process.on('uncaughtException', err => this._exceptionHandler(err));
         process.on('unhandledRejection', err => this._exceptionHandler(err as any, true));
 
-        const pluginSettings: PluginHandlerSettings = {
-            scope: 'adapter',
-            namespace: `system.adapter.${this.namespace}`,
-            logNamespace: this.namespaceLog,
-            // @ts-expect-error
-            log: this._logger,
-            iobrokerConfig: this._config,
-            // @ts-expect-error
-            parentPackage: this.pack,
-            controllerVersion
-        };
-
-        this.pluginHandler = new PluginHandler(pluginSettings);
-        try {
-            this.pluginHandler.addPlugins(this.ioPack.common.plugins, [this.adapterDir, thisDir]); // first resolve from adapter directory, else from js-controller
-        } catch (e) {
-            this._logger.error(`Could not add plugins: ${e.message}`);
-        }
+        this._initPluginHandler();
         // finally init
         _initDBs();
     }

--- a/packages/adapter/src/lib/adapter/adapter.ts
+++ b/packages/adapter/src/lib/adapter/adapter.ts
@@ -12018,10 +12018,6 @@ export class AdapterClass extends EventEmitter {
      * Initialize the plugin handler for this adapter
      */
     private _initPluginHandler(): void {
-        if (!this.ioPack.common.plugins) {
-            return;
-        }
-
         const pluginSettings: PluginHandlerSettings = {
             scope: 'adapter',
             namespace: `system.adapter.${this.namespace}`,
@@ -12036,7 +12032,7 @@ export class AdapterClass extends EventEmitter {
 
         this.pluginHandler = new PluginHandler(pluginSettings);
         try {
-            this.pluginHandler.addPlugins(this.ioPack.common.plugins, [this.adapterDir, thisDir]); // first resolve from adapter directory, else from js-controller
+            this.pluginHandler.addPlugins(this.ioPack.common.plugins || {}, [this.adapterDir, thisDir]); // first resolve from adapter directory, else from js-controller
         } catch (e) {
             this._logger.error(`Could not add plugins: ${e.message}`);
         }

--- a/packages/common/src/lib/common/tools.ts
+++ b/packages/common/src/lib/common/tools.ts
@@ -65,3 +65,25 @@ export async function getInstancesOrderedByStartPrio(
 
     return [...instances.admin, ...instances['1'], ...instances['2'], ...instances['3']];
 }
+
+interface IsInstalledFromNpmOptions {
+    /** Installed from attribute of instance/adapter object */
+    installedFrom?: ioBroker.InstalledFrom;
+    /** Name of the adapter */
+    adapterName: string;
+}
+
+/**
+ * Check if the adapter has been installed from NPM
+ *
+ * @param options installedFrom and name information
+ */
+export function isInstalledFromNpm(options: IsInstalledFromNpmOptions): boolean {
+    const { adapterName, installedFrom } = options;
+
+    if (installedFrom === undefined) {
+        return true;
+    }
+
+    return installedFrom.startsWith(`${appName.toLowerCase()}.${adapterName}`);
+}

--- a/packages/controller/src/main.ts
+++ b/packages/controller/src/main.ts
@@ -29,7 +29,8 @@ import {
     getObjectsConstructor,
     getStatesConstructor,
     zipFiles,
-    getInstancesOrderedByStartPrio
+    getInstancesOrderedByStartPrio,
+    isInstalledFromNpm
 } from '@iobroker/js-controller-common';
 import {
     SYSTEM_ADAPTER_PREFIX,
@@ -3696,7 +3697,14 @@ async function startScheduledInstance(callback?: () => void): Promise<void> {
                 storePids();
                 const { pid } = proc.process;
 
-                logger.info(`${hostLogPrefix} instance ${instance._id} started with pid ${proc.process.pid}`);
+                const isNpm = isInstalledFromNpm({
+                    installedFrom: instance.common.installedFrom,
+                    adapterName: instance.common.name
+                });
+
+                logger.info(
+                    `${hostLogPrefix} instance ${instance._id} in version "${instance.common.version}"${!isNpm ? ` (non-npm: ${instance.common.installedFrom})` : ''} started with pid ${proc.process.pid}`
+                );
 
                 proc.process.on('exit', (code, signal) => {
                     outputCount++;
@@ -4325,8 +4333,13 @@ async function startInstance(id: ioBroker.ObjectIDs.Instance, wakeUp = false): P
                                 `${hostLogPrefix} instance ${instance._id} is handled by compact group controller pid ${proc.process.pid}`
                             );
                         } else {
+                            const isNpm = isInstalledFromNpm({
+                                installedFrom: instance.common.installedFrom,
+                                adapterName: instance.common.name
+                            });
+
                             logger.info(
-                                `${hostLogPrefix} instance ${instance._id} started with pid ${proc.process.pid}`
+                                `${hostLogPrefix} instance ${instance._id} in version "${instance.common.version}"${!isNpm ? ` (non-npm: ${instance.common.installedFrom})` : ''} started with pid ${proc.process.pid}`
                             );
                         }
                     }
@@ -4705,12 +4718,19 @@ async function startInstance(id: ioBroker.ObjectIDs.Instance, wakeUp = false): P
                         windowsHide: true,
                         cwd: adapterDir!
                     });
-                } catch (err) {
-                    logger.info(`${hostLogPrefix} instance ${instance._id} could not be started: ${err}`);
+                } catch (e) {
+                    logger.info(`${hostLogPrefix} instance ${instance._id} could not be started: ${e.message}`);
                 }
                 if (proc.process) {
                     storePids();
-                    logger.info(`${hostLogPrefix} instance ${instance._id} started with pid ${proc.process.pid}`);
+                    const isNpm = isInstalledFromNpm({
+                        installedFrom: instance.common.installedFrom,
+                        adapterName: instance.common.name
+                    });
+
+                    logger.info(
+                        `${hostLogPrefix} instance ${instance._id} in version "${instance.common.version}"${!isNpm ? ` (non-npm: ${instance.common.installedFrom})` : ''} started with pid ${proc.process.pid}`
+                    );
 
                     proc.process.on('exit', (code, signal) => {
                         cleanAutoSubscribes(id, () => {

--- a/packages/controller/test/testInternalUtilities.ts
+++ b/packages/controller/test/testInternalUtilities.ts
@@ -5,6 +5,7 @@ import { startController, stopController } from './lib/setup4controller.js';
 import url from 'node:url';
 const thisDir = url.fileURLToPath(new URL('.', import.meta.url));
 import type { Client as ObjectsInRedisClient } from '@iobroker/db-objects-redis';
+import { isInstalledFromNpm } from '@iobroker/js-controller-common';
 
 let objects: ObjectsInRedisClient;
 
@@ -61,6 +62,22 @@ describe('test internal helpers', () => {
 
         isBlocked = await blocklistManager.isAdapterVersionBlocked({ version: '3.14.0', adapterName: 'alexa2' });
         expect(isBlocked).to.be.true;
+    });
+
+    it('isInstalledFromNpm', () => {
+        expect(
+            isInstalledFromNpm({
+                adapterName: 'admin',
+                installedFrom: 'iobroker.admin@6.13.16' as ioBroker.InstalledFrom
+            })
+        ).to.be.true;
+
+        expect(
+            isInstalledFromNpm({
+                adapterName: 'benchmark',
+                installedFrom: 'foxriver76/ioBroker.benchmark' as ioBroker.InstalledFrom
+            })
+        ).to.be.false;
     });
 
     after('Stop js-controller', async function () {

--- a/packages/types-dev/index.d.ts
+++ b/packages/types-dev/index.d.ts
@@ -3,12 +3,9 @@
 import type * as fs from 'node:fs';
 import './objects';
 import type { IoBJson, DatabaseOptions, ObjectsDatabaseOptions as ObjectsDbOptions } from './config';
+import type { Branded } from './utils';
 
 export {}; // avoids exporting AtLeastOne into the global scope
-
-declare const __brand: unique symbol;
-type Brand<B> = { [__brand]: B };
-type Branded<T, B> = T & Brand<B>;
 
 // Requires at least one of the properties of T to be given, whether it's optional or not
 type AtLeastOne<T, Req = { [K in keyof T]-?: T[K] }, Opt = { [K in keyof T]+?: T[K] }> = {

--- a/packages/types-dev/objects.d.ts
+++ b/packages/types-dev/objects.d.ts
@@ -1,4 +1,5 @@
 import type * as os from 'node:os';
+import type { Branded } from './utils';
 
 declare global {
     namespace ioBroker {
@@ -340,6 +341,9 @@ declare global {
             tab?: 'html' | 'materialize';
         }
 
+        /** Installed from attribute of instance/adapter object */
+        type InstalledFrom = Branded<string, 'InstalledFrom'>;
+
         interface InstanceCommon extends AdapterCommon {
             version: string;
             /** The name of the host where this instance is running */
@@ -364,7 +368,8 @@ declare global {
             compactGroup?: number;
             /** String (or array) with names of attributes in common of instance, which will not be deleted. */
             preserveSettings?: string | string[];
-            installedFrom?: string;
+            /** Source, where this adapter has been installed from, to enable reinstalling on e.g., backup restore */
+            installedFrom?: InstalledFrom;
             /** Arguments passed to the adapter process, this disables compact mode */
             nodeProcessParams?: string[];
             /** If adapter can consume log messages, like admin, javascript or logparser */
@@ -624,7 +629,7 @@ declare global {
             /** The adapter will be executed once additionally after installation and the `install` event will be emitted during this run. This allows for executing one time installation code. */
             install?: boolean;
             /** Source, where this adapter has been installed from, to enable reinstalling on e.g., backup restore */
-            installedFrom?: string;
+            installedFrom?: InstalledFrom;
             /** Which version of this adapter is installed */
             installedVersion: string;
             keywords?: string[];

--- a/packages/types-dev/package.json
+++ b/packages/types-dev/package.json
@@ -26,6 +26,7 @@
         "index.d.ts",
         "config.d.ts",
         "objects.d.ts",
+        "utils.d.ts",
         "LICENSE"
     ]
 }

--- a/packages/types-dev/utils.d.ts
+++ b/packages/types-dev/utils.d.ts
@@ -1,0 +1,3 @@
+declare const __brand: unique symbol;
+type Brand<B> = { [__brand]: B };
+export type Branded<T, B> = T & Brand<B>;

--- a/packages/types-public/build.ts
+++ b/packages/types-public/build.ts
@@ -32,6 +32,7 @@ if (extractorResult.succeeded) {
     fs.copyFileSync(path.join(thisDir, '../types-dev/objects.d.ts'), path.join(thisDir, 'build/objects.d.ts'));
     fs.copyFileSync(path.join(thisDir, '../types-dev/index.d.ts'), path.join(thisDir, 'build/shared.d.ts'));
     fs.copyFileSync(path.join(thisDir, '../types-dev/config.d.ts'), path.join(thisDir, 'build/config.d.ts'));
+    fs.copyFileSync(path.join(thisDir, '../types-dev/utils.d.ts'), path.join(thisDir, 'build/utils.d.ts'));
 
     // Ensure that the generated types don't contain any references to @iobroker/*
     if (content.includes('@iobroker/')) {


### PR DESCRIPTION
**Link the feature issue which is closed by this PR**
<!--
If the PR closes an issue add a `closes #issue-no`. If no issue exists yet, please create an issue first to discuss with the core team if this feature is desirable.
-->
- closes #2805

**Implementation details**
<!--
    What has been changed?
-->
Added to the log line outside of the adapter process the version and installed from information if it is not npm.
Branded the type for `installedFrom`

**Tests**
- [x] I have added tests to test this feature
- [ ] It is not possible to test this feature

**Documentation**
<!--
    New features should be documented in the `README.md` file under `Feature Overview`. If a host message was added, please document it under `Feature Overview/js-controller Host Messages`.
-->
- [ ] I have documented the new feature
Not needed