### PR TITLE
[fix]: fix nightly version increment

### DIFF
--- a/.github/workflows/nightly-dev-release.yml
+++ b/.github/workflows/nightly-dev-release.yml
@@ -108,7 +108,7 @@ jobs:
 
           // Figure out the next version
           const versionBump = process.env.VERSION_BUMP || 'prerelease';
-          const nightlyVersion = `${parsed.inc(process.env.VERSION_BUMP, prereleaseIdentifier)}-${dateStr}-${sha}`;
+          const nightlyVersion = `${parsed.inc(versionBump, prereleaseIdentifier)}-${dateStr}-${sha}`;
 
           // ensure that io-pack is in sync
           const fs = require('fs');


### PR DESCRIPTION
**Link the issue which is closed by this PR**
<!--
    If the PR closes the issue add a `closes #issue-no`. If no issue exists yet, please create an issue first.
-->
Bug hunter @Apollon77 found these luckily before a failing nightly

**Implementation details**
<!--
    What has been changed?
-->
Just fixed the new implementation of the nightly where we forgot to use a variable

**Tests**
- [ ] I have added tests to avoid a recursion of this bug
- [x] It is not possible to test for this bug

**If no tests added, please specify why it was not possible**
<!--
    E.g. the bug is only reproducible if the system runs out of disk space.
-->
It's GH action, we would have seen the fail on the next nightly

