### PR TITLE
[fix]: also pass in gid/uid for non-systemd systems on UI upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 	## __WORK IN PROGRESS__
 -->
 
+## __WORK IN PROGRESS__
+* (@foxriver76) fixed UI upgrade for non-systemd systems
+
 ## 7.0.4 (2024-12-04)
 * (@Apollon77) Fixes async usage of extendObject
 * (@Apollon77) Makes setObject async save

--- a/packages/controller/src/main.ts
+++ b/packages/controller/src/main.ts
@@ -5868,10 +5868,14 @@ async function startUpgradeManager(options: UpgradeArguments): Promise<void> {
             },
         );
     } else {
-        upgradeProcess = spawn(process.execPath, [upgradeProcessPath, version, adminInstance.toString()], {
-            detached: true,
-            stdio: 'ignore',
-        });
+        upgradeProcess = spawn(
+            process.execPath,
+            [upgradeProcessPath, version, adminInstance.toString(), uid.toString(), gid.toString()],
+            {
+                detached: true,
+                stdio: 'ignore',
+            },
+        );
     }
 
     upgradeProcess.unref();


### PR DESCRIPTION
**Link the issue which is closed by this PR**
<!--
    If the PR closes the issue add a `closes #issue-no`. If no issue exists yet, please create an issue first.
-->

- closes #2964

**Implementation details**
<!--
    What has been changed?
-->

For non systemd services we were missing to pass in two newly introduced CLI params. We now pass them down. 


**Tests**
- [ ] I have added tests to avoid a recursion of this bug
- [x] It is not possible to test for this bug

**If no tests added, please specify why it was not possible**
<!--
    E.g. the bug is only reproducible if the system runs out of disk space.
-->

No upgrade possible on CI