### PR TITLE
[feat]: create backup via jsonl files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ## __WORK IN PROGRESS__
 * (@foxriver76) enhanced translations for the `diskSpaceIssues` notification category
+* (@foxriver76) improved backup/restore process to work for arbitrary large installations
 
 ## 6.0.11 (2024-08-21) - Kiera
 * (@foxriver76) only generate `packageUpdates` notification, if new updates detected

--- a/packages/cli/src/lib/setup.ts
+++ b/packages/cli/src/lib/setup.ts
@@ -1304,7 +1304,7 @@ async function processCommand(
                 try {
                     const filePath = await backup.createBackup(name);
                     console.log(`Backup created: ${filePath!}`);
-                    console.log('This backup can only be restored with js-controller version up from 4.1');
+                    console.log('This backup can only be restored with js-controller version up from 6.1');
                     return void callback(EXIT_CODES.NO_ERROR);
                 } catch (e) {
                     console.log(`Cannot create backup: ${e.message}`);

--- a/packages/cli/src/lib/setup.ts
+++ b/packages/cli/src/lib/setup.ts
@@ -1259,7 +1259,7 @@ async function processCommand(
         case 'restore': {
             const { BackupRestore } = await import('./setup/setupBackup.js');
 
-            dbConnect(params, ({ isOffline, objects, states }) => {
+            dbConnect(params, async ({ isOffline, objects, states }) => {
                 if (!isOffline) {
                     console.error(`Stop ${tools.appName} first!`);
                     return void callback(EXIT_CODES.CONTROLLER_RUNNING);
@@ -1273,17 +1273,16 @@ async function processCommand(
                     processExit: callback
                 });
 
-                backup.restoreBackup({
+                const { exitCode } = await backup.restoreBackup({
                     name: args[0],
                     force: !!params.force,
-                    dontDeleteAdapters: false,
-                    callback: ({ exitCode }) => {
-                        if (exitCode === EXIT_CODES.NO_ERROR) {
-                            console.log('System successfully restored!');
-                        }
-                        return void callback(exitCode);
-                    }
+                    dontDeleteAdapters: false
                 });
+
+                if (exitCode === EXIT_CODES.NO_ERROR) {
+                    console.log('System successfully restored!');
+                }
+                return void callback(exitCode);
             });
             break;
         }

--- a/packages/cli/src/lib/setup.ts
+++ b/packages/cli/src/lib/setup.ts
@@ -1303,7 +1303,7 @@ async function processCommand(
                 try {
                     const filePath = await backup.createBackup(name);
                     console.log(`Backup created: ${filePath!}`);
-                    console.log('This backup can only be restored with js-controller version up from 6.1');
+                    console.log('This backup can only be restored with js-controller version 6.1 or higher');
                     return void callback(EXIT_CODES.NO_ERROR);
                 } catch (e) {
                     console.log(`Cannot create backup: ${e.message}`);

--- a/packages/cli/src/lib/setup/setupBackup.ts
+++ b/packages/cli/src/lib/setup/setupBackup.ts
@@ -25,7 +25,7 @@ type BackupObject = Omit<ioBroker.GetObjectListItem<ioBroker.Object>, 'doc'>;
 
 export interface RestoreBackupReturnValue {
     /** Exit code of the process */
-    exitCode: number;
+    exitCode: EXIT_CODES;
     /** The new states db connection after restore */
     states: StatesRedisClient;
     /** The new objects db connection after restore */
@@ -217,7 +217,7 @@ export class BackupRestore {
      */
     private removeTempBackupDir(): void {
         try {
-            fs.rmSync(`${this.tmpDir}/backup`, { recursive: true, force: true });
+            fs.rmSync(path.join(this.tmpDir, 'backup'), { recursive: true, force: true });
         } catch (e) {
             console.error(`host.${this.hostname} Cannot clear temporary backup directory: ${e.message}`);
         }
@@ -394,58 +394,47 @@ export class BackupRestore {
 
     //--------------------------------------- RESTORE ---------------------------------------------------
     /**
-     * Helper to restore raw states
+     * Helper to restore raw state
      *
-     * @param statesList - list of state ids
-     * @param stateObjects - list of state objects
+     * @param stateId - state ID
+     * @param stateObject - the corresponding state object
      */
-    private async _setStateHelper(statesList: string[], stateObjects: Record<string, ioBroker.State>): Promise<void> {
-        for (let i = 0; i < statesList.length; i++) {
-            try {
-                await this.states.setRawState(statesList[i], stateObjects[statesList[i]]);
-            } catch (err) {
-                console.log(`host.${this.hostname} Could not set value for state ${statesList[i]}: ${err.message}`);
-            }
-            if (i % 200 === 0) {
-                console.log(`host.${this.hostname} Processed ${i}/${statesList.length} states`);
-            }
+    private async _setStateHelper(stateId: string, stateObject: ioBroker.State): Promise<void> {
+        try {
+            await this.states.setRawState(stateId, stateObject);
+        } catch (e) {
+            console.log(`host.${this.hostname} Could not set value for state ${stateId}: ${e.message}`);
         }
     }
 
     /**
      * Sets all objects to the db and disables all adapters
      *
-     * @param _objects - array of all objects to be set
+     * @param object - object to be set
      */
-    private async _setObjHelper(_objects: BackupObject[]): Promise<void> {
-        for (let i = 0; i < _objects.length; i++) {
-            // Disable all adapters.
-            if (
-                !this.dbMigration &&
-                _objects[i].id &&
-                /^system\.adapter\..+\.\d$/.test(_objects[i].id) &&
-                !_objects[i].id.startsWith('system.adapter.admin.') &&
-                !_objects[i].id.startsWith('system.adapter.backitup.')
-            ) {
-                if (_objects[i].value.common?.enabled) {
-                    _objects[i].value.common.enabled = false;
-                }
+    private async _setObjHelper(object: ioBroker.Object): Promise<void> {
+        // Disable all adapters.
+        if (
+            !this.dbMigration &&
+            object._id &&
+            /^system\.adapter\..+\.\d$/.test(object._id) &&
+            !object._id.startsWith('system.adapter.admin.') &&
+            !object._id.startsWith('system.adapter.backitup.')
+        ) {
+            if (object.common?.enabled) {
+                object.common.enabled = false;
             }
+        }
 
-            try {
-                await this.objects.setObject(_objects[i].id, _objects[i].value);
-            } catch (err) {
-                console.warn(`host.${this.hostname} Cannot restore ${_objects[i].id}: ${err.message}`);
-            }
-
-            if (i % 200 === 0) {
-                console.log(`host.${this.hostname} Processed ${i}/${_objects.length} objects`);
-            }
+        try {
+            await this.objects.setObject(object._id, object);
+        } catch (e) {
+            console.warn(`host.${this.hostname} Cannot restore ${object._id}: ${e.message}`);
         }
     }
 
     /**
-     * Creates all provided object if non existing
+     * Creates all provided object if non-existing
      *
      * @param objectList - list of objects to be created
      */
@@ -654,53 +643,52 @@ export class BackupRestore {
                         return;
                     }
                     stat = fs.statSync(backupPath);
-                } catch (err) {
-                    console.error(`Ignoring ${backupPath} because can not get file type: ${err.message}`);
+                } catch (e) {
+                    console.error(`Ignoring ${backupPath} because can not get file type: ${e.message}`);
                     return;
                 }
                 if (stat.isDirectory()) {
                     this.copyFolderRecursiveSync(backupPath, this.configDir);
                 }
             });
-        } catch (err) {
-            console.error(`Ignoring ${backupDir} because can not read directory: ${err.message}`);
+        } catch (e) {
+            console.error(`Ignoring ${backupDir} because can not read directory: ${e.message}`);
         }
     }
 
     /**
-     * Restore after controller has been stopped
+     * Restore JSONL backup after controller has been stopped
      *
      * @param options The restore options
      */
-    private async _restoreAfterStop(options: RestoreAfterStopOptions): Promise<number> {
-        const { force, restartOnFinish, dontDeleteAdapters } = options;
-
-        // Open file
-        let data = fs.readFileSync(`${this.tmpDir}/backup/backup.json`, 'utf8');
+    private async _restoreJsonlBackup(options: RestoreAfterStopOptions): Promise<EXIT_CODES> {
+        const { force, dontDeleteAdapters } = options;
         const hostname = tools.getHostName();
-        // replace all hostnames of instances etc with the new host
-        data = data.replace(this.HOSTNAME_PLACEHOLDER_REGEX, hostname);
-        fs.writeFileSync(`${this.tmpDir}/backup/backup_.json`, data);
-        let restore: Backup;
-        try {
-            restore = JSON.parse(data);
-        } catch (err) {
-            console.error(`Cannot parse "${this.tmpDir}/backup/backup_.json": ${err.message}`);
-            return EXIT_CODES.CANNOT_RESTORE_BACKUP;
+
+        const backupBaseDir = path.join(this.tmpDir, 'backup');
+
+        const config: ioBroker.IoBrokerJson = await fs.readJSON(path.join(backupBaseDir, 'config.json'));
+        const backupHostName = config.system?.hostname || hostname;
+
+        // we need to find the host obj for the compatibility check
+        const objFd = await open(path.join(backupBaseDir, 'objects.jsonl'));
+        const rlObj = objFd.readLines();
+
+        const hostObjArr: BackupObject[] = [];
+
+        for await (let line of rlObj) {
+            line = line.replace(this.HOSTNAME_PLACEHOLDER_REGEX, hostname);
+            const obj: ioBroker.Object = JSON.parse(line);
+            if (obj._id === `system.host.${backupHostName}`) {
+                hostObjArr.push({ id: obj._id, value: obj });
+                break;
+            }
         }
 
-        if (!restore.objects) {
-            console.error('The backup does not contain any objects.');
-            return EXIT_CODES.CANNOT_RESTORE_BACKUP;
-        }
+        await objFd.close();
 
         // check that the same controller version is installed as it is contained in backup
-        const exitCode = this._ensureCompatibility(
-            controllerDir,
-            restore.config?.system?.hostname || hostname,
-            restore.objects,
-            force
-        );
+        const exitCode = this._ensureCompatibility(controllerDir, backupHostName, hostObjArr, force);
 
         if (exitCode) {
             // we had an error
@@ -713,30 +701,144 @@ export class BackupRestore {
         }
 
         // restore ioBroker.json
-        if (restore.config) {
-            fs.writeFileSync(tools.getConfigFileName(), JSON.stringify(restore.config, null, 2));
-            await this.connectToNewDatabase(restore.config);
-        }
+        fs.writeFileSync(tools.getConfigFileName(), JSON.stringify(config, null, 2));
+        await this.connectToNewDatabase(config);
 
         console.log(`host.${hostname} Clear all objects and states...`);
         await this.cleanDatabase(false);
         console.log(`host.${hostname} done.`);
 
-        const sList = Object.keys(restore.states);
+        const objectsFd = await open(path.join(backupBaseDir, 'objects.jsonl'));
+        const rlObjects = objectsFd.readLines();
 
-        await this._setObjHelper(restore.objects);
-        console.log(`${restore.objects.length} objects restored.`);
-        await this._setStateHelper(sList, restore.states);
-        console.log(`${sList.length} states restored.`);
+        let count = 0;
+
+        for await (let line of rlObjects) {
+            line = line.replace(this.HOSTNAME_PLACEHOLDER_REGEX, hostname);
+            const obj: ioBroker.Object = JSON.parse(line);
+            await this._setObjHelper(obj);
+            count++;
+        }
+
+        console.log(`${count} objects restored.`);
+
+        await objectsFd.close();
+
+        const statesFd = await open(path.join(backupBaseDir, 'states.jsonl'));
+        const rlStates = statesFd.readLines();
+
+        count = 0;
+
+        for await (let line of rlStates) {
+            line = line.replace(this.HOSTNAME_PLACEHOLDER_REGEX, hostname);
+            const state: { id: string; state: ioBroker.State } = JSON.parse(line);
+            await this._setStateHelper(state.id, state.state);
+            count++;
+        }
+
+        console.log(`${count} states restored.`);
+
+        await statesFd.close();
+
+        return EXIT_CODES.NO_ERROR;
+    }
+
+    /**
+     * Restore after controller has been stopped
+     *
+     * @param options The restore options
+     */
+    private async _restoreAfterStop(options: RestoreAfterStopOptions): Promise<EXIT_CODES> {
+        const { force, restartOnFinish, dontDeleteAdapters } = options;
+
+        const backupBaseDir = path.join(this.tmpDir, 'backup');
+        const isJsonl = await fs.pathExists(path.join(backupBaseDir, 'config.json'));
+
+        if (isJsonl) {
+            const exitCode = await this._restoreJsonlBackup(options);
+            if (exitCode !== EXIT_CODES.NO_ERROR) {
+                return exitCode;
+            }
+        } else {
+            const hostname = tools.getHostName();
+            console.log(`host.${hostname} Restore legacy backup.`);
+
+            // Open file
+            let data = fs.readFileSync(path.join(backupBaseDir, 'backup.json'), 'utf8');
+            // replace all hostnames of instances etc with the new host
+            data = data.replace(this.HOSTNAME_PLACEHOLDER_REGEX, hostname);
+            fs.writeFileSync(path.join(backupBaseDir, 'backup_.json'), data);
+            let restore: Backup;
+            try {
+                restore = JSON.parse(data);
+            } catch (e) {
+                console.error(`Cannot parse "${path.join(backupBaseDir, 'backup_.json')}": ${e.message}`);
+                return EXIT_CODES.CANNOT_RESTORE_BACKUP;
+            }
+
+            if (!restore.objects) {
+                console.error('The backup does not contain any objects.');
+                return EXIT_CODES.CANNOT_RESTORE_BACKUP;
+            }
+
+            // check that the same controller version is installed as it is contained in backup
+            const exitCode = this._ensureCompatibility(
+                controllerDir,
+                restore.config?.system?.hostname || hostname,
+                restore.objects,
+                force
+            );
+
+            if (exitCode) {
+                // we had an error
+                return exitCode;
+            }
+
+            if (!dontDeleteAdapters) {
+                // prevent having wrong versions of adapters
+                await this._removeAllAdapters();
+            }
+
+            // restore ioBroker.json
+            if (restore.config) {
+                fs.writeFileSync(tools.getConfigFileName(), JSON.stringify(restore.config, null, 2));
+                await this.connectToNewDatabase(restore.config);
+            }
+
+            console.log(`host.${hostname} Clear all objects and states...`);
+            await this.cleanDatabase(false);
+            console.log(`host.${hostname} done.`);
+
+            const sList = Object.keys(restore.states);
+
+            for (let i = 0; i < restore.objects.length; i++) {
+                await this._setObjHelper(restore.objects[i].value);
+                if (i % 200 === 0) {
+                    console.log(`host.${this.hostname} Processed ${i}/${restore.objects.length} objects`);
+                }
+            }
+
+            console.log(`${restore.objects.length} objects restored.`);
+            for (let i = 0; i < sList.length; i++) {
+                const id = sList[i];
+                await this._setStateHelper(id, restore.states[id]);
+                if (i % 200 === 0) {
+                    console.log(`host.${this.hostname} Processed ${i}/${sList.length} states`);
+                }
+            }
+
+            console.log(`${sList.length} states restored.`);
+        }
+
         // Load user files into DB
-        await this._uploadUserFiles(`${this.tmpDir}/backup/files`);
+        await this._uploadUserFiles(path.join(backupBaseDir, 'files'));
         // reload objects of adapters (if some couldn't be removed - normally this shouldn't be necessary anymore)
         await this._reloadAdaptersObjects();
         // Reload host objects
         const packageIO = fs.readJSONSync(path.join(controllerDir, 'io-package.json'));
         await this._reloadAdapterObject(packageIO ? packageIO.objects : null);
         // copy all files into iob-data
-        await this._copyBackupedFiles(path.join(this.tmpDir, 'backup'));
+        this._copyBackupedFiles(backupBaseDir);
         // reinstall preserve adapters
         await this._restorePreservedAdapters();
 
@@ -1172,7 +1274,6 @@ export class BackupRestore {
             return { exitCode: EXIT_CODES.CANNOT_EXTRACT_FROM_ZIP, objects: this.objects, states: this.states };
         }
 
-        // TODO: or check for config.json
         if (
             !(await fs.pathExists(path.join(backupBasePath, 'backup.json'))) &&
             !(await fs.pathExists(path.join(backupBasePath, 'config.json')))
@@ -1189,6 +1290,8 @@ export class BackupRestore {
             force,
             dontDeleteAdapters
         });
+
+        this.removeTempBackupDir();
 
         return { exitCode, objects: this.objects, states: this.states };
     }

--- a/packages/cli/src/lib/setup/setupSetup.ts
+++ b/packages/cli/src/lib/setup/setupSetup.ts
@@ -647,33 +647,32 @@ Please DO NOT copy files manually into ioBroker storage directories!`
                     });
                     console.log('Restore backup ...');
                     console.log(`${COLOR_GREEN}This can take some time ... please be patient!${COLOR_RESET}`);
-                    backupRestore.restoreBackup({
+                    const { objects, states, exitCode } = await backupRestore.restoreBackup({
                         name: filePath,
                         force: false,
-                        dontDeleteAdapters: true,
-                        callback: async ({ exitCode, states, objects }) => {
-                            this.objects = objects;
-                            this.states = states;
-
-                            if (exitCode) {
-                                console.log(`Error happened during restore. Exit-Code: ${exitCode}`);
-                                console.log();
-                                console.log(`restoring conf/${tools.appName.toLowerCase()}.json`);
-                                fs.writeFileSync(tools.getConfigFileName(), JSON.stringify(oldConfig, null, 2));
-                                fs.unlinkSync(`${tools.getConfigFileName()}.bak`);
-                            } else {
-                                await this._maybeMigrateSets();
-                                console.log('Backup restored - Migration successful');
-                                console.log(COLOR_YELLOW);
-                                console.log('Important: If your system consists of multiple hosts please execute ');
-                                console.log('"iobroker upload all" on the master AFTER all other hosts/slaves have ');
-                                console.log('also been updated to this states/objects database configuration AND are');
-                                console.log(`running!${COLOR_RESET}`);
-                            }
-
-                            resolve(exitCode ? EXIT_CODES.MIGRATION_ERROR : EXIT_CODES.NO_ERROR);
-                        }
+                        dontDeleteAdapters: true
                     });
+
+                    this.objects = objects;
+                    this.states = states;
+
+                    if (exitCode) {
+                        console.log(`Error happened during restore. Exit-Code: ${exitCode}`);
+                        console.log();
+                        console.log(`restoring conf/${tools.appName.toLowerCase()}.json`);
+                        fs.writeFileSync(tools.getConfigFileName(), JSON.stringify(oldConfig, null, 2));
+                        fs.unlinkSync(`${tools.getConfigFileName()}.bak`);
+                    } else {
+                        await this._maybeMigrateSets();
+                        console.log('Backup restored - Migration successful');
+                        console.log(COLOR_YELLOW);
+                        console.log('Important: If your system consists of multiple hosts please execute ');
+                        console.log('"iobroker upload all" on the master AFTER all other hosts/slaves have ');
+                        console.log('also been updated to this states/objects database configuration AND are');
+                        console.log(`running!${COLOR_RESET}`);
+                    }
+
+                    resolve(exitCode ? EXIT_CODES.MIGRATION_ERROR : EXIT_CODES.NO_ERROR);
                 });
             } else if (!newObjectsHasServer) {
                 console.log('');


### PR DESCRIPTION
**Link the feature issue which is closed by this PR**
<!--
If the PR closes an issue add a `closes #issue-no`. If no issue exists yet, please create an issue first to discuss with the core team if this feature is desirable.
-->
- closes #2042

**Implementation details**
<!--
    What has been changed?
-->
We make several changes out of one large backup.json we split into three files:

- config.json (the iobroker.json)
- states.jsonl
- objects.jsonl

These are now jsonl files containing one entry per line. Thus we no longer need to parse one large json, we simply stream line by line and avoid OOM situatiosn for arbitrary large isntallations.

**Tests**
- [ ] I have added tests to test this feature
- [ ] It is not possible to test this feature

The backup process is already tested

**Documentation**
<!--
    New features should be documented in the `README.md` file under `Feature Overview`. If a host message was added, please document it under `Feature Overview/js-controller Host Messages`.
-->
- [ ] I have documented the new feature
It just changes internal functionalities nothing changing to user side

**If no tests added, please specify why it was not possible**
<!--
    E.g. the feature is only triggered if the system runs low on memory.
-->
The backup process is already tested