### PR TITLE
[fix]: fixed UI upgrade if admin is running on privileged port (<1024)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,13 @@
 	## __WORK IN PROGRESS__
 -->
 
-## 7.0.5 (2024-12-07)
+## __WORK IN PROGRESS__ - Lucy
+* (@foxriver76) fixed UI upgrade if admin is running on privileged port (<1024)
+
+## 7.0.5 (2024-12-07) - Lucy
 * (@foxriver76) fixed UI upgrade for non-systemd systems
 
-## 7.0.4 (2024-12-04)
+## 7.0.4 (2024-12-04) - Lucy
 * (@Apollon77) Fixes async usage of extendObject
 * (@Apollon77) Makes setObject async save
 * (@foxriver76) deprecated `set(Foreign)ObjectAsync` as the non async methods are now working correctly with promises


### PR DESCRIPTION
**Link the issue which is closed by this PR**
<!--
    If the PR closes the issue add a `closes #issue-no`. If no issue exists yet, please create an issue first.
-->
See https://forum.iobroker.net/topic/78324/js-controller-lucy-version-7-0-jetzt-im-stable-repository/51?_=1733667237372

**Implementation details**
<!--
    What has been changed?
-->
As we are now ensuring that npm is executed as the iobroker user on UI upgrades too, this is done via `process.setgid` and `process.setuid`. It seems compared to starting directly as the iobroker user, we are not allowed to bind to priviliged ports after calling `setuid`, hence we do this now after the server is started and before npm is executed!

**Tests**
- [ ] I have added tests to avoid a recursion of this bug
- [x] It is not possible to test for this bug

**If no tests added, please specify why it was not possible**
<!--
    E.g. the bug is only reproducible if the system runs out of disk space.
-->

No upgrades are performed on CI
