### PR TITLE
[fix]: fix edge case problem on Windows (if adapter calls 'readDir' on single file)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 	## __WORK IN PROGRESS__
 -->
 
+## __WORK IN PROGRESS__ - Lucy
+* (@foxriver76) fix edge case problem on Windows (if adapter calls `readDir` on single file)
+
 ## 7.0.6 (2024-12-08) - Lucy
 * (@foxriver76) fixed UI upgrade if admin is running on privileged port (<1024)
 

--- a/packages/controller/test/lib/testFiles.ts
+++ b/packages/controller/test/lib/testFiles.ts
@@ -1,4 +1,5 @@
 import type { TestContext } from '../_Types.js';
+import { objectsUtils as utils } from '@iobroker/db-objects-redis';
 
 export function register(it: Mocha.TestFunction, expect: Chai.ExpectStatic, context: TestContext): void {
     const testName = `${context.name} ${context.adapterShortName} files: `;
@@ -223,12 +224,12 @@ export function register(it: Mocha.TestFunction, expect: Chai.ExpectStatic, cont
         });
     });
 
-    it(`${testName}should not crash if calling readDir on a single file`, async () => {
+    it(`${testName}should respond with 'ERROR_NOT_FOUND' if calling readDir on a single file`, async () => {
         const objects = context.objects;
         const fileName = 'dir/notADir.txt';
 
         await objects.writeFileAsync(testId, fileName, 'dataInFile');
-        await objects.readDirAsync(testId, fileName);
+        expect(objects.readDirAsync(testId, fileName)).to.be.eventually.rejectedWith(utils.ERRORS.ERROR_NOT_FOUND);
     });
 
     it(`${testName}should read file and prevent path traversing`, done => {

--- a/packages/controller/test/lib/testFiles.ts
+++ b/packages/controller/test/lib/testFiles.ts
@@ -223,6 +223,14 @@ export function register(it: Mocha.TestFunction, expect: Chai.ExpectStatic, cont
         });
     });
 
+    it(`${testName}should not crash if calling readDir on a single file`, async () => {
+        const objects = context.objects;
+        const fileName = 'dir/notADir.txt';
+
+        await objects.writeFileAsync(testId, fileName, 'dataInFile');
+        await objects.readDirAsync(testId, fileName);
+    });
+
     it(`${testName}should read file and prevent path traversing`, done => {
         const objects = context.objects;
         objects.readFile(testId, '../../myFileA/abc1.txt', null, (err, data, _mimeType) => {

--- a/packages/db-objects-file/src/lib/objects/objectsInMemFileDB.js
+++ b/packages/db-objects-file/src/lib/objects/objectsInMemFileDB.js
@@ -627,7 +627,7 @@ export class ObjectsInMemoryFileDB extends InMemoryFileDB {
         }
 
         const location = path.join(this.objectsDir, id, name);
-        if (fs.existsSync(location)) {
+        if (fs.existsSync(location) && fs.statSync(location).isDirectory()) {
             const dirFiles = fs.readdirSync(location);
             for (let i = 0; i < dirFiles.length; i++) {
                 if (dirFiles[i] === '..' || dirFiles[i] === '.') {

--- a/packages/db-objects-file/src/lib/objects/objectsInMemFileDB.js
+++ b/packages/db-objects-file/src/lib/objects/objectsInMemFileDB.js
@@ -627,7 +627,7 @@ export class ObjectsInMemoryFileDB extends InMemoryFileDB {
         }
 
         const location = path.join(this.objectsDir, id, name);
-        if (fs.existsSync(location) && fs.statSync(location).isDirectory()) {
+        if (fs.existsSync(location)) {
             const dirFiles = fs.readdirSync(location);
             for (let i = 0; i < dirFiles.length; i++) {
                 if (dirFiles[i] === '..' || dirFiles[i] === '.') {


### PR DESCRIPTION
**Link the issue which is closed by this PR**
<!--
    If the PR closes the issue add a `closes #issue-no`. If no issue exists yet, please create an issue first.
-->
See https://github.com/ioBroker/ioBroker.vis-2/issues/510

**Implementation details**
<!--
    What has been changed?
-->

we now ensure, that we only call scan dir on directories

**Tests**
- [x] I have added tests to avoid a recursion of this bug
- [ ] It is not possible to test for this bug

