### PR TITLE
Adjustments for Repo-CLI PR

### DIFF
--- a/packages/cli/src/lib/setup.ts
+++ b/packages/cli/src/lib/setup.ts
@@ -20,7 +20,14 @@ import { CLIMessage } from '@/lib/cli/cliMessage.js';
 import { CLIPlugin } from '@/lib/cli/cliPlugin.js';
 import { error as CLIError } from '@/lib/cli/messages.js';
 import type { CLICommandContext, CLICommandOptions } from '@/lib/cli/cliCommand.js';
-import { getRepository, ignoreVersion, recognizeVersion } from '@/lib/setup/utils.js';
+import {
+    BETA_REPO_URL,
+    getRepository,
+    ignoreVersion,
+    isIntegerLikeInput,
+    recognizeVersion,
+    STABLE_REPO_URL,
+} from '@/lib/setup/utils.js';
 import { dbConnect, dbConnectAsync, exitApplicationSave } from '@/lib/setup/dbConnection.js';
 import { IoBrokerError } from '@/lib/setup/customError.js';
 import type { ListType } from '@/lib/setup/setupList.js';
@@ -30,6 +37,7 @@ import * as events from 'node:events';
 // eslint-disable-next-line unicorn/prefer-module
 const thisDir = url.fileURLToPath(new URL('.', import.meta.url || `file://${__filename}`));
 import { createRequire } from 'node:module';
+import { SYSTEM_CONFIG_ID, SYSTEM_REPOSITORIES_ID } from '@iobroker/js-controller-common-db/constants';
 // eslint-disable-next-line unicorn/prefer-module
 const require = createRequire(import.meta.url || `file://${__filename}`);
 
@@ -395,12 +403,12 @@ function initYargs(): ReturnType<typeof yargs> {
                 .command('all', 'Show entire config')
                 .command('<adapter>[.<instance>]', 'Status of a specified adapter instance');
         })
-        .command('repo [<name/index>]', 'Show repo information', yargs => {
+        .command('repo', 'Show repo information', yargs => {
             yargs
-                .command('set <name/index>', 'Set active repository')
-                .command('del <name/index>', 'Remove repository')
-                .command('add <name/index> <url>', 'Add repository')
-                .command('addset <name/index> <url>', 'Add repository and set it as active one')
+                .command('set <name>|<index>', 'Set active repository')
+                .command('del <name>|<index>', 'Remove repository')
+                .command('add <name> <url>', 'Add repository')
+                .command('addset <name> <url>', 'Add repository and set it as active one')
                 .command('show', 'List repositories');
         })
         .command(['uuid', 'id'], 'Show uuid of the installation', {})
@@ -670,8 +678,8 @@ async function processCommand(
                     const repo = new Repo({ objects, states });
 
                     try {
-                        await repo.rename('default', 'stable', 'http://download.iobroker.net/sources-dist.json');
-                        await repo.rename('latest', 'beta', 'http://download.iobroker.net/sources-dist-latest.json');
+                        await repo.rename('default', 'stable', STABLE_REPO_URL);
+                        await repo.rename('latest', 'beta', BETA_REPO_URL);
                     } catch (err) {
                         console.warn(`Cannot rename: ${err.message}`);
                     }
@@ -2529,103 +2537,102 @@ async function processCommand(
                 repoUrlOrCommand = 'show';
             }
 
-            dbConnect(params, async ({ objects, states }) => {
-                const { Repo } = await import('./setup/setupRepo.js');
-                const repo = new Repo({
-                    objects,
-                    states,
-                });
+            const { objects, states } = await dbConnectAsync(false, params);
+            const { Repo } = await import('./setup/setupRepo.js');
+            const repo = new Repo({
+                objects,
+                states,
+            });
 
-                if (repoUrlOrCommand === 'show') {
+            if (repoUrlOrCommand === 'show') {
+                try {
+                    await repo.showRepoStatus();
+                    return void callback();
+                } catch (e) {
+                    console.error(`Cannot show repository status: ${e.message}`);
+                    return void callback(EXIT_CODES.INVALID_REPO);
+                }
+            }
+
+            if (
+                repoUrlOrCommand === 'add' ||
+                repoUrlOrCommand === 'del' ||
+                repoUrlOrCommand === 'set' ||
+                repoUrlOrCommand === 'addset' ||
+                repoUrlOrCommand === 'unset'
+            ) {
+                if (!repoName || !repoName.match(/[-_\w]+/)) {
+                    console.error(`Invalid repository name: "${repoName}"`);
+                    return void callback(EXIT_CODES.INVALID_ARGUMENTS);
+                }
+
+                if (isIntegerLikeInput(repoName)) {
                     try {
-                        await repo.showRepoStatus();
-                        return void callback();
-                    } catch (err) {
-                        console.error(`Cannot show repository status: ${err.message}`);
-                        return void callback(EXIT_CODES.INVALID_REPO);
-                    }
-                } else if (
-                    repoUrlOrCommand === 'add' ||
-                    repoUrlOrCommand === 'del' ||
-                    repoUrlOrCommand === 'set' ||
-                    repoUrlOrCommand === 'addset' ||
-                    repoUrlOrCommand === 'unset'
-                ) {
-                    if (!repoName || !repoName.match(/[-_\w\d]+/)) {
-                        console.error(`Invalid repository name: "${repoName}"`);
-                        return void callback();
-                    }
-
-                    // If repository set as number in the list
-                    if (repoName.match(/^\d+$/)) {
-                        const repoIndexName: number = parseInt(repoName, 10);
-                        const obj = await objects.getObject('system.repositories');
-                        if (obj?.native?.repositories) {
-                            if (Object.keys(obj.native.repositories)[repoIndexName]) {
-                                repoName = Object.keys(obj.native.repositories)[repoIndexName];
-                            }
-                        }
-                    }
-
-                    if (repoUrlOrCommand === 'add' || repoUrlOrCommand === 'addset') {
-                        if (!repoUrl) {
-                            console.warn(
-                                `Please define repository URL or path: ${tools.appName.toLowerCase()} add <repoName> <repoUrlOrPath>`,
-                            );
-                            return void callback(EXIT_CODES.INVALID_ARGUMENTS);
-                        }
-                        try {
-                            await repo.add(repoName, repoUrl);
-
-                            if (repoUrlOrCommand === 'addset') {
-                                await repo.setActive(repoName);
-                                console.log(`Repository "${repoName}" set as active: "${repoUrl}"`);
-                                await repo.showRepoStatus();
-                                return void callback();
-                            }
-                            console.log(`Repository "${repoName}" added as "${repoUrl}"`);
-                            await repo.showRepoStatus();
-                            return void callback();
-                        } catch (err) {
-                            console.error(`Cannot add repository location: ${err.message}`);
-                            return void callback(EXIT_CODES.INVALID_REPO);
-                        }
-                    } else if (repoUrlOrCommand === 'set') {
-                        try {
-                            await repo.setActive(repoName);
-                            console.log(`Repository "${repoName}" set as active.`);
-                            await repo.showRepoStatus();
-                            return void callback();
-                        } catch (err) {
-                            console.error(`Cannot activate repository: ${err.message}`);
-                            return void callback(EXIT_CODES.INVALID_REPO);
-                        }
-                    } else if (repoUrlOrCommand === 'del') {
-                        try {
-                            await repo.del(repoName);
-                            console.log(`Repository "${repoName}" deleted.`);
-                            await repo.showRepoStatus();
-                            return void callback();
-                        } catch (err) {
-                            console.error(`Cannot remove repository: ${err.message}`);
-                            return void callback(EXIT_CODES.INVALID_REPO);
-                        }
-                    } else if (repoUrlOrCommand === 'unset') {
-                        try {
-                            await repo.setInactive(repoName);
-                            console.log(`Repository "${repoName}" deactivated.`);
-                            await repo.showRepoStatus();
-                            return void callback();
-                        } catch (err) {
-                            console.error(`Cannot deactivate repository: ${err.message}`);
-                            return void callback(EXIT_CODES.INVALID_REPO);
-                        }
-                    } else {
-                        console.warn(`Unknown repo command: ${repoUrlOrCommand as string}`);
+                        repoName = await repo.getNameByIndex(parseInt(repoName));
+                    } catch (e) {
+                        console.error(e.message);
                         return void callback(EXIT_CODES.INVALID_ARGUMENTS);
                     }
                 }
-            });
+
+                if (repoUrlOrCommand === 'add' || repoUrlOrCommand === 'addset') {
+                    if (!repoUrl) {
+                        console.warn(
+                            `Please define repository URL or path: ${tools.appName.toLowerCase()} add <repoName> <repoUrlOrPath>`,
+                        );
+                        return void callback(EXIT_CODES.INVALID_ARGUMENTS);
+                    }
+                    try {
+                        await repo.add(repoName, repoUrl);
+
+                        if (repoUrlOrCommand === 'addset') {
+                            await repo.setActive(repoName);
+                            console.log(`Repository "${repoName}" set as active: "${repoUrl}"`);
+                            await repo.showRepoStatus();
+                            return void callback();
+                        }
+                        console.log(`Repository "${repoName}" added as "${repoUrl}"`);
+                        await repo.showRepoStatus();
+                        return void callback();
+                    } catch (e) {
+                        console.error(`Cannot add repository location: ${e.message}`);
+                        return void callback(EXIT_CODES.INVALID_REPO);
+                    }
+                } else if (repoUrlOrCommand === 'set') {
+                    try {
+                        await repo.setActive(repoName);
+                        console.log(`Repository "${repoName}" set as active.`);
+                        await repo.showRepoStatus();
+                        return void callback();
+                    } catch (e) {
+                        console.error(`Cannot activate repository: ${e.message}`);
+                        return void callback(EXIT_CODES.INVALID_REPO);
+                    }
+                } else if (repoUrlOrCommand === 'del') {
+                    try {
+                        await repo.del(repoName);
+                        console.log(`Repository "${repoName}" deleted.`);
+                        await repo.showRepoStatus();
+                        return void callback();
+                    } catch (e) {
+                        console.error(`Cannot remove repository: ${e.message}`);
+                        return void callback(EXIT_CODES.INVALID_REPO);
+                    }
+                } else if (repoUrlOrCommand === 'unset') {
+                    try {
+                        await repo.setInactive(repoName);
+                        console.log(`Repository "${repoName}" deactivated.`);
+                        await repo.showRepoStatus();
+                        return void callback();
+                    } catch (e) {
+                        console.error(`Cannot deactivate repository: ${e.message}`);
+                        return void callback(EXIT_CODES.INVALID_REPO);
+                    }
+                } else {
+                    console.warn(`Unknown repo command: ${repoUrlOrCommand as string}`);
+                    return void callback(EXIT_CODES.INVALID_ARGUMENTS);
+                }
+            }
             break;
         }
 
@@ -2800,10 +2807,10 @@ const OBJECTS_THAT_CANNOT_BE_DELETED = [
     'alias.0',
     'enum.functions',
     'enum.rooms',
-    'system.config',
+    SYSTEM_CONFIG_ID,
     'system.group.administrator',
     'system.group.user',
-    'system.repositories',
+    SYSTEM_REPOSITORIES_ID,
     'system.user.admin',
 ];
 
@@ -2881,40 +2888,40 @@ async function cleanDatabase(isDeleteDb: boolean): Promise<number> {
     return keysCount;
 }
 
-function unsetup(params: Record<string, any>, callback: ExitCodeCb): void {
-    dbConnect(params, ({ objects }) => {
-        objects.delObject('system.meta.uuid', err => {
-            if (err) {
-                console.log(`uuid cannot be deleted: ${err.message}`);
-            } else {
-                console.log('system.meta.uuid deleted');
-            }
-            objects.getObject('system.config', (_err, obj) => {
-                if (obj?.common.licenseConfirmed || obj?.common.language || obj?.native?.secret) {
-                    obj.common.language = 'en';
-                    // allow with parameter --keepsecret to not delete the secret
-                    // This is very specific use case for vendors and must not be described in documentation
-                    if (!params.keepsecret) {
-                        obj.common.licenseConfirmed = false;
-                        obj.native && delete obj.native.secret;
-                    }
+async function unsetup(params: Record<string, any>, callback: ExitCodeCb): Promise<void> {
+    const { objects } = await dbConnectAsync(false, params);
 
-                    obj.from = `system.host.${tools.getHostName()}.cli`;
-                    obj.ts = new Date().getTime();
-
-                    objects.setObject('system.config', obj as any, err => {
-                        if (err) {
-                            console.log(`not found: ${err.message}`);
-                            return void callback(EXIT_CODES.CANNOT_SET_OBJECT);
-                        }
-                        console.log('system.config reset');
-                        return void callback();
-                    });
-                } else {
-                    console.log('system.config is OK');
-                    return void callback();
+    objects.delObject('system.meta.uuid', err => {
+        if (err) {
+            console.log(`uuid cannot be deleted: ${err.message}`);
+        } else {
+            console.log('system.meta.uuid deleted');
+        }
+        objects.getObject(SYSTEM_CONFIG_ID, (_err, obj) => {
+            if (obj?.common.licenseConfirmed || obj?.common.language || obj?.native?.secret) {
+                obj.common.language = 'en';
+                // allow with parameter --keepsecret to not delete the secret
+                // This is very specific use case for vendors and must not be described in documentation
+                if (!params.keepsecret) {
+                    obj.common.licenseConfirmed = false;
+                    obj.native && delete obj.native.secret;
                 }
-            });
+
+                obj.from = `system.host.${tools.getHostName()}.cli`;
+                obj.ts = new Date().getTime();
+
+                objects.setObject(SYSTEM_CONFIG_ID, obj, err => {
+                    if (err) {
+                        console.log(`not found: ${err.message}`);
+                        return void callback(EXIT_CODES.CANNOT_SET_OBJECT);
+                    }
+                    console.log(`${SYSTEM_CONFIG_ID} reset`);
+                    return void callback();
+                });
+            } else {
+                console.log(`${SYSTEM_CONFIG_ID} is OK`);
+                return void callback();
+            }
         });
     });
 }

--- a/packages/cli/src/lib/setup/setupRepo.ts
+++ b/packages/cli/src/lib/setup/setupRepo.ts
@@ -541,7 +541,7 @@ export class Repo {
         }
 
         if (confObj.common.activeRepo.length > 1) {
-            console.info('More than one repository is active. Please be sure, that this is a desired constellation');
+            console.info('More than one repository is active. Please be sure, that this is a desired constellation!');
         }
 
         confObj.from = `system.host.${tools.getHostName()}.cli`;
@@ -565,21 +565,6 @@ export class Repo {
             confObj.common.activeRepo.splice(pos, 1);
             confObj.from = `system.host.${tools.getHostName()}.cli`;
             confObj.ts = Date.now();
-            // If no one repository is active set stable as active
-            if (!confObj.common.activeRepo.length) {
-                const sysRepoObj = await this.objects.getObject(SYSTEM_REPOSITORIES_ID);
-                const obj = sysRepoObj || this.defaultSystemRepo;
-                // find a stable repository
-                const stableName = Object.keys(obj?.native?.repositories).find(name => name.startsWith('stable'));
-                if (stableName) {
-                    confObj.common.activeRepo.push(stableName);
-                }
-                if (!confObj.common.activeRepo.length) {
-                    console.warn(
-                        'Actually no one repository is active! Update of adapter will not be possible. Please define some repository as active',
-                    );
-                }
-            }
             await this.objects.setObject(SYSTEM_CONFIG_ID, confObj);
         }
     }

--- a/packages/cli/src/lib/setup/setupRepo.ts
+++ b/packages/cli/src/lib/setup/setupRepo.ts
@@ -3,24 +3,55 @@ import axios from 'axios';
 import fs from 'fs-extra';
 import type { Client as ObjectsRedisClient } from '@iobroker/db-objects-redis';
 import type { Client as StatesRedisClient } from '@iobroker/db-states-redis';
-import { isVersionIgnored } from '@/lib/setup/utils.js';
+import { BETA_REPO_URL, isIntegerLikeInput, isVersionIgnored, STABLE_REPO_URL } from '@/lib/setup/utils.js';
 import path from 'node:path';
+import { SYSTEM_CONFIG_ID, SYSTEM_REPOSITORIES_ID } from '@iobroker/js-controller-common-db/constants';
 
+/** The options passed to the Repo constructor */
 export interface CLIRepoOptions {
+    /** Instance of objects DB */
     objects: ObjectsRedisClient;
+    /** Instance of states DB */
     states: StatesRedisClient;
 }
 
+/**
+ * All possible Repo Flags which can be passed to the `show` method
+ */
 export interface RepoFlags {
     /** Also list not installed adapters */
     a?: boolean;
+    /** Also list not installed adapters */
     all?: boolean;
     /** Only list updatable adapters */
     u?: boolean;
+    /** Only list updatable adapters */
     updatable?: boolean;
     /** Force update even if hash hasn't changed */
     f?: boolean;
+    /** Force update even if hash hasn't changed */
     force?: boolean;
+}
+
+type RepoActiveInfo =
+    | {
+          /** If the repo is active */
+          isActive: true;
+          /** Name of the repository */
+          name: string;
+      }
+    | {
+          /** If the repo is active */
+          isActive: false;
+      };
+
+interface RepoActiveOptions {
+    /** Url to check if active */
+    url: string;
+    /** System config object */
+    sysConfObj: ioBroker.SystemConfigObject;
+    /** Repository object */
+    repoObj: ioBroker.RepositoryObject;
 }
 
 export class Repo {
@@ -51,18 +82,38 @@ export class Repo {
             native: {
                 repositories: {
                     stable: {
-                        link: 'http://download.iobroker.net/sources-dist.json',
+                        link: STABLE_REPO_URL,
                         json: null,
                     },
                     beta: {
-                        link: 'http://download.iobroker.net/sources-dist-latest.json',
+                        link: BETA_REPO_URL,
                         json: null,
                     },
                 },
             },
-            _id: 'system.repositories',
+            _id: SYSTEM_REPOSITORIES_ID,
             type: 'config',
         };
+    }
+
+    /**
+     * Get the repository name by index
+     * Throws if the index does not exist
+     *
+     * @param repoIndex repo name or index
+     */
+    async getNameByIndex(repoIndex: number): Promise<string> {
+        const obj = await this.objects.getObject(SYSTEM_REPOSITORIES_ID);
+        if (!obj?.native?.repositories) {
+            throw new Error('No repositories setup!');
+        }
+
+        const repoNames = Object.keys(obj.native.repositories);
+        if (!repoNames[repoIndex]) {
+            throw new Error(`No repository for index "${repoIndex}" found`);
+        }
+
+        return repoNames[repoIndex];
     }
 
     /**
@@ -80,13 +131,13 @@ export class Repo {
         systemRepos?: ioBroker.RepositoryObject,
     ): Promise<null | ioBroker.RepositoryJson> {
         if (!repoName) {
-            const sysConfig = systemConfig || (await this.objects.getObject('system.config'));
+            const sysConfig = systemConfig || (await this.objects.getObject(SYSTEM_CONFIG_ID));
             repoName = sysConfig!.common.activeRepo;
         }
 
-        const oldRepos = systemRepos || (await this.objects.getObject('system.repositories'));
+        const oldRepos = systemRepos || (await this.objects.getObject(SYSTEM_REPOSITORIES_ID));
         if (!oldRepos?.native.repositories?.[repoName]) {
-            console.log(`Error: repository "${repoName}" not found in the "system.repositories`);
+            console.log(`Error: repository "${repoName}" not found in the "${SYSTEM_REPOSITORIES_ID}"`);
             return null;
         }
 
@@ -161,7 +212,7 @@ export class Repo {
         if (changed) {
             oldRepos.from = `system.host.${tools.getHostName()}.cli`;
             oldRepos.ts = Date.now();
-            await this.objects.setObject('system.repositories', oldRepos);
+            await this.objects.setObject(SYSTEM_REPOSITORIES_ID, oldRepos);
         }
 
         return oldRepos.native.repositories[repoName].json;
@@ -175,14 +226,14 @@ export class Repo {
      */
     async showRepo(repoUrl: string | string[], flags: RepoFlags): Promise<void> {
         // Get the repositories
-        const systemConfig = await this.objects.getObject('system.config');
-        const systemRepos = await this.objects.getObject('system.repositories');
+        const systemConfig = await this.objects.getObject(SYSTEM_CONFIG_ID);
+        const systemRepos = await this.objects.getObject(SYSTEM_REPOSITORIES_ID);
         if (!systemConfig) {
-            console.error('Error: Object "system.config" not found');
+            console.error(`Error: Object "${SYSTEM_CONFIG_ID}" not found`);
         } else if (!systemRepos) {
-            console.error('Error: Object "system.repositories" not found');
+            console.error(`Error: Object "${SYSTEM_REPOSITORIES_ID}" not found`);
         } else if (!systemRepos.native || !systemRepos.native.repositories) {
-            console.error('Error: no repositories found in the "system.config');
+            console.error(`Error: no repositories found in the "${SYSTEM_REPOSITORIES_ID}"`);
         } else {
             repoUrl = repoUrl || systemConfig.common.activeRepo;
 
@@ -331,8 +382,8 @@ export class Repo {
      */
     async showRepoStatus(): Promise<number> {
         try {
-            const obj = await this.objects.getObject('system.repositories');
-            const objCfg = await this.objects.getObject('system.config');
+            const obj = await this.objects.getObject(SYSTEM_REPOSITORIES_ID);
+            const objCfg = await this.objects.getObject(SYSTEM_CONFIG_ID);
 
             if (!obj) {
                 console.error('List is empty');
@@ -373,15 +424,15 @@ export class Repo {
      * @param repoUrl url of new repo
      */
     async add(repoName: string, repoUrl: string): Promise<void> {
-        const sysRepoObj = await this.objects.getObject('system.repositories');
+        const sysRepoObj = await this.objects.getObject(SYSTEM_REPOSITORIES_ID);
         const obj = sysRepoObj || this.defaultSystemRepo;
 
         if (obj.native.repositories[repoName]) {
             throw new Error(`Repository "${repoName}" yet exists: ${obj.native.repositories[repoName].link}`);
         } else {
-            if (repoName && repoName.length < 3 && repoName.match(/^\d+$/)) {
+            if (isIntegerLikeInput(repoName)) {
                 throw new Error(
-                    `Name "${repoName}" of repository cannot contain only numbers as it could be confused with an index`,
+                    `Invalid name "${repoName}"! A repository name is not allowed to contain only numbers.`,
                 );
             }
 
@@ -391,7 +442,7 @@ export class Repo {
             };
             obj.from = `system.host.${tools.getHostName()}.cli`;
             obj.ts = Date.now();
-            await this.objects.setObject('system.repositories', obj);
+            await this.objects.setObject(SYSTEM_REPOSITORIES_ID, obj);
         }
     }
 
@@ -401,7 +452,7 @@ export class Repo {
      * @param repoName name of repository to remove
      */
     async del(repoName: string): Promise<void> {
-        const obj = await this.objects.getObject('system.config');
+        const obj = await this.objects.getObject(SYSTEM_CONFIG_ID);
         if (
             (obj?.common.activeRepo &&
                 typeof obj.common.activeRepo === 'string' &&
@@ -410,7 +461,7 @@ export class Repo {
         ) {
             throw new Error(`Cannot delete active repository: ${repoName}`);
         } else {
-            const repoObj = await this.objects.getObject('system.repositories');
+            const repoObj = await this.objects.getObject(SYSTEM_REPOSITORIES_ID);
             if (repoObj) {
                 if (!repoObj.native.repositories[repoName]) {
                     throw new Error(`Repository "${repoName}" not found.`);
@@ -418,10 +469,25 @@ export class Repo {
                     delete repoObj.native.repositories[repoName];
                     repoObj.from = `system.host.${tools.getHostName()}.cli`;
                     repoObj.ts = Date.now();
-                    await this.objects.setObject('system.repositories', repoObj);
+                    await this.objects.setObject(SYSTEM_REPOSITORIES_ID, repoObj);
                 }
             }
         }
+    }
+
+    /**
+     * Checks if stable repo is active
+     *
+     * @param options the system config object and the repository object
+     */
+    private getRepoActiveInfo(options: RepoActiveOptions): RepoActiveInfo {
+        const { repoObj, sysConfObj, url } = options;
+
+        const name = sysConfObj.common.activeRepo.find(
+            activeRepo => repoObj.native.repositories[activeRepo].link === url,
+        );
+
+        return name ? { isActive: true, name } : { isActive: false };
     }
 
     /**
@@ -430,45 +496,57 @@ export class Repo {
      * @param repoName name of the repository to activate
      */
     async setActive(repoName: string): Promise<void> {
-        const sysRepoObj = await this.objects.getObject('system.repositories');
+        const sysRepoObj = await this.objects.getObject(SYSTEM_REPOSITORIES_ID);
         const obj = sysRepoObj || this.defaultSystemRepo;
 
         if (!obj.native.repositories[repoName]) {
             throw new Error(`Repository "${repoName}" not found.`);
-        } else {
-            const confObj = await this.objects.getObject('system.config');
-            if (typeof confObj?.common.activeRepo === 'string') {
-                confObj.common.activeRepo = [confObj.common.activeRepo];
-            }
+        }
 
-            if (confObj && !confObj.common.activeRepo.includes(repoName)) {
-                confObj.common.activeRepo.push(repoName);
+        const confObj = await this.objects.getObject(SYSTEM_CONFIG_ID);
+        if (typeof confObj?.common.activeRepo === 'string') {
+            confObj.common.activeRepo = [confObj.common.activeRepo];
+        }
 
-                // Check that stable and beta repositories cannot be active at the same time.
-                if (repoName.toLowerCase().startsWith('beta')) {
-                    // Stable repository could be "stable", "Stable (default)"
-                    const pos = confObj.common.activeRepo.findIndex(item => item.toLowerCase().startsWith('stable'));
-                    if (pos !== -1) {
-                        confObj.common.activeRepo.splice(pos, 1);
-                    }
-                } else if (repoName.toLowerCase().startsWith('stable')) {
-                    // Beta repository could be "beta" or "Beta (latest)"
-                    const pos = confObj.common.activeRepo.findIndex(item => item.toLowerCase().startsWith('beta'));
-                    if (pos !== -1) {
-                        confObj.common.activeRepo.splice(pos, 1);
-                    }
-                }
-                if (confObj.common.activeRepo.length > 1) {
-                    console.warn(
-                        'More than one repository is active. Please be sure, that this is a desired constellation',
-                    );
-                }
+        if (!confObj || confObj.common.activeRepo.includes(repoName)) {
+            return;
+        }
 
-                confObj.from = `system.host.${tools.getHostName()}.cli`;
-                confObj.ts = Date.now();
-                await this.objects.setObject('system.config', confObj);
+        confObj.common.activeRepo.push(repoName);
+
+        const stableInfo = this.getRepoActiveInfo({
+            url: STABLE_REPO_URL,
+            sysConfObj: confObj,
+            repoObj: obj,
+        });
+
+        const betaInfo = this.getRepoActiveInfo({
+            url: BETA_REPO_URL,
+            sysConfObj: confObj,
+            repoObj: obj,
+        });
+
+        if (stableInfo.isActive && betaInfo.isActive) {
+            const posStable = confObj.common.activeRepo.indexOf(stableInfo.name);
+            const posBeta = confObj.common.activeRepo.indexOf(betaInfo.name);
+
+            if (posStable < posBeta) {
+                // put beta in front of stable, so stable will override adapters
+                confObj.common.activeRepo.splice(posBeta, 1);
+                confObj.common.activeRepo.splice(posStable, 0, betaInfo.name);
+                console.info(
+                    `Ensured that stable repository "${stableInfo.name}" has priority over beta repository "${betaInfo.name}"`,
+                );
             }
         }
+
+        if (confObj.common.activeRepo.length > 1) {
+            console.info('More than one repository is active. Please be sure, that this is a desired constellation');
+        }
+
+        confObj.from = `system.host.${tools.getHostName()}.cli`;
+        confObj.ts = Date.now();
+        await this.objects.setObject(SYSTEM_CONFIG_ID, confObj);
     }
 
     /**
@@ -477,7 +555,7 @@ export class Repo {
      * @param repoName name of the repository
      */
     async setInactive(repoName: string): Promise<void> {
-        const confObj = (await this.objects.getObject('system.config'))!;
+        const confObj = (await this.objects.getObject(SYSTEM_CONFIG_ID))!;
         if (typeof confObj?.common.activeRepo === 'string') {
             confObj.common.activeRepo = [confObj.common.activeRepo];
         }
@@ -489,7 +567,7 @@ export class Repo {
             confObj.ts = Date.now();
             // If no one repository is active set stable as active
             if (!confObj.common.activeRepo.length) {
-                const sysRepoObj = await this.objects.getObject('system.repositories');
+                const sysRepoObj = await this.objects.getObject(SYSTEM_REPOSITORIES_ID);
                 const obj = sysRepoObj || this.defaultSystemRepo;
                 // find a stable repository
                 const stableName = Object.keys(obj?.native?.repositories).find(name => name.startsWith('stable'));
@@ -502,7 +580,7 @@ export class Repo {
                     );
                 }
             }
-            await this.objects.setObject('system.config', confObj);
+            await this.objects.setObject(SYSTEM_CONFIG_ID, confObj);
         }
     }
 
@@ -517,54 +595,51 @@ export class Repo {
         let repoObj;
         let sysConfigObj;
         try {
-            sysConfigObj = await this.objects.getObject('system.config');
-            repoObj = await this.objects.getObject('system.repositories');
+            sysConfigObj = await this.objects.getObject(SYSTEM_CONFIG_ID);
+            repoObj = await this.objects.getObject(SYSTEM_REPOSITORIES_ID);
         } catch (err) {
             throw new Error(`Could not rename repository "${oldName}" to "${newName}": ${err.message}`);
         }
 
-        if (newName && newName.length < 3 && newName.match(/^\d+$/)) {
-            throw new Error(
-                `Name "${newName}" of repository cannot contain only numbers as it could be confused with an index`,
-            );
+        if (isIntegerLikeInput(newName)) {
+            throw new Error(`Invalid name "${newName}"! A repository name is not allowed to contain only numbers.`);
         }
 
-        if (repoObj?.native?.repositories) {
+        if (!repoObj) {
+            return;
+        }
+
+        if (
+            repoObj.native.repositories[oldName] &&
+            repoObj.native.repositories[oldName].link === repoUrl &&
+            !repoObj.native.repositories[newName]
+        ) {
+            repoObj.native.repositories[newName] = repoObj.native.repositories[oldName];
+            delete repoObj.native.repositories[oldName];
+
+            try {
+                await this.objects.setObject(SYSTEM_REPOSITORIES_ID, repoObj);
+                console.log(`Renamed repository "${oldName} to "${newName}"`);
+            } catch (e) {
+                throw new Error(`Could not rename repository "${oldName}" to "${newName}": ${e.message}`);
+            }
+
+            // if we changed the name of the activeRepo, we should set newName as active repo
             if (
-                repoObj.native.repositories[oldName] &&
-                repoObj.native.repositories[oldName].link === repoUrl &&
-                !repoObj.native.repositories[newName]
+                sysConfigObj?.common &&
+                ((typeof sysConfigObj.common.activeRepo === 'string' && sysConfigObj.common.activeRepo === oldName) ||
+                    (Array.isArray(sysConfigObj.common.activeRepo) && sysConfigObj.common.activeRepo.includes(oldName)))
             ) {
-                repoObj.native.repositories[newName] = repoObj.native.repositories[oldName];
-                delete repoObj.native.repositories[oldName];
+                if (typeof sysConfigObj.common.activeRepo === 'string') {
+                    sysConfigObj.common.activeRepo = [sysConfigObj.common.activeRepo];
+                }
+                const pos = sysConfigObj.common.activeRepo.indexOf(oldName);
+                sysConfigObj.common.activeRepo.splice(pos, 1, newName);
 
                 try {
-                    await this.objects.setObject('system.repositories', repoObj);
-                    console.log(`Renamed repository "${oldName} to "${newName}"`);
-                } catch (err) {
-                    throw new Error(`Could not rename repository "${oldName}" to "${newName}": ${err.message}`);
-                }
-
-                // if we changed the name of the activeRepo, we should set newName as active repo
-                if (
-                    sysConfigObj &&
-                    sysConfigObj.common &&
-                    ((typeof sysConfigObj.common.activeRepo === 'string' &&
-                        sysConfigObj.common.activeRepo === oldName) ||
-                        (Array.isArray(sysConfigObj.common.activeRepo) &&
-                            sysConfigObj.common.activeRepo.includes(oldName)))
-                ) {
-                    if (typeof sysConfigObj.common.activeRepo === 'string') {
-                        sysConfigObj.common.activeRepo = [sysConfigObj.common.activeRepo];
-                    }
-                    const pos = sysConfigObj.common.activeRepo.indexOf(oldName);
-                    sysConfigObj.common.activeRepo.splice(pos, 1, newName);
-
-                    try {
-                        await this.objects.setObject('system.config', sysConfigObj);
-                    } catch (err) {
-                        throw new Error(`Could not set "${newName}" as active repository: ${err.message}`);
-                    }
+                    await this.objects.setObject(SYSTEM_CONFIG_ID, sysConfigObj);
+                } catch (e) {
+                    throw new Error(`Could not set "${newName}" as active repository: ${e.message}`);
                 }
             }
         }

--- a/packages/cli/src/lib/setup/utils.ts
+++ b/packages/cli/src/lib/setup/utils.ts
@@ -151,3 +151,18 @@ export async function recognizeVersion(options: VersionOptions): Promise<void> {
 
     await objects.setObject(id, obj);
 }
+
+/**
+ * Check if user input is an integer
+ *
+ * @param input input string to check
+ */
+export function isIntegerLikeInput(input: string): boolean {
+    return /^\d+$/.test(input);
+}
+
+/** URL of the official stable repository */
+export const STABLE_REPO_URL = 'http://download.iobroker.net/sources-dist.json';
+
+/** URL of the official beta repository */
+export const BETA_REPO_URL = 'http://download.iobroker.net/sources-dist-latest.json';


### PR DESCRIPTION
Some refactoring and cleanup here:

- the < 3 logic for numbers were removed, as it was inconsistent with the logic in `setup.ts` and I think forbidding also larger numbers is no downside and just improves consistency
- stable and beta repos are now detected by the URLs of the official repos. Users have the ability to rename them easily in admin, so we should handle these cases!
- some of the commands descriptions in yargs were wrong -> new repos cannot be created by index
- having stable and beta active at the same time is not forbidden, it is a valid use case to have stable active and get only repositories which are not in stable yet from the beta repository. For this scenario, I have adapted the logic to re-sort if stable and beta is active, so stable always has higher priority than beta