### PR TITLE
[feat]: only generate packageUpdates notification if a new package update has been detected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@
 	## __WORK IN PROGRESS__
 -->
 
-## 6.0.10 (2024-08-05)
+## __WORK IN PROGRESS__
+* (@foxriver76) only generate `packageUpdates` notification, if new updates detected
+
+## 6.0.10 (2024-08-05) - Kiera
 * (foxriver76) fixed "alias subscription error" log 
 * (foxriver76) do not check for OS updates on Docker installations
 * (foxriver76) clear package update notification if no updates are present anymore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 	## __WORK IN PROGRESS__
 -->
 
-## __WORK IN PROGRESS__
+## __WORK IN PROGRESS__ - Kiera
 * (@foxriver76) only generate `packageUpdates` notification, if new updates detected
 
 ## 6.0.10 (2024-08-05) - Kiera

--- a/packages/controller/src/main.ts
+++ b/packages/controller/src/main.ts
@@ -5734,7 +5734,7 @@ async function listUpdatableOsPackages(): Promise<void> {
     }
 
     const knownPackages: string[] = typeof packagesState?.val === 'string' ? JSON.parse(packagesState.val) : [];
-    const hasNewPackage = !!packages.find(pack => !knownPackages.includes(pack));
+    const hasNewPackage = packages.some(pack => !knownPackages.includes(pack));
 
     if (!hasNewPackage) {
         return;

--- a/packages/controller/src/main.ts
+++ b/packages/controller/src/main.ts
@@ -5725,20 +5725,15 @@ async function listUpdatableOsPackages(): Promise<void> {
 
     const packageStateId = `${hostObjectPrefix}.osPackageUpdates`;
     const packagesState = await states.getState(packageStateId);
-    const newPackStateVal = JSON.stringify(packages);
 
-    if (packagesState?.val === newPackStateVal) {
-        return;
-    }
-
-    await states.setState(packageStateId, { val: newPackStateVal, ack: true });
+    await states.setState(packageStateId, { val: JSON.stringify(packages), ack: true });
 
     if (!packages.length) {
         await notificationHandler.clearNotifications('system', 'packageUpdates', `system.host.${hostname}`);
         return;
     }
 
-    const knownPackages = JSON.parse(typeof packagesState?.val === 'string' ? packagesState.val : '[]');
+    const knownPackages: string[] = JSON.parse(typeof packagesState?.val === 'string' ? packagesState.val : '[]');
     const hasNewPackage = !!packages.find(pack => !knownPackages.includes(pack));
 
     if (!hasNewPackage) {

--- a/packages/controller/src/main.ts
+++ b/packages/controller/src/main.ts
@@ -5724,7 +5724,6 @@ async function listUpdatableOsPackages(): Promise<void> {
     const packages = await packManager.listUpgradeablePackages();
 
     const packageStateId = `${hostObjectPrefix}.osPackageUpdates`;
-
     const packagesState = await states.getState(packageStateId);
     const newPackStateVal = JSON.stringify(packages);
 
@@ -5732,7 +5731,7 @@ async function listUpdatableOsPackages(): Promise<void> {
         return;
     }
 
-    await states.setState(`${hostObjectPrefix}.osPackageUpdates`, { val: newPackStateVal, ack: true });
+    await states.setState(packageStateId, { val: newPackStateVal, ack: true });
 
     if (!packages.length) {
         await notificationHandler.clearNotifications('system', 'packageUpdates', `system.host.${hostname}`);

--- a/packages/controller/src/main.ts
+++ b/packages/controller/src/main.ts
@@ -5733,7 +5733,7 @@ async function listUpdatableOsPackages(): Promise<void> {
         return;
     }
 
-    const knownPackages: string[] = JSON.parse(typeof packagesState?.val === 'string' ? packagesState.val : '[]');
+    const knownPackages: string[] = typeof packagesState?.val === 'string' ? JSON.parse(packagesState.val) : [];
     const hasNewPackage = !!packages.find(pack => !knownPackages.includes(pack));
 
     if (!hasNewPackage) {


### PR DESCRIPTION
**Link the feature issue which is closed by this PR**
<!--
If the PR closes an issue add a `closes #issue-no`. If no issue exists yet, please create an issue first to discuss with the core team if this feature is desirable.
-->
- closes #2864

**Implementation details**
<!--
    What has been changed?
-->
We only re-generate the notification if a new package has been detected which was not in the packages that have already been reported to the user. 

**Tests**
- [ ] I have added tests to test this feature
- [x] It is not possible to test this feature

**Documentation**
<!--
    New features should be documented in the `README.md` file under `Feature Overview`. If a host message was added, please document it under `Feature Overview/js-controller Host Messages`.
-->
- [ ] I have documented the new feature

It already is.

**If no tests added, please specify why it was not possible**
<!--
    E.g. the feature is only triggered if the system runs low on memory.
-->

would need updatable packages