### PR TITLE
[feat]: handle non-existing directories as empty if they have a meta file

### DIFF
--- a/packages/controller/test/lib/testFiles.ts
+++ b/packages/controller/test/lib/testFiles.ts
@@ -224,6 +224,22 @@ export function register(it: Mocha.TestFunction, expect: Chai.ExpectStatic, cont
         });
     });
 
+    it(`${testName}should read empty directory`, async () => {
+        const objects = context.objects;
+        const id = `${testId}.files`;
+
+        const res = await objects.readDirAsync(id, '');
+        expect(res).to.be.empty;
+    });
+
+    it(`${testName}should read empty directory with path`, async () => {
+        const objects = context.objects;
+        const id = `${testId}.files`;
+
+        const res = await objects.readDirAsync(id, 'random/path');
+        expect(res).to.be.empty;
+    });
+
     it(`${testName}should respond with 'ERROR_NOT_FOUND' if calling readDir on a single file`, async () => {
         const objects = context.objects;
         const fileName = 'dir/notADir.txt';

--- a/packages/controller/test/lib/testFiles.ts
+++ b/packages/controller/test/lib/testFiles.ts
@@ -245,6 +245,15 @@ export function register(it: Mocha.TestFunction, expect: Chai.ExpectStatic, cont
         expect(res).to.be.empty;
     });
 
+    it(`${testName}should not read directory without meta object`, () => {
+        const objects = context.objects;
+        const id = `${testId}.meta.nonExisting`;
+
+        expect(objects.readDirAsync(id, '')).to.be.eventually.rejectedWith(
+            new Error(`${id} is not an object of type "meta"`),
+        );
+    });
+
     it(`${testName}should respond with empty array if calling readDir on a single file`, async () => {
         const objects = context.objects;
         const fileName = 'dir/notADir.txt';

--- a/packages/controller/test/lib/testFiles.ts
+++ b/packages/controller/test/lib/testFiles.ts
@@ -249,9 +249,7 @@ export function register(it: Mocha.TestFunction, expect: Chai.ExpectStatic, cont
         const objects = context.objects;
         const id = `${testId}.meta.nonExisting`;
 
-        expect(objects.readDirAsync(id, '')).to.be.eventually.rejectedWith(
-            new Error(`${id} is not an object of type "meta"`),
-        );
+        expect(objects.readDirAsync(id, '')).to.be.eventually.rejectedWith(`${id} is not an object of type "meta"`);
     });
 
     it(`${testName}should respond with empty array if calling readDir on a single file`, async () => {

--- a/packages/controller/test/lib/testFiles.ts
+++ b/packages/controller/test/lib/testFiles.ts
@@ -1,5 +1,4 @@
 import type { TestContext } from '../_Types.js';
-import { objectsUtils as utils } from '@iobroker/db-objects-redis';
 
 export function register(it: Mocha.TestFunction, expect: Chai.ExpectStatic, context: TestContext): void {
     const testName = `${context.name} ${context.adapterShortName} files: `;
@@ -10,7 +9,7 @@ export function register(it: Mocha.TestFunction, expect: Chai.ExpectStatic, cont
         const fileName = 'testFile.bin';
         const dataBinary = Buffer.from('1234');
         // create an object of type file first
-        await context.adapter.setForeignObjectAsync(objId, {
+        await context.adapter.setForeignObject(objId, {
             type: 'meta',
             common: {
                 name: 'Files and more',
@@ -226,7 +225,13 @@ export function register(it: Mocha.TestFunction, expect: Chai.ExpectStatic, cont
 
     it(`${testName}should read empty directory`, async () => {
         const objects = context.objects;
-        const id = `${testId}.files`;
+        const id = `${testId}.meta.files`;
+
+        await objects.setObject(id, {
+            type: 'meta',
+            common: { name: 'test', type: 'meta.user' },
+            native: {},
+        });
 
         const res = await objects.readDirAsync(id, '');
         expect(res).to.be.empty;
@@ -234,18 +239,19 @@ export function register(it: Mocha.TestFunction, expect: Chai.ExpectStatic, cont
 
     it(`${testName}should read empty directory with path`, async () => {
         const objects = context.objects;
-        const id = `${testId}.files`;
+        const id = `${testId}.meta.files`;
 
         const res = await objects.readDirAsync(id, 'random/path');
         expect(res).to.be.empty;
     });
 
-    it(`${testName}should respond with 'ERROR_NOT_FOUND' if calling readDir on a single file`, async () => {
+    it(`${testName}should respond with empty array if calling readDir on a single file`, async () => {
         const objects = context.objects;
         const fileName = 'dir/notADir.txt';
 
         await objects.writeFileAsync(testId, fileName, 'dataInFile');
-        expect(objects.readDirAsync(testId, fileName)).to.be.eventually.rejectedWith(utils.ERRORS.ERROR_NOT_FOUND);
+        const res = await objects.readDirAsync(testId, fileName);
+        expect(res).to.be.empty;
     });
 
     it(`${testName}should read file and prevent path traversing`, done => {

--- a/packages/db-objects-redis/src/lib/objects/objectsInRedisClient.ts
+++ b/packages/db-objects-redis/src/lib/objects/objectsInRedisClient.ts
@@ -1443,8 +1443,7 @@ export class ObjectsInRedisClient {
         }
 
         try {
-            // TODO: activate
-            // await this.validateMetaObject(id);
+            await this.validateMetaObject(id);
         } catch (e) {
             return tools.maybeCallbackWithRedisError(callback, e);
         }
@@ -1469,8 +1468,7 @@ export class ObjectsInRedisClient {
         const dirs: string[] = [];
         const deepLevel = baseName.split('/').length;
         if (!keys || !keys.length) {
-            // TODO: empty array
-            return tools.maybeCallbackWithError(callback, ERRORS.ERROR_NOT_FOUND, []);
+            return tools.maybeCallbackWithError(callback, null, []);
         }
         keys = keys.sort().filter(key => {
             if (key.endsWith('$%$meta')) {

--- a/packages/db-objects-redis/src/lib/objects/objectsInRedisClient.ts
+++ b/packages/db-objects-redis/src/lib/objects/objectsInRedisClient.ts
@@ -21,7 +21,6 @@ import type {
     CheckFileRightsCallback,
     GetUserGroupPromiseReturn,
 } from '@/lib/objects/objectsUtils.js';
-import { CheckFileRightsReturn } from '@/lib/objects/objectsUtils.js';
 import * as utils from '@/lib/objects/objectsUtils.js';
 import semver from 'semver';
 import * as CONSTS from '@/lib/objects/constants.js';


### PR DESCRIPTION
**Link the feature issue which is closed by this PR**
<!--
If the PR closes an issue add a `closes #issue-no`. If no issue exists yet, please create an issue first to discuss with the core team if this feature is desirable.
-->
closes #2998

**Implementation details**
<!--
    What has been changed?
-->
when reading an non-existing directory where the id has an existing meta file we handle it as empty instead of non-existing

**Tests**
- [x] I have added tests to test this feature
- [ ] It is not possible to test this feature

**Documentation**
<!--
    New features should be documented in the `README.md` file under `Feature Overview`. If a host message was added, please document it under `Feature Overview/js-controller Host Messages`.
-->
- [ ] I have documented the new feature

changelog should be enough
