### PR TITLE
[fix]: do not check for os updates on docker installations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 -->
 
 ## __WORK IN PROGRESS__
+* (foxriver76) do not check for OS updates on Docker installations
 * (foxriver76) clear package update notification if no updates are present anymore
 * (Gaspode69) fixed restarting controller on Windows systems
 

--- a/packages/controller/src/main.ts
+++ b/packages/controller/src/main.ts
@@ -5714,6 +5714,10 @@ async function setInstanceOfflineStates(id: ioBroker.ObjectIDs.Instance): Promis
  * Check for updatable OS packages and register them as notification
  */
 async function listUpdatableOsPackages(): Promise<void> {
+    if (tools.isDocker()) {
+        return;
+    }
+
     const packManager = new PacketManager();
     await packManager.ready();
 


### PR DESCRIPTION
**Link the issue which is closed by this PR**
<!--
    If the PR closes the issue add a `closes #issue-no`. If no issue exists yet, please create an issue first.
-->
- closes #2849

**Implementation details**
<!--
    What has been changed?
-->
On docker systems we do not inform about OS updates, in the feature we could think about informing about new docker image versions

**Tests**
- [ ] I have added tests to avoid a recursion of this bug
- [x] It is not possible to test for this bug

**If no tests added, please specify why it was not possible**
<!--
    E.g. the bug is only reproducible if the system runs out of disk space.
-->

needs a system which has updates available and would need a docker env.. 