### PR TITLE
[fix]: States guard sendto

### DIFF
--- a/packages/controller/src/main.ts
+++ b/packages/controller/src/main.ts
@@ -1846,6 +1846,10 @@ async function sendTo(
     message: ioBroker.MessagePayload,
     callback?: ioBroker.ErrorCallback | ioBroker.MessageCallbackInfo
 ): Promise<void> {
+    if (!states) {
+        return;
+    }
+
     if (message === undefined) {
         message = command;
         command = 'send';
@@ -1876,7 +1880,7 @@ async function sendTo(
         }
     }
     try {
-        await states!.pushMessage(objName, obj);
+        await states.pushMessage(objName, obj);
     } catch (e) {
         // do not stringify the object, we had the issue with the invalid string length on serialization
         logger.error(


### PR DESCRIPTION
**Implementation details**
<!--
    What has been changed?
-->
On restart sometimes there were errors logs on windows systems because sendTo no longer works as states db was already gone. As this is expected to not work if states db is disconnected we return like on other methods.

**Tests**
- [ ] I have added tests to avoid a recursion of this bug
- [x] It is not possible to test for this bug


**If no tests added, please specify why it was not possible**
<!--
    E.g. the bug is only reproducible if the system runs out of disk space.
-->

No need to test just the log dissapears for these cases

