### PR TITLE
[fix]: fixed `iob setup custom` migration and  `iob validate`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 	Placeholder for the next version (at the beginning of the line):
 	## __WORK IN PROGRESS__
 -->
+
+## __WORK IN PROGRESS__
+* (@foxriver76) fixed `iob validate` command and `setup custom` migration
+
 ## 7.0.0 (2024-10-06) - Lucy
 **Breaking changes**
 * Backups created with 7.0.x cannot be restored with previous version

--- a/packages/cli/src/lib/setup.ts
+++ b/packages/cli/src/lib/setup.ts
@@ -1328,9 +1328,9 @@ async function processCommand(
                     await backup.validateBackup(name);
                     console.log('Backup OK');
                     return void exitApplicationSave(0);
-                } catch (err) {
-                    console.log(`Backup check failed: ${err.message}`);
-                    return void exitApplicationSave(1);
+                } catch (e) {
+                    console.log(`Backup check failed: ${e.message}`);
+                    return void exitApplicationSave(e instanceof IoBrokerError ? e.code : 1);
                 }
             });
             break;

--- a/packages/cli/src/lib/setup/setupBackup.ts
+++ b/packages/cli/src/lib/setup/setupBackup.ts
@@ -1066,7 +1066,7 @@ export class BackupRestore {
             } else {
                 console.warn(`No backups found. Create a backup, using "${tools.appName} backup" first`);
             }
-            return void this.processExit(EXIT_CODES.INVALID_ARGUMENTS);
+            throw new IoBrokerError({ message: 'Backup not found', code: EXIT_CODES.INVALID_ARGUMENTS });
         }
         // If number
         if (parseInt(name, 10).toString() === name.toString()) {
@@ -1085,7 +1085,8 @@ export class BackupRestore {
                 } else {
                     console.log(`No existing backups. Create a backup, using "${tools.appName} backup" first`);
                 }
-                return void this.processExit(EXIT_CODES.INVALID_ARGUMENTS);
+
+                throw new IoBrokerError({ message: 'Backup not found', code: EXIT_CODES.INVALID_ARGUMENTS });
             }
             console.log(`host.${this.hostname} Using backup file ${name}`);
         }
@@ -1103,7 +1104,7 @@ export class BackupRestore {
         }
         if (!fs.existsSync(name)) {
             console.error(`host.${this.hostname} Cannot find ${name}`);
-            return void this.processExit(EXIT_CODES.INVALID_ARGUMENTS);
+            throw new IoBrokerError({ message: 'Backup not found', code: EXIT_CODES.INVALID_ARGUMENTS });
         }
 
         if (fs.existsSync(`${this.tmpDir}/backup/backup.json`)) {
@@ -1116,8 +1117,9 @@ export class BackupRestore {
                 cwd: this.tmpDir,
             });
         } catch (e) {
-            console.error(`host.${this.hostname} Cannot extract from file "${name}": ${e.message}`);
-            return void this.processExit(EXIT_CODES.INVALID_ARGUMENTS);
+            const errMessage = `Cannot extract from file "${name}": ${e.message}`;
+            console.error(`host.${this.hostname} ${errMessage}`);
+            throw new IoBrokerError({ message: 'Backup not found', code: EXIT_CODES.INVALID_ARGUMENTS });
         }
 
         try {
@@ -1135,14 +1137,14 @@ export class BackupRestore {
                 console.error(`host.${this.hostname} Cannot clear temporary backup directory: ${e.message}`);
             }
 
-            return void this.processExit(EXIT_CODES.CANNOT_EXTRACT_FROM_ZIP);
+            throw new IoBrokerError({ message: e.message, code: EXIT_CODES.CANNOT_EXTRACT_FROM_ZIP });
         }
 
         try {
             this.removeTempBackupDir();
         } catch (e) {
             console.error(`host.${this.hostname} Cannot clear temporary backup directory: ${e.message}`);
-            return void this.processExit(EXIT_CODES.CANNOT_EXTRACT_FROM_ZIP);
+            throw new IoBrokerError({ message: e.message, code: EXIT_CODES.CANNOT_EXTRACT_FROM_ZIP });
         }
     }
 

