### PR TITLE
[fix]: Only generate reboot notification once per run

### DIFF
--- a/packages/controller/src/main.ts
+++ b/packages/controller/src/main.ts
@@ -161,8 +161,6 @@ if (os.platform() === 'win32') {
 
 tools.ensureDNSOrder();
 
-let title = `${tools.appName}.js-controller`;
-
 let Objects: typeof ObjectsClient;
 let States: typeof StatesClient;
 
@@ -5171,6 +5169,8 @@ function stop(force?: boolean, callback?: () => void): void {
  * @param compactGroupId the id of the compact group
  */
 export async function init(compactGroupId?: number): Promise<void> {
+    let title = `${tools.appName}.js-controller`;
+
     if (compactGroupId) {
         compactGroupController = true;
         compactGroup = compactGroupId;


### PR DESCRIPTION
**Link the issue which is closed by this PR**
<!--
    If the PR closes the issue add a `closes #issue-no`. If no issue exists yet, please create an issue first.
-->
If a user acknowledges the reboot notification and reloads admin, a repo update is triggered, and the notification is re-generated.

**Implementation details**
<!--
    What has been changed?
-->
We only generate it once per controller run, because if rebooted it is resetted anyway. 

**Tests**
- [ ] I have added tests to avoid a recursion of this bug
- [x] It is not possible to test for this bug

**If no tests added, please specify why it was not possible**
<!--
    E.g. the bug is only reproducible if the system runs out of disk space.
-->

needs a system with reboot and multiple repo updates