### PR TITLE
[fix]: no longer create the iob_npm.done file

### DIFF
--- a/packages/cli/src/lib/setup/setupInstall.ts
+++ b/packages/cli/src/lib/setup/setupInstall.ts
@@ -435,8 +435,7 @@ export class Install {
                 console.error(`host.${hostname} Cannot install ${npmUrl}: ${result.exitCode}`);
                 return this.processExit(EXIT_CODES.CANNOT_INSTALL_NPM_PACKET);
             }
-            // create file that indicates that npm was called there
-            fs.writeFileSync(path.join(installDir, 'iob_npm.done'), ' ');
+
             // command succeeded
             return { _url: npmUrl, installDir: path.dirname(installDir) };
         } else {


### PR DESCRIPTION
**Link the issue which is closed by this PR**
<!--
    If the PR closes the issue add a `closes #issue-no`. If no issue exists yet, please create an issue first.
-->
It came up that the `iob_npm.done` file was checked in in repos in the past. This lead us into investigating and it seems that this file does not serve any purpose anymore.

**Implementation details**
<!--
    What has been changed?
-->
Simply no longer create the file

**Tests**
- [ ] I have added tests to avoid a recursion of this bug
- [x] It is not possible to test for this bug

**If no tests added, please specify why it was not possible**
<!--
    E.g. the bug is only reproducible if the system runs out of disk space.
-->
nothing to test here

