### PR TITLE
[feature]: Add auto upgrade information to cli output

### DIFF
--- a/packages/cli/src/lib/setup/setupList.ts
+++ b/packages/cli/src/lib/setup/setupList.ts
@@ -388,10 +388,12 @@ export class List {
                                 return;
                             }
                             const reg = filter ? new RegExp(tools.pattern2RegEx('system.adapter.' + filter)) : null;
+                            const vals = [];
                             for (const obj of objs.rows) {
                                 if (obj.value.type !== 'adapter') {
                                     continue;
                                 }
+
                                 if (
                                     !reg ||
                                     reg.test(obj.value._id) ||
@@ -403,11 +405,16 @@ export class List {
                                         name = name[lang] || name.en;
                                     }
 
-                                    const text = `${id.padEnd(39)}: ${name.padEnd(14)} - v${obj.value.common.version}`;
-
-                                    console.log(text);
+                                    vals.push({
+                                        id,
+                                        name,
+                                        version: obj.value.common.version,
+                                        'upgrade policy': obj.value.common.automaticUpgrade ?? 'none'
+                                    });
                                 }
                             }
+
+                            console.table(vals);
                             this.processExit();
                         }
                     );

--- a/packages/cli/src/lib/setup/setupList.ts
+++ b/packages/cli/src/lib/setup/setupList.ts
@@ -59,6 +59,17 @@ export type ListType =
     | 'files'
     | 'f';
 
+interface AdapterListEntry {
+    /** The object id */
+    id: string;
+    /** Adapter name */
+    name: string;
+    /** Version of adapter */
+    version: string;
+    /** The configured upgrade policy */
+    'upgrade policy': ioBroker.AutoUpgradePolicy;
+}
+
 export class List {
     private config: Record<string, any>;
     private objects: ObjectsRedisClient;
@@ -388,7 +399,7 @@ export class List {
                                 return;
                             }
                             const reg = filter ? new RegExp(tools.pattern2RegEx('system.adapter.' + filter)) : null;
-                            const vals = [];
+                            const adapterList: AdapterListEntry[] = [];
                             for (const obj of objs.rows) {
                                 if (obj.value.type !== 'adapter') {
                                     continue;
@@ -405,7 +416,7 @@ export class List {
                                         name = name[lang] || name.en;
                                     }
 
-                                    vals.push({
+                                    adapterList.push({
                                         id,
                                         name,
                                         version: obj.value.common.version,
@@ -414,7 +425,7 @@ export class List {
                                 }
                             }
 
-                            console.table(vals);
+                            console.table(adapterList);
                             this.processExit();
                         }
                     );

--- a/packages/cli/src/lib/setup/setupRepo.ts
+++ b/packages/cli/src/lib/setup/setupRepo.ts
@@ -354,7 +354,7 @@ export class Repo {
                         activeRepo = [activeRepo];
                     }
                     console.log(`\nActive repo(s): ${activeRepo.join(', ')}`);
-                    console.log(`Upgrade policy: ${objCfg.common.adapterAutoUpgrade?.defaultPolicy}` ?? 'none');
+                    console.log(`Upgrade policy: ${objCfg.common.adapterAutoUpgrade?.defaultPolicy ?? 'none'}`);
                 }
             } else {
                 console.error('List is empty');


### PR DESCRIPTION
**Link the feature issue which is closed by this PR**
<!--
If the PR closes an issue add a `closes #issue-no`. If no issue exists yet, please create an issue first to discuss with the core team if this feature is desirable.
-->
closes #2825

**Implementation details**
<!--
    What has been changed?
-->
Added auto upgrade output to cli `repo show` and `list adapters`

**Tests**
- [ ] I have added tests to test this feature
- [x] It is not possible to test this feature

**Documentation**
<!--
    New features should be documented in the `README.md` file under `Feature Overview`. If a host message was added, please document it under `Feature Overview/js-controller Host Messages`.
-->
- [ ] I have documented the new feature

Not necessary 

**If no tests added, please specify why it was not possible**
<!--
    E.g. the feature is only triggered if the system runs low on memory.
-->

Just cli output we dont test it currently