### PR TITLE
Makes sure to return promise from setObject logic. …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 	Placeholder for the next version (at the beginning of the line):
 	## __WORK IN PROGRESS__
 -->
+
+## __WORK IN PROGRESS__
+* (Apollon77) Fixes async usage of setObject and extendObject methods
+
 ## 7.0.3 (2024-11-13) - Lucy
 * (@foxriver76) Introduce "Vendor Packages Workflow" (only relevant for vendors - see README.md)
 

--- a/packages/adapter/src/lib/adapter/adapter.ts
+++ b/packages/adapter/src/lib/adapter/adapter.ts
@@ -2921,7 +2921,7 @@ export class AdapterClass extends EventEmitter {
             options.obj.user = options.obj.user || (options.options ? options.options.user : '') || SYSTEM_ADMIN_USER;
             options.obj.ts = options.obj.ts || Date.now();
 
-            this._setObjectWithDefaultValue(options.id, options.obj, options.options, options.callback);
+            return this._setObjectWithDefaultValue(options.id, options.obj, options.options, options.callback);
         } else {
             this._logger.error(`${this.namespaceLog} setObject ${options.id} mandatory property type missing!`);
             return tools.maybeCallbackWithError(options.callback, 'mandatory property type missing!');
@@ -3426,7 +3426,7 @@ export class AdapterClass extends EventEmitter {
             }
         }
 
-        this._setObjectWithDefaultValue(id, obj, options, callback);
+        return this._setObjectWithDefaultValue(id, obj, options, callback);
     }
 
     // external signatures


### PR DESCRIPTION
Affects setObject  and extendObject at least

**Implementation details**
Return the promise from _setObjectWithDefaultValue to the calling method else this gets lost when no callback was provided

**Tests**
- [ ] I have added tests to avoid a recursion of this bug
- [x] It is not possible to test for this bug

**If no tests added, please specify why it was not possible**
change is too obbvious :-)