--- a/packages/cli/src/lib/setup/setupBackup.ts
+++ b/packages/cli/src/lib/setup/setupBackup.ts
@@ -91,7 +91,7 @@ export class BackupRestore {
     /** Regex to replace all occurrences of the HOSTNAME_PLACEHOLDER */
     private readonly HOSTNAME_PLACEHOLDER_REGEX = /\$\$__hostname__\$\$/g;
     /** Postfix for backup name */
-    private readonly BACKUP_POSTFIX = `_backup${tools.appName}`;
+    private readonly BACKUP_POSTFIX = `_backup${tools.appNameLowerCase}`;
 
     constructor(options: CLIBackupRestoreOptions) {
         options = options || {};

--- a/packages/cli/src/lib/setup/setupBackup.ts
+++ b/packages/cli/src/lib/setup/setupBackup.ts
@@ -90,6 +90,8 @@ export class BackupRestore {
     private readonly HOSTNAME_PLACEHOLDER_REPLACE = '$$$$__hostname__$$$$';
     /** Regex to replace all occurrences of the HOSTNAME_PLACEHOLDER */
     private readonly HOSTNAME_PLACEHOLDER_REGEX = /\$\$__hostname__\$\$/g;
+    /** Postfix for backup name */
+    private readonly BACKUP_POSTFIX = `_backup${tools.appName}`;
 
     constructor(options: CLIBackupRestoreOptions) {
         options = options || {};
@@ -261,7 +263,9 @@ export class BackupRestore {
             const d = new Date();
             name = `${d.getFullYear()}_${`0${d.getMonth() + 1}`.slice(-2)}_${`0${d.getDate()}`.slice(-2)}-${`0${d.getHours()}`.slice(
                 -2,
-            )}_${`0${d.getMinutes()}`.slice(-2)}_${`0${d.getSeconds()}`.slice(-2)}_backup${tools.appName}`;
+            )}_${`0${d.getMinutes()}`.slice(-2)}_${`0${d.getSeconds()}`.slice(-2)}${this.BACKUP_POSTFIX}`;
+        } else if (!name.endsWith(this.BACKUP_POSTFIX) && !name.endsWith(`${this.BACKUP_POSTFIX}.tar.gz`)) {
+            name += this.BACKUP_POSTFIX;
         }
 
         name = name.toString().replace(/\\/g, '/');
@@ -1061,7 +1065,7 @@ export class BackupRestore {
                 console.log('Please specify one of the backup names:');
 
                 for (const t in backups) {
-                    console.log(`${backups[t]} or ${backups[t].replace(`_backup${tools.appName}.tar.gz`, '')} or ${t}`);
+                    console.log(`${backups[t]} or ${backups[t].replace(`${this.BACKUP_POSTFIX}.tar.gz`, '')} or ${t}`);
                 }
             } else {
                 console.warn(`No backups found. Create a backup, using "${tools.appName} backup" first`);
@@ -1079,7 +1083,7 @@ export class BackupRestore {
                     console.log('Please specify one of the backup names:');
                     for (const t in backups) {
                         console.log(
-                            `${backups[t]} or ${backups[t].replace(`_backup${tools.appName}.tar.gz`, '')} or ${t}`,
+                            `${backups[t]} or ${backups[t].replace(`${this.BACKUP_POSTFIX}.tar.gz`, '')} or ${t}`,
                         );
                     }
                 } else {
@@ -1094,9 +1098,9 @@ export class BackupRestore {
         name = name.toString().replace(/\\/g, '/');
         if (!name.includes('/')) {
             name = BackupRestore.getBackupDir() + name;
-            const regEx = new RegExp(`_backup${tools.appName}`, 'i');
+            const regEx = new RegExp(this.BACKUP_POSTFIX, 'i');
             if (!regEx.test(name)) {
-                name += `_backup${tools.appName}`;
+                name += this.BACKUP_POSTFIX;
             }
             if (!name.match(/\.tar\.gz$/i)) {
                 name += '.tar.gz';
@@ -1222,7 +1226,7 @@ export class BackupRestore {
             backups.sort((a, b) => (b > a ? 1 : b === a ? 0 : -1));
             if (backups.length) {
                 backups.forEach((backup, i) =>
-                    console.log(`${backup} or ${backup.replace(`_backup${tools.appName}.tar.gz`, '')} or ${i}`),
+                    console.log(`${backup} or ${backup.replace(`${this.BACKUP_POSTFIX}.tar.gz`, '')} or ${i}`),
                 );
             } else {
                 console.warn('No backups found');
@@ -1247,7 +1251,7 @@ export class BackupRestore {
                 if (backups.length) {
                     console.log('Please specify one of the backup names:');
                     backups.forEach((backup, i) =>
-                        console.log(`${backup} or ${backup.replace(`_backup${tools.appName}.tar.gz`, '')} or ${i}`),
+                        console.log(`${backup} or ${backup.replace(`${this.BACKUP_POSTFIX}.tar.gz`, '')} or ${i}`),
                     );
                 }
             } else {
@@ -1258,9 +1262,9 @@ export class BackupRestore {
         name = name.toString().replace(/\\/g, '/');
         if (!name.includes('/')) {
             name = BackupRestore.getBackupDir() + name;
-            const regEx = new RegExp(`_backup${tools.appName}`, 'i');
+            const regEx = new RegExp(this.BACKUP_POSTFIX, 'i');
             if (!regEx.test(name)) {
-                name += `_backup${tools.appName}`;
+                name += this.BACKUP_POSTFIX;
             }
             if (!name.match(/\.tar\.gz$/i)) {
                 name += '.tar.gz';

--- a/packages/controller/test/lib/testConsole.ts
+++ b/packages/controller/test/lib/testConsole.ts
@@ -581,10 +581,16 @@ export function register(it: Mocha.TestFunction, expect: Chai.ExpectStatic, cont
 
         // expect(found).to.be.true;
 
-        const name = Math.round(Math.random() * 10000).toString();
+        const name = Math.round(Math.random() * 10_000).toString();
         res = await execAsync(`"${process.execPath}" "${iobExecutable}" backup ${name}`);
         expect(res.stderr).to.be.not.ok;
         expect(fs.existsSync(`${BackupRestore.getBackupDir() + name}.tar.gz`)).to.be.true;
+    }).timeout(20_000);
+
+    it(`${testName}validates backup`, async () => {
+        const res = await execAsync(`"${process.execPath}" "${iobExecutable}" validate 0`);
+        expect(res.stderr).to.be.not.ok;
+        expect(res.stdout).to.include('Backup OK');
     }).timeout(20_000);
 
     // list l

--- a/packages/controller/test/lib/testConsole.ts
+++ b/packages/controller/test/lib/testConsole.ts
@@ -581,13 +581,16 @@ export function register(it: Mocha.TestFunction, expect: Chai.ExpectStatic, cont
 
         // expect(found).to.be.true;
 
-        const name = `${Math.round(Math.random() * 10_000).toString()}iob`;
+        const name = Math.round(Math.random() * 10_000).toString();
         res = await execAsync(`"${process.execPath}" "${iobExecutable}" backup ${name}`);
         expect(res.stderr).to.be.not.ok;
         expect(fs.existsSync(`${BackupRestore.getBackupDir() + name}.tar.gz`)).to.be.true;
     }).timeout(20_000);
 
     it(`${testName}validates backup`, async () => {
+        // create a backup
+        await execAsync(`"${process.execPath}" "${iobExecutable}" backup`);
+        // and validate it
         const res = await execAsync(`"${process.execPath}" "${iobExecutable}" validate 0`);
         expect(res.stderr).to.be.not.ok;
         expect(res.stdout).to.include('Backup OK');

--- a/packages/controller/test/lib/testConsole.ts
+++ b/packages/controller/test/lib/testConsole.ts
@@ -584,13 +584,10 @@ export function register(it: Mocha.TestFunction, expect: Chai.ExpectStatic, cont
         const name = Math.round(Math.random() * 10_000).toString();
         res = await execAsync(`"${process.execPath}" "${iobExecutable}" backup ${name}`);
         expect(res.stderr).to.be.not.ok;
-        expect(fs.existsSync(`${BackupRestore.getBackupDir() + name}.tar.gz`)).to.be.true;
+        expect(fs.existsSync(`${BackupRestore.getBackupDir() + name}_backupiobroker.tar.gz`)).to.be.true;
     }).timeout(20_000);
 
     it(`${testName}validates backup`, async () => {
-        // create a backup
-        await execAsync(`"${process.execPath}" "${iobExecutable}" backup`);
-        // and validate it
         const res = await execAsync(`"${process.execPath}" "${iobExecutable}" validate 0`);
         expect(res.stderr).to.be.not.ok;
         expect(res.stdout).to.include('Backup OK');

--- a/packages/controller/test/lib/testConsole.ts
+++ b/packages/controller/test/lib/testConsole.ts
@@ -581,7 +581,7 @@ export function register(it: Mocha.TestFunction, expect: Chai.ExpectStatic, cont
 
         // expect(found).to.be.true;
 
-        const name = Math.round(Math.random() * 10_000).toString();
+        const name = `${Math.round(Math.random() * 10_000).toString()}iob`;
         res = await execAsync(`"${process.execPath}" "${iobExecutable}" backup ${name}`);
         expect(res.stderr).to.be.not.ok;
         expect(fs.existsSync(`${BackupRestore.getBackupDir() + name}.tar.gz`)).to.be.true;


### PR DESCRIPTION
**Link the issue which is closed by this PR**
<!--
    If the PR closes the issue add a `closes #issue-no`. If no issue exists yet, please create an issue first.
-->

#2945

**Implementation details**
<!--
    What has been changed?
-->
For validate we still assumed that the backup has the old structure. However, it should work with new backups and old ones.

Hence, we now detect if it is a new or old one by the existence of the `backup.json` file and call the appropriate validation respectively!

**Tests**
- [x] I have added tests to avoid a recursion of this bug
- [ ] It is not possible to test for this bug


