### PR TITLE
[fix]: Windows: Fix restart.ts to make it compatible with current Node.js

### DIFF
--- a/packages/controller/src/lib/restart.ts
+++ b/packages/controller/src/lib/restart.ts
@@ -1,4 +1,5 @@
 import { spawn } from 'node:child_process';
+import { exec } from 'node:child_process';
 import os from 'node:os';
 import { getRootDir } from '@iobroker/js-controller-common-db/tools';
 import path from 'node:path';
@@ -13,21 +14,47 @@ export default function restart(callback?: () => void): void {
     let cmd;
     let args;
     if (os.platform() === 'win32') {
-        // On Windows, we execute the controller entry point directly
-        cmd = path.join(getRootDir(), 'iob.bat');
-        args = ['restart'];
+        // On Windows, we use powershell to restart the service, because execution of bat files
+        // is no more possible
+        const envPath = path.join(getRootDir(), '.env').replaceAll('\\', '\\\\');
+        cmd =
+            'powershell -Command ' +
+            '"$envPath = \\"' +
+            envPath +
+            '\\"; ' +
+            '$iobServiceName = \\"ioBroker\\"; ' +
+            'if (Test-Path $envPath){' +
+            '  foreach ($line in Get-Content $envPath){' +
+            '    $line = $line.Trim(); ' +
+            '    if ($line -match \\"^\\s*iobservicename\\s*=\\s*(.+)\\s*$\\"){' +
+            '      $iobServiceName = $matches[1].Trim(); break;' +
+            '    }' +
+            '  }' +
+            '}' +
+            'Write-Output \\"Restarting service $iobServiceName.exe\\";' +
+            'Restart-Service \\"$iobServiceName.exe\\" -Force"';
+        exec(cmd, (error, stdout, stderr) => {
+            if (error) {
+                console.error(`Error occurred: ${error.toString()}`);
+            }
+            if (stderr) {
+                console.error(`Error occurred: ${stderr}`);
+            }
+            console.log(`OK: ${stdout}`);
+        });
     } else {
         // Unix has a global ioBroker binary that delegates to the init system
         // We need to call that, so we don't have two instances of ioBroker running
         cmd = 'iobroker';
         args = ['restart'];
+
+        const child = spawn(cmd, args, {
+            detached: true,
+            stdio: ['ignore', 'ignore', 'ignore'],
+            windowsHide: true
+        });
+        child.unref();
     }
-    const child = spawn(cmd, args, {
-        detached: true,
-        stdio: ['ignore', 'ignore', 'ignore'],
-        windowsHide: true
-    });
-    child.unref();
     if (typeof callback === 'function') {
         setTimeout(() => callback(), 500);
     } else {

--- a/packages/controller/src/lib/restart.ts
+++ b/packages/controller/src/lib/restart.ts
@@ -15,17 +15,20 @@ export default async function restart(callback?: () => void): Promise<void> {
     if (os.platform() === 'win32') {
         // On Windows, we use powershell to restart the service, because execution of bat files is no more possible
         const envPath = path.join(getRootDir(), '.env').replaceAll('\\', '\\\\');
-        cmd = `powershell -Command "$envPath = \\"${envPath}\\"; 
-        $iobServiceName = \\"ioBroker\\"; 
-        if (Test-Path $envPath) {  
-          foreach ($line in Get-Content $envPath) {    
-            $line = $line.Trim(); 
-            if ($line -match \\"^\\s*iobservicename\\s*=\\s*(.+)\\s*$\\") {      
-                $iobServiceName = $matches[1].Trim(); break;   
-            }  
+        cmd = `powershell -Command "$envPath = \\"${envPath}\\";
+        $iobServiceName = \\"ioBroker\\";
+        if (Test-Path $envPath) {
+          foreach ($line in Get-Content $envPath) {
+            $line = $line.Trim();
+            if ($line -match \\"^\\s*iobservicename\\s*=\\s*(.+)\\s*$\\") {
+                $iobServiceName = $matches[1].Trim(); break;
+            }
           }
         }
         Write-Output \\"Restarting service $iobServiceName.exe\\";Restart-Service \\"$iobServiceName.exe\\" -Force"`;
+
+        // Remove line breaks, because the powershell command will fail otherwise
+        cmd = cmd.replaceAll('\r\n', ' ').replaceAll('\n', ' ').replaceAll('\r', ' ');
 
         try {
             await execAsync(cmd);

--- a/packages/controller/src/lib/restart.ts
+++ b/packages/controller/src/lib/restart.ts
@@ -28,7 +28,7 @@ export default async function restart(callback?: () => void): Promise<void> {
         Write-Output \\"Restarting service $iobServiceName.exe\\";Restart-Service \\"$iobServiceName.exe\\" -Force"`;
 
         // Remove line breaks, because the powershell command will fail otherwise
-        cmd = cmd.replaceAll('\r\n', ' ').replaceAll('\n', ' ').replaceAll('\r', ' ');
+        cmd = cmd.replace(/[\r\n]+/gm, ' ');
 
         try {
             await execAsync(cmd);


### PR DESCRIPTION
**Implementation details**
<!--
    Up to now, iob.bat was called to restart the windows service in restart.ts.
    due to a security fix for CVE-2024-27980 this is no more possible.
    The current fix uses a powershell call to resatrt the service.
-->

**Tests**
- [ ] I have added tests to avoid a recursion of this bug
- [X] It is not possible to test for this bug

**If no tests added, please specify why it was not possible**
<!--
    A complete Windows environment with setup windows service is needed to verify this fix.
-->

