### PR TITLE
provide method getAdapterScopedPackageIdentifier on adapter level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 	## __WORK IN PROGRESS__
 -->
 
+## __WORK IN PROGRESS__ - Kiera
+* (foxriver76) provide method `getAdapterScopedPackageIdentifier` for adapters
+
 ## 6.0.8 (2024-07-13) - Kiera
 * (foxriver76) fixed problem with Sentry plugin
 

--- a/README.md
+++ b/README.md
@@ -260,6 +260,13 @@ const installedNodeModules = await adapter.listInstalledNodeModules();
 adapter.log.info(`Installed modules are: ${installedNodeModules.join(', ')}`);
 ```
 
+To get the adapter scoped package identifier you can use: 
+
+```typescript
+// e.g. @iobroker-javascript.0/axios
+const packageIdentifier = adapter.getAdapterScopedPackageIdentifier('axios');
+```
+
 ### Per host `adapter` objects
 **Feature status:** New in 6.0.0
 

--- a/packages/adapter/src/lib/adapter/adapter.ts
+++ b/packages/adapter/src/lib/adapter/adapter.ts
@@ -1246,6 +1246,15 @@ export class AdapterClass extends EventEmitter {
         this._init();
     }
 
+    /**
+     * Get the adapter scoped package identifier of a node module
+     *
+     * @param moduleName name of the node module
+     */
+    getAdapterScopedPackageIdentifier(moduleName: string): string {
+        return getAdapterScopedPackageIdentifier({ moduleName, namespace: this.namespace });
+    }
+
     installNodeModule(moduleName: string, options: InstallNodeModuleOptions): Promise<CommandResult>;
 
     /**

--- a/packages/controller/test/lib/testAdapterHelpers.ts
+++ b/packages/controller/test/lib/testAdapterHelpers.ts
@@ -598,4 +598,12 @@ export function register(it: Mocha.TestFunction, expect: Chai.ExpectStatic, cont
             });
         });
     }
+
+    it(context.name + ' ' + context.adapterShortName + ' getAdapterScopedPackageIdentifier', () => {
+        const nonOrgaPacket = context.adapter.getAdapterScopedPackageIdentifier('axios');
+        const orgaPacket = context.adapter.getAdapterScopedPackageIdentifier('@iobroker/adapter-react-v5');
+
+        expect(nonOrgaPacket).to.be.equal('@iobroker-test.0/axios');
+        expect(orgaPacket).to.be.equal('@iobroker-test.0/iobroker-adapter-react-v5');
+    });
 }


### PR DESCRIPTION
**Link the feature issue which is closed by this PR**
<!--
If the PR closes an issue add a `closes #issue-no`. If no issue exists yet, please create an issue first to discuss with the core team if this feature is desirable.
-->

Came up during beta test.

We noticed that adapters need to access their own installed packages directly in some cases, see https://github.com/ioBroker/ioBroker.javascript/issues/1642

**Implementation details**
<!--
    What has been changed?
-->

We provide a method for adapters to get the real package id to allow require resolving it etc.

**Tests**
- [x] I have added tests to test this feature
- [ ] It is not possible to test this feature

**Documentation**
<!--
    New features should be documented in the `README.md` file under `Feature Overview`. If a host message was added, please document it under `Feature Overview/js-controller Host Messages`.
-->
- [x] I have documented the new feature