### PR TITLE
[fix]: do not log stack trace on user commands if error occurs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 	## __WORK IN PROGRESS__
 -->
 
+## __WORK IN PROGRESS__
+* (foxriver76) added auto upgrade information to cli `list adapters` and `repo show`
+* (foxriver76) do not show the stack trace if user does not exist on `iob user check`
+
 ## 6.0.6 (2024-06-30) - Kiera
 * (foxriver76) fixed Windows installation
 * (foxriver76) fixed issue on package updates (e.g. Admin Node.js update)

--- a/packages/cli/src/lib/setup.ts
+++ b/packages/cli/src/lib/setup.ts
@@ -1815,9 +1815,9 @@ async function processCommand(
                         }
                     });
                 } else if (command === 'check') {
-                    users.checkUserPassword(user, password, (err: any) => {
+                    users.checkUserPassword(user, password, err => {
                         if (err) {
-                            console.error(err);
+                            console.error(err.message);
                             return void callback(EXIT_CODES.CANNOT_CREATE_USER_OR_GROUP);
                         } else {
                             console.log(`Password for user "${user}" matches.`);
@@ -1825,9 +1825,9 @@ async function processCommand(
                         }
                     });
                 } else if (command === 'set' || command === 'passwd') {
-                    users.setUserPassword(user, password, (err: any) => {
+                    users.setUserPassword(user, password, err => {
                         if (err) {
-                            console.error(err);
+                            console.error(err.message);
                             return void callback(EXIT_CODES.CANNOT_CREATE_USER_OR_GROUP);
                         } else {
                             console.log(`Password for "${user}" was successfully set.`);
@@ -1835,9 +1835,9 @@ async function processCommand(
                         }
                     });
                 } else if (command === 'enable' || command === 'e') {
-                    users.enableUser(user, true, (err: any) => {
+                    users.enableUser(user, true, err => {
                         if (err) {
-                            console.error(err);
+                            console.error(err.message);
                             return void callback(EXIT_CODES.CANNOT_CREATE_USER_OR_GROUP);
                         } else {
                             console.log(`User "${user}" was successfully enabled.`);
@@ -1845,9 +1845,9 @@ async function processCommand(
                         }
                     });
                 } else if (command === 'disable' || command === 'd') {
-                    users.enableUser(user, false, (err: any) => {
+                    users.enableUser(user, false, err => {
                         if (err) {
-                            console.error(err);
+                            console.error(err.message);
                             return void callback(EXIT_CODES.CANNOT_CREATE_USER_OR_GROUP);
                         } else {
                             console.log(`User "${user}" was successfully disabled.`);
@@ -1855,9 +1855,9 @@ async function processCommand(
                         }
                     });
                 } else if (command === 'get') {
-                    users.getUser(user, (err: any, isEnabled: any) => {
+                    users.getUser(user, (err, isEnabled) => {
                         if (err) {
-                            console.error(err);
+                            console.error(err.message);
                             return void callback(EXIT_CODES.CANNOT_CREATE_USER_OR_GROUP);
                         } else {
                             console.log(`User "${user}" is ${isEnabled ? 'enabled' : 'disabled'}`);

--- a/packages/cli/src/lib/setup/setupUsers.ts
+++ b/packages/cli/src/lib/setup/setupUsers.ts
@@ -8,6 +8,9 @@ export interface CLIUsersOptions {
     objects: ObjectsRedisClient;
 }
 
+/** Return type of prompt.get() for user */
+type UsernamePromptProps = { password: string; username: string };
+
 export class Users {
     private readonly objects: ObjectsRedisClient;
     private readonly processExit: ProcessExitCallback;
@@ -461,12 +464,12 @@ export class Users {
             };
             prompt.start();
 
-            prompt.get(schema, (err, result) => {
-                this.checkPassword(result.username as string, result.password as string, (err, res) => {
+            prompt.get<UsernamePromptProps>(schema, (err, result) => {
+                this.checkPassword(result.username, result.password, (err, res) => {
                     if (err || !res) {
                         return tools.maybeCallbackWithError(
                             callback,
-                            `Password for user "${result.username as string}" does not match${err ? ': ' + err : ''}`
+                            `Password for user "${result.username as string}" does not match${err ? `: ${err.message}` : ''}`
                         );
                     } else {
                         return tools.maybeCallbackWithError(callback, null);
@@ -488,13 +491,12 @@ export class Users {
             };
             prompt.start();
 
-            prompt.get(schema, (err, result) => {
-                // @ts-expect-error external types problem?
+            prompt.get<UsernamePromptProps>(schema, (err, result) => {
                 this.checkPassword(username, result.password, (err, res) => {
                     if (err || !res) {
                         return tools.maybeCallbackWithError(
                             callback,
-                            `Password for user "${username}" does not matched${err ? ': ' + err : ''}`
+                            `Password for user "${username}" does not match${err ? `: ${err.message}` : ''}`
                         );
                     } else {
                         return tools.maybeCallbackWithError(callback, null);
@@ -506,7 +508,7 @@ export class Users {
                 if (err || !res) {
                     return tools.maybeCallbackWithError(
                         callback,
-                        'Password for user "' + username + '" does not matched' + (err ? ': ' + err : '')
+                        `Password for user "${username}" does not match${err ? `: ${err.message}` : ''}`
                     );
                 } else {
                     return tools.maybeCallbackWithError(callback, null);


### PR DESCRIPTION
**Link the issue which is closed by this PR**
<!--
    If the PR closes the issue add a `closes #issue-no`. If no issue exists yet, please create an issue first.
-->

closes #2830

**Implementation details**
<!--
    What has been changed?
-->

Instead of logging the error object, just log `message` attribute which is relevant for users. 

**Tests**
- [ ] I have added tests to avoid a recursion of this bug
- [x] It is not possible to test for this bug

**If no tests added, please specify why it was not possible**
<!--
    E.g. the bug is only reproducible if the system runs out of disk space.
-->
just cli log output
