### PR TITLE
[fix]: fixed setting negative numbers via state set cli command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ## __WORK IN PROGRESS__ - Lucy
 * (@foxriver76) fix edge case problem on Windows (if adapter calls `readDir` on single file)
+* (@foxriver76) fixed setting negative numbers via `state set` cli command
 
 ## 7.0.6 (2024-12-08) - Lucy
 * (@foxriver76) fixed UI upgrade if admin is running on privileged port (<1024)

--- a/packages/controller/test/lib/testConsole.ts
+++ b/packages/controller/test/lib/testConsole.ts
@@ -536,7 +536,7 @@ export function register(it: Mocha.TestFunction, expect: Chai.ExpectStatic, cont
     it(`${testName}state set with negative number`, async () => {
         const id = 'system.adapter.admin.upload';
         // check update
-        const res = await execAsync(`"${process.execPath}" "${iobExecutable}" iob state set "${id}" "-1" 1`);
+        const res = await execAsync(`"${process.execPath}" "${iobExecutable}" state set "${id}" "-1" 1`);
         expect(res.stderr).to.be.not.ok;
 
         const state = await context.states.getState(id);

--- a/packages/controller/test/lib/testConsole.ts
+++ b/packages/controller/test/lib/testConsole.ts
@@ -533,6 +533,17 @@ export function register(it: Mocha.TestFunction, expect: Chai.ExpectStatic, cont
     // object o
 
     // state s
+    it(`${testName}state set with negative number`, async () => {
+        const id = 'system.adapter.admin.upload';
+        // check update
+        const res = await execAsync(`"${process.execPath}" "${iobExecutable}" iob state set "${id}" "-1" 1`);
+        expect(res.stderr).to.be.not.ok;
+
+        const state = await context.states.getState(id);
+
+        expect(state?.val).to.be.equal(-1);
+        expect(state?.ack).to.be.equal(true);
+    }).timeout(20_000);
 
     // message
     // update
@@ -718,7 +729,7 @@ export function register(it: Mocha.TestFunction, expect: Chai.ExpectStatic, cont
             // ok
         }
 
-        await context.objects.setObjectAsync('system.adapter.vis.0', {
+        await context.objects.setObject('system.adapter.vis.0', {
             common: {
                 name: 'iobroker.vis-2',
                 version: '1.0.0',


### PR DESCRIPTION
**Link the issue which is closed by this PR**
<!--
    If the PR closes the issue add a `closes #issue-no`. If no issue exists yet, please create an issue first.
-->
see https://forum.iobroker.net/topic/79235/negative-werte-mit-cli-state-set/8?_=1736760992753

**Implementation details**
<!--
    What has been changed?
-->
Use the args parsed via yargs instead of the raw ones where we filtered out flags. 

**Tests**
- [x] I have added tests to avoid a recursion of this bug
- [ ] It is not possible to test for this bug

