### PR TITLE
[fix]: Update io-package.json - correct descr of supportCustoms

### DIFF
--- a/schemas/io-package.json
+++ b/schemas/io-package.json
@@ -1436,7 +1436,7 @@
           "type": "boolean"
         },
         "supportCustoms": {
-          "description": "If the adapter supports settings for every state. It requires file jsonCustom.json in admin and "common.adminUI":{"custom":"json"}. Sample can be found in ioBroker.history",
+          "description": "If the adapter supports settings for every state. It requires file jsonCustom.json in admin and \"common.adminUI\":{\"custom\":\"json\"}. Sample can be found in ioBroker.history",
           "type": "boolean"
         },
         "supportStopInstance": {

--- a/schemas/io-package.json
+++ b/schemas/io-package.json
@@ -1436,7 +1436,7 @@
           "type": "boolean"
         },
         "supportCustoms": {
-          "description": "If the adapter support settings for every state. It has to have custom.html file in admin. Sample can be found in ioBroker.history",
+          "description": "If the adapter supports settings for every state. It requires file jsonCustom.json in admin and "common.adminUI":{"custom":"json"}. Sample can be found in ioBroker.history",
           "type": "boolean"
         },
         "supportStopInstance": {


### PR DESCRIPTION
### For Bugfixes:

**Link the issue which is closed by this PR**
none

**Implementation details**
This PR corrects the description of io-package.json attribute supportCustoms. This option no longer requires a custom.html file beut a jsonCustom.json file ans setting auf "common.adminUI":{"custom":"json"} - AT LEAST AS FAR AS I KNOW.

**Tests**
- [ ] I have added tests to avoid a recursion of this bug
- [x] It is not possible to test for this bug

**If no tests added, please specify why it was not possible**
This PR only changes a description and does not alter code flow

@GermanBluefox 
Please verify correctness of new description - or adapt if wrong.