### PR TITLE
[feat]: clear package update notification if no updates are present anymore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 	## __WORK IN PROGRESS__
 -->
 
+## __WORK IN PROGRESS__
+* (foxriver76) clear package update notification if no updates are present anymore
+* (Gaspode69) fixed restarting controller on Windows systems
+
 ## 6.0.9 (2024-07-20) - Kiera
 * (foxriver76) provide method `getAdapterScopedPackageIdentifier` for adapters
 

--- a/packages/controller/src/main.ts
+++ b/packages/controller/src/main.ts
@@ -5720,6 +5720,7 @@ async function listUpdatableOsPackages(): Promise<void> {
     const packages = await packManager.listUpgradeablePackages();
 
     if (!packages.length) {
+        await notificationHandler.clearNotifications('system', 'packageUpdates', `system.host.${hostname}`);
         return;
     }
 


### PR DESCRIPTION
**Link the feature issue which is closed by this PR**
<!--
If the PR closes an issue add a `closes #issue-no`. If no issue exists yet, please create an issue first to discuss with the core team if this feature is desirable.
-->
- closes #2842

**Implementation details**
<!--
    What has been changed?
-->
During the update check if no updates are found, we ensure that the notification is deleted. 

**Tests**
- [ ] I have added tests to test this feature
- [x] It is not possible to test this feature

**Documentation**
<!--
    New features should be documented in the `README.md` file under `Feature Overview`. If a host message was added, please document it under `Feature Overview/js-controller Host Messages`.
-->
- [ ] I have documented the new feature
Not necessary

**If no tests added, please specify why it was not possible**
<!--
    E.g. the feature is only triggered if the system runs low on memory.
-->
Needs available os updates which would need to be performed. 