### PR TITLE
[fix]: make the uid gid apply optional on ui upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 	## __WORK IN PROGRESS__
 -->
 
+## __WORK IN PROGRESS__ - Lucy
+* (@foxriver76) fixed UI upgrade for non-systemd systems
+
 ## 7.0.6 (2024-12-08) - Lucy
 * (@foxriver76) fixed UI upgrade if admin is running on privileged port (<1024)
 

--- a/packages/controller/src/main.ts
+++ b/packages/controller/src/main.ts
@@ -5842,7 +5842,7 @@ async function upgradeOsPackages(packages: UpgradePacket[]): Promise<void> {
  *
  * @param options Arguments passed to the UpgradeManager process
  */
-async function startUpgradeManager(options: UpgradeArguments): Promise<void> {
+async function startUpgradeManager(options: Required<UpgradeArguments>): Promise<void> {
     const { version, adminInstance, uid, gid } = options;
     const upgradeProcessPath = require.resolve('./lib/upgradeManager');
     let upgradeProcess: cp.ChildProcess;
@@ -5868,14 +5868,10 @@ async function startUpgradeManager(options: UpgradeArguments): Promise<void> {
             },
         );
     } else {
-        upgradeProcess = spawn(
-            process.execPath,
-            [upgradeProcessPath, version, adminInstance.toString(), uid.toString(), gid.toString()],
-            {
-                detached: true,
-                stdio: 'ignore',
-            },
-        );
+        upgradeProcess = spawn(process.execPath, [upgradeProcessPath, version, adminInstance.toString()], {
+            detached: true,
+            stdio: 'ignore',
+        });
     }
 
     upgradeProcess.unref();


### PR DESCRIPTION
**Link the issue which is closed by this PR**
<!--
    If the PR closes the issue add a `closes #issue-no`. If no issue exists yet, please create an issue first.
-->

- likely closes #2988

**Implementation details**
<!--
    What has been changed?
-->
non systemd ui upgrade processes do not need to apply them as they are not started via sudo but just as the current iobroker user.


**Tests**
- [ ] I have added tests to avoid a recursion of this bug
- [x] It is not possible to test for this bug

**If no tests added, please specify why it was not possible**
<!--
    E.g. the bug is only reproducible if the system runs out of disk space.
-->

no upgrade on ci