### PR TITLE
[fix]: UI upgrade now runs as the same user as the js-controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 	Placeholder for the next version (at the beginning of the line):
 	## __WORK IN PROGRESS__
 -->
+
+## __WORK IN PROGRESS__ - Lucy
+* (@foxriver76) the UI upgrade now runs as the same user as the js-controller
+
 ## 7.0.0 (2024-10-06) - Lucy
 **Breaking changes**
 * Backups created with 7.0.x cannot be restored with previous version

--- a/packages/controller/src/lib/upgradeManager.ts
+++ b/packages/controller/src/lib/upgradeManager.ts
@@ -19,7 +19,9 @@ export interface UpgradeArguments {
     version: string;
     /** Admin instance which triggered the upgrade */
     adminInstance: number;
+    /** User id the process should run as */
     uid: number;
+    /** Group id the process should run as */
     gid: number;
 }
 

--- a/packages/controller/src/lib/upgradeManager.ts
+++ b/packages/controller/src/lib/upgradeManager.ts
@@ -101,6 +101,9 @@ class UpgradeManager {
         this.applyUser();
     }
 
+    /**
+     * To prevent commands (including npm) running as root, we apply the passed in gid and uid
+     */
     applyUser(): void {
         if (!process.setuid || !process.setgid) {
             const errMessage = 'Cannot ensure user and group ids on this system, because no POSIX platform';

--- a/packages/controller/src/lib/upgradeManager.ts
+++ b/packages/controller/src/lib/upgradeManager.ts
@@ -11,12 +11,16 @@ import fs from 'fs-extra';
 import type { Socket } from 'node:net';
 import type { Duplex } from 'node:stream';
 import url from 'node:url';
+import process from 'node:process';
 
+/** The upgrade arguments provided to the constructor of the UpgradeManager */
 export interface UpgradeArguments {
     /** Version of controller to upgrade too */
     version: string;
     /** Admin instance which triggered the upgrade */
     adminInstance: number;
+    uid: number;
+    gid: number;
 }
 
 interface Certificates {
@@ -63,6 +67,10 @@ class UpgradeManager {
     private readonly adminInstance: number;
     /** Desired controller version */
     private readonly version: string;
+    /** Group id the process should run as */
+    private readonly gid: number;
+    /** User id the process should run as */
+    private readonly uid: number;
     /** Response send by webserver */
     private readonly response: ServerResponse = {
         running: true,
@@ -85,6 +93,27 @@ class UpgradeManager {
         this.adminInstance = args.adminInstance;
         this.version = args.version;
         this.logger = this.setupLogger();
+        this.gid = args.gid;
+        this.uid = args.uid;
+
+        this.applyUser();
+    }
+
+    applyUser(): void {
+        if (!process.setuid || !process.setgid) {
+            const errMessage = 'Cannot ensure user and group ids on this system, because no POSIX platform';
+            this.log(errMessage, true);
+            throw new Error(errMessage);
+        }
+
+        try {
+            process.setgid(this.gid);
+            process.setuid(this.uid);
+        } catch (e) {
+            const errMessage = `Could not ensure user and group ids on this system: ${e.message}`;
+            this.log(errMessage, true);
+            throw new Error(errMessage);
+        }
     }
 
     /**
@@ -103,6 +132,8 @@ class UpgradeManager {
 
         const version = additionalArgs[0];
         const adminInstance = parseInt(additionalArgs[1]);
+        const uid = parseInt(additionalArgs[2]);
+        const gid = parseInt(additionalArgs[3]);
 
         const isValid = !!valid(version);
 
@@ -116,7 +147,17 @@ class UpgradeManager {
             throw new Error('Please provide a valid admin instance');
         }
 
-        return { version, adminInstance };
+        if (isNaN(uid)) {
+            UpgradeManager.printUsage();
+            throw new Error('Please provide a valid uid');
+        }
+
+        if (isNaN(gid)) {
+            UpgradeManager.printUsage();
+            throw new Error('Please provide a valid gid');
+        }
+
+        return { version, adminInstance, uid, gid };
     }
 
     /**
@@ -163,7 +204,7 @@ class UpgradeManager {
      * Print how the module should be used
      */
     static printUsage(): void {
-        console.info('Example usage: "node upgradeManager.js <version> <adminInstance>"');
+        console.info('Example usage: "node upgradeManager.js <version> <adminInstance> <uid> <gid>"');
     }
 
     /**

--- a/packages/controller/src/lib/upgradeManager.ts
+++ b/packages/controller/src/lib/upgradeManager.ts
@@ -104,7 +104,7 @@ class UpgradeManager {
     /**
      * To prevent commands (including npm) running as root, we apply the passed in gid and uid
      */
-    applyUser(): void {
+    private applyUser(): void {
         if (!process.setuid || !process.setgid) {
             const errMessage = 'Cannot ensure user and group ids on this system, because no POSIX platform';
             this.log(errMessage, true);

--- a/packages/controller/src/main.ts
+++ b/packages/controller/src/main.ts
@@ -5859,9 +5859,6 @@ async function startUpgradeManager(options: UpgradeArguments): Promise<void> {
 
     const isSystemd = await tools.isIoBrokerInstalledAsSystemd();
 
-    logger.error(`${hostLogPrefix} ${process.getuid ? process.getuid().toString() : 'asfasfasfasf'}`);
-    logger.error(`${hostLogPrefix} ${process.getgid ? process.getgid().toString() : 'asfasfasfasf'}`);
-
     if (isSystemd) {
         upgradeProcess = spawn(
             'sudo',

--- a/packages/controller/src/main.ts
+++ b/packages/controller/src/main.ts
@@ -2760,7 +2760,12 @@ async function processMessage(msg: ioBroker.SendableMessage): Promise<null | voi
             const { version, adminInstance } = msg.message;
 
             logger.info(`${hostLogPrefix} Controller will upgrade itself to version ${version}`);
-            await startUpgradeManager({ version, adminInstance });
+            await startUpgradeManager({
+                version,
+                adminInstance,
+                uid: process.getuid ? process.getuid() : 0,
+                gid: process.getgid ? process.getgid() : 0,
+            });
 
             if (msg.callback) {
                 sendTo(msg.from, msg.command, { result: true }, msg.callback);
@@ -5848,11 +5853,14 @@ async function upgradeOsPackages(packages: UpgradePacket[]): Promise<void> {
  * @param options Arguments passed to the UpgradeManager process
  */
 async function startUpgradeManager(options: UpgradeArguments): Promise<void> {
-    const { version, adminInstance } = options;
+    const { version, adminInstance, uid, gid } = options;
     const upgradeProcessPath = require.resolve('./lib/upgradeManager');
     let upgradeProcess: cp.ChildProcess;
 
     const isSystemd = await tools.isIoBrokerInstalledAsSystemd();
+
+    logger.error(`${hostLogPrefix} ${process.getuid ? process.getuid().toString() : 'asfasfasfasf'}`);
+    logger.error(`${hostLogPrefix} ${process.getgid ? process.getgid().toString() : 'asfasfasfasf'}`);
 
     if (isSystemd) {
         upgradeProcess = spawn(
@@ -5864,6 +5872,8 @@ async function startUpgradeManager(options: UpgradeArguments): Promise<void> {
                 upgradeProcessPath,
                 version,
                 adminInstance.toString(),
+                uid.toString(),
+                gid.toString(),
             ],
             {
                 detached: true,


### PR DESCRIPTION
**Link the issue which is closed by this PR**
<!--
    If the PR closes the issue add a `closes #issue-no`. If no issue exists yet, please create an issue first.
-->
See this problem here https://forum.iobroker.net/topic/77574/änderungen-iob-cli-installer-fixer-mit-root-accounts/116?_=1729624052577

**Implementation details**
<!--
    What has been changed?
-->
Currently the UI upgrade runs as root as the upgrade process needs to be started via `systemd` to survive the stop of the controller which runs as `systemd` itself. This has the downside that everything including `npm` is executed as `root`.
Hence, the `/opt/iobroker/node_modules/iobroker.js-controller/` content and likely other modules touched by npm are now owned by root.

Due to permission errors it seems that the `iobroker` user cannot read the users file and is not able to start the `systemd` via `sudo -u iobroker` leading to 
```
sudo: Unbekannter Benutzer iobroker
sudo: Fehler beim Initialisieren des Audit-Plugins sudoers_audit
```
Hence, we need another solution. This solution proposed here requires the controller to pass the current `uid` and `gid` to the upgrade process which then degrades itself from `root` to the given `gid` and `uid`.

**Tests**
- [ ] I have added tests to avoid a recursion of this bug
- [x] It is not possible to test for this bug

**If no tests added, please specify why it was not possible**
<!--
    E.g. the bug is only reproducible if the system runs out of disk space.
-->

Would need to upgrade the controller and a specific setup 