### PR TITLE
prevent 'iob logs --watch' logging entries two times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 	## __WORK IN PROGRESS__
 -->
 
+## __WORK IN PROGRESS__
+* (foxriver76) prevent `iob logs --watch` logging the entries two times
+
 ## 6.0.6 (2024-06-30) - Kiera
 * (foxriver76) fixed Windows installation
 * (foxriver76) fixed issue on package updates (e.g. Admin Node.js update)

--- a/packages/cli/src/lib/cli/cliLogs.ts
+++ b/packages/cli/src/lib/cli/cliLogs.ts
@@ -69,7 +69,10 @@ export class CLILogs extends CLICommand {
                 const parts = fileName.split('/');
                 parts.pop();
                 chokidar
-                    .watch(`${parts.join('/')}/iobroker.current.log`, { awaitWriteFinish: { stabilityThreshold: 500 } })
+                    .watch(`${parts.join('/')}/iobroker*`, {
+                        awaitWriteFinish: { stabilityThreshold: 500 },
+                        followSymlinks: false
+                    })
                     .on('all', this.watchHandler.bind(this, options))
                     .on('ready', () => (this.isReady = true));
             }

--- a/packages/cli/src/lib/cli/cliLogs.ts
+++ b/packages/cli/src/lib/cli/cliLogs.ts
@@ -69,7 +69,7 @@ export class CLILogs extends CLICommand {
                 const parts = fileName.split('/');
                 parts.pop();
                 chokidar
-                    .watch(`${parts.join('/')}/iobroker*`, { awaitWriteFinish: { stabilityThreshold: 500 } })
+                    .watch(`${parts.join('/')}/iobroker.current.log`, { awaitWriteFinish: { stabilityThreshold: 500 } })
                     .on('all', this.watchHandler.bind(this, options))
                     .on('ready', () => (this.isReady = true));
             }


### PR DESCRIPTION
**Link the issue which is closed by this PR**
<!--
    If the PR closes the issue add a `closes #issue-no`. If no issue exists yet, please create an issue first.
-->
- closes #2831

**Implementation details**
<!--
    What has been changed?
-->
We now only don't follow the symlinks anymore to prevent double logging on linux

**Tests**
- [ ] I have added tests to avoid a recursion of this bug
- [x] It is not possible to test for this bug

**If no tests added, please specify why it was not possible**
<!--
    E.g. the bug is only reproducible if the system runs out of disk space.
-->

too complex ;-)