### PR TITLE
[fix]: only validate config.json in backup if not setup custom migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 	Placeholder for the next version (at the beginning of the line):
 	## __WORK IN PROGRESS__
 -->
+
+## __WORK IN PROGRESS__ - Lucy
+* (@foxriver76) fixed crash case on database migration
+
 ## 7.0.0 (2024-10-06) - Lucy
 **Breaking changes**
 * Backups created with 7.0.x cannot be restored with previous version

--- a/packages/cli/src/lib/setup/setupBackup.ts
+++ b/packages/cli/src/lib/setup/setupBackup.ts
@@ -256,7 +256,7 @@ export class BackupRestore {
      * @param name - name of the backup
      * @param noConfig - do not store configs (used by setup custom migration)
      */
-    async createBackup(name: string, noConfig?: boolean): Promise<string> {
+    async createBackup(name: string, noConfig = false): Promise<string> {
         if (!name) {
             const d = new Date();
             name = `${d.getFullYear()}_${`0${d.getMonth() + 1}`.slice(-2)}_${`0${d.getDate()}`.slice(-2)}-${`0${d.getHours()}`.slice(
@@ -367,7 +367,7 @@ export class BackupRestore {
 
         console.log(`host.${hostname} Validating backup ...`);
         try {
-            await this._validateBackupAfterCreation();
+            await this._validateBackupAfterCreation(noConfig);
             console.log(`host.${hostname} The backup is valid!`);
 
             return await this._packBackup(name);
@@ -967,10 +967,15 @@ export class BackupRestore {
 
     /**
      * Validates the backup.json and all json files inside the backup after (in temporary directory), here we only abort if backup.json is corrupted
+     *
+     * @param noConfig if the backup does not contain a `config.json` (used by setup custom migration)
      */
-    private async _validateBackupAfterCreation(): Promise<void> {
+    private async _validateBackupAfterCreation(noConfig = false): Promise<void> {
         const backupBaseDir = path.join(this.tmpDir, 'backup');
-        await fs.readJSON(path.join(backupBaseDir, 'config.json'));
+
+        if (!noConfig) {
+            await fs.readJSON(path.join(backupBaseDir, 'config.json'));
+        }
 
         if (!(await fs.pathExists(path.join(backupBaseDir, 'objects.jsonl')))) {
             throw new Error('Backup does not contain valid objects');


### PR DESCRIPTION
**Link the issue which is closed by this PR**
<!--
    If the PR closes the issue add a `closes #issue-no`. If no issue exists yet, please create an issue first.
-->
- closes #2945

**Implementation details**
<!--
    What has been changed?
-->

We did not respect the no config flag on validation of the backup and always checked the `config.json` which is not there in migration cases. Hence, we simply passed this flag down now and only check if it is not a migration backup!

**Tests**
- [ ] I have added tests to avoid a recursion of this bug
- [x] It is not possible to test for this bug

**If no tests added, please specify why it was not possible**
<!--
    E.g. the bug is only reproducible if the system runs out of disk space.
-->

Would need a DB migration on the pipeline!

