### PR TITLE
[fix]: ignore-scripts on the npm install call in root dir (setup) to avoid partial recursion

### DIFF
--- a/packages/cli/src/lib/setup/setupInstall.ts
+++ b/packages/cli/src/lib/setup/setupInstall.ts
@@ -301,8 +301,8 @@ export class Install {
                     npmVersion = semver.valid(npmVersion.trim());
                 }
                 console.log(`NPM version: ${npmVersion}`);
-            } catch (err) {
-                console.error(`Error trying to check npm version: ${err.message}`);
+            } catch (e) {
+                console.error(`Error trying to check npm version: ${e.message}`);
             }
 
             if (!npmVersion) {
@@ -330,8 +330,8 @@ export class Install {
                 console.error('!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!');
                 return this.processExit(EXIT_CODES.INVALID_NPM_VERSION);
             }
-        } catch (err) {
-            console.error(`Could not check npm version: ${err.message}`);
+        } catch (e) {
+            console.error(`Could not check npm version: ${e.message}`);
             console.error('Assuming that correct version is installed.');
         }
 

--- a/packages/cli/src/lib/setup/setupSetup.ts
+++ b/packages/cli/src/lib/setup/setupSetup.ts
@@ -1130,7 +1130,7 @@ Please DO NOT copy files manually into ioBroker storage directories!`
         packJson.overrides = { '@iobroker/adapter-core': this.SUPPORTED_ADAPTER_CORE_VERSION };
 
         await fs.writeFile(packPath, JSON.stringify(packJson));
-        await tools.execAsync('npm i --omit=dev', { cwd: rootDir });
+        await tools.execAsync('npm i --omit=dev --ignore-scripts', { cwd: rootDir });
 
         console.log(
             `Successfully specified supported "@iobroker/adapter-core" version as "${this.SUPPORTED_ADAPTER_CORE_VERSION}"`

--- a/packages/common-db/src/lib/common/tools.ts
+++ b/packages/common-db/src/lib/common/tools.ts
@@ -31,6 +31,7 @@ import {
 import type * as DiskUsage from 'diskusage';
 import * as url from 'node:url';
 import { createRequire } from 'node:module';
+import type { WithRequired } from '@iobroker/types-dev';
 
 // eslint-disable-next-line unicorn/prefer-module
 const thisDir = url.fileURLToPath(new URL('.', import.meta.url || 'file://' + __filename));
@@ -1715,22 +1716,27 @@ export async function installNodeModule(
         pak.loglevel = 'error';
     }
 
+    // And install the module
+    const installOpts: WithRequired<InstallOptions, 'additionalArgs'> = {
+        additionalArgs: []
+    };
+
     // Set up streams to pass the command output through
     if (options.debug) {
         const stdall = new PassThrough();
         pak.stdall = stdall;
         pipeLinewise(stdall, process.stdout);
+        installOpts.additionalArgs.push('--foreground-scripts');
     } else {
         const stdout = new PassThrough();
         pak.stdout = stdout;
         pipeLinewise(stdout, process.stdout);
     }
 
-    // And install the module
-    const installOpts: InstallOptions = {};
     if (options.unsafePerm) {
-        installOpts.additionalArgs = ['--unsafe-perm'];
+        installOpts.additionalArgs.push('--unsafe-perm');
     }
+
     return pak.install([npmUrl], installOpts);
 }
 

--- a/packages/controller/src/lib/restart.ts
+++ b/packages/controller/src/lib/restart.ts
@@ -17,7 +17,7 @@ export default function restart(callback?: () => void): void {
         cmd = path.join(getRootDir(), 'iob.bat');
         args = ['restart'];
     } else {
-        // Unix has a global iobroker binary that delegates to the init system
+        // Unix has a global ioBroker binary that delegates to the init system
         // We need to call that, so we don't have two instances of ioBroker running
         cmd = 'iobroker';
         args = ['restart'];

--- a/packages/types-dev/index.d.ts
+++ b/packages/types-dev/index.d.ts
@@ -15,6 +15,9 @@ type AtLeastOne<T, Req = { [K in keyof T]-?: T[K] }, Opt = { [K in keyof T]+?: T
     [K in keyof Req]: Omit<Opt, K> & { [P in K]: Req[P] };
 }[keyof Req];
 
+/** Type of T but makes specific optional properties required */
+export type WithRequired<T, K extends keyof T> = T & { [P in K]-?: T[P] };
+
 declare global {
     namespace ioBroker {
         /** Two-way mapping for state quality ("q" attribute of a state) */


### PR DESCRIPTION
**Link the issue which is closed by this PR**
<!--
    If the PR closes the issue add a `closes #issue-no`. If no issue exists yet, please create an issue first.
-->
On windows there is a install script in the root package json which we do not want to be executed, as it is just for updating adapter-core which is not relying on any install script and likely never will (as this is normally bad practice) I think we ca simply perform the install here with `ignore-scripts` flag

**Implementation details**
<!--
    What has been changed?
-->
- Root install after overrides ignores scripts
- When upgrading with debug flag also use the `foreground-scripts` flag to show output of setup first, since `npm@7` the default changed to not show it.


**Tests**
- [ ] I have added tests to avoid a recursion of this bug
- [x] It is not possible to test for this bug

**If no tests added, please specify why it was not possible**
<!--
    E.g. the bug is only reproducible if the system runs out of disk space.
-->

the root folder does not exist on dev install
