### PR TITLE
[types] Added types for JSON config of tabs

### DIFF
--- a/packages/db-objects-redis/src/lib/objects/objectsInRedisClient.ts
+++ b/packages/db-objects-redis/src/lib/objects/objectsInRedisClient.ts
@@ -153,11 +153,7 @@ export class ObjectsInRedisClient {
 
     constructor(settings: ObjectsSettings) {
         this.settings = settings || {};
-        this.redisNamespace = `${
-            this.settings.redisNamespace ||
-            this.settings.connection?.redisNamespace ||
-            'cfg'
-        }.`;
+        this.redisNamespace = `${this.settings.redisNamespace || this.settings.connection?.redisNamespace || 'cfg'}.`;
         this.fileNamespace = `${this.redisNamespace}f.`;
         this.fileNamespaceL = this.fileNamespace.length;
         this.objNamespace = `${this.redisNamespace}o.`;
@@ -573,7 +569,7 @@ export class ObjectsInRedisClient {
                     // subscribe on system.config anytime because also adapters need stuff like defaultNewAcl (especially admin)
                     try {
                         if (this.subSystem) {
-                            (await this.subSystem.psubscribe(`${this.objNamespace}system.config`));
+                            await this.subSystem.psubscribe(`${this.objNamespace}system.config`);
                         }
                     } catch {
                         // ignore
@@ -582,7 +578,7 @@ export class ObjectsInRedisClient {
                     // subscribe to meta changes
                     try {
                         if (this.subSystem) {
-                            (await this.subSystem.psubscribe(`${this.metaNamespace}*`));
+                            await this.subSystem.psubscribe(`${this.metaNamespace}*`);
                         }
                     } catch (e) {
                         this.log.warn(
@@ -1494,7 +1490,7 @@ export class ObjectsInRedisClient {
                     return !key.includes('/_data.json$%$') && key !== '_data.json'; // sort out "virtual" files that are used to mark directories
                 }
                 const dir = parts[deepLevel - 1];
-                if (dirs.indexOf(dir) === -1) {
+                if (!dirs.includes(dir)) {
                     dirs.push(dir);
                 }
             }
@@ -1547,11 +1543,7 @@ export class ObjectsInRedisClient {
                     continue;
                 }
                 obj.acl = obj.acl || {};
-                if (
-                    options.user !== CONSTS.SYSTEM_ADMIN_USER &&
-                    options.groups &&
-                    options.groups.indexOf(CONSTS.SYSTEM_ADMIN_GROUP) === -1
-                ) {
+                if (options.user !== CONSTS.SYSTEM_ADMIN_USER && !options.groups?.includes(CONSTS.SYSTEM_ADMIN_GROUP)) {
                     obj.acl.read = !!(obj.acl.permissions & CONSTS.ACCESS_EVERY_READ);
                     obj.acl.write = !!(obj.acl.permissions & CONSTS.ACCESS_EVERY_WRITE);
                 } else {
@@ -2801,8 +2793,7 @@ export class ObjectsInRedisClient {
                     if (!obj.acl) {
                         obj.acl = {
                             owner: this.defaultNewAcl?.owner || CONSTS.SYSTEM_ADMIN_USER,
-                            ownerGroup:
-                                this.defaultNewAcl?.ownerGroup || CONSTS.SYSTEM_ADMIN_GROUP,
+                            ownerGroup: this.defaultNewAcl?.ownerGroup || CONSTS.SYSTEM_ADMIN_GROUP,
                             object:
                                 this.defaultNewAcl?.object ||
                                 CONSTS.ACCESS_USER_RW | CONSTS.ACCESS_GROUP_READ | CONSTS.ACCESS_EVERY_READ, // '0644'
@@ -2928,8 +2919,7 @@ export class ObjectsInRedisClient {
                     if (!obj.acl) {
                         obj.acl = {
                             owner: this.defaultNewAcl?.owner || CONSTS.SYSTEM_ADMIN_USER,
-                            ownerGroup:
-                                this.defaultNewAcl?.ownerGroup || CONSTS.SYSTEM_ADMIN_GROUP,
+                            ownerGroup: this.defaultNewAcl?.ownerGroup || CONSTS.SYSTEM_ADMIN_GROUP,
                             object:
                                 this.defaultNewAcl?.object ||
                                 CONSTS.ACCESS_USER_RW | CONSTS.ACCESS_GROUP_READ | CONSTS.ACCESS_EVERY_READ, // '0644'
@@ -4590,8 +4580,7 @@ export class ObjectsInRedisClient {
                     oldObj.acl.ownerGroup = null;
                     return void this.getUserGroup(options.owner, (user, groups /*, permissions */) => {
                         if (!groups || !groups[0]) {
-                            options.ownerGroup =
-                                this.defaultNewAcl?.ownerGroup || CONSTS.SYSTEM_ADMIN_GROUP;
+                            options.ownerGroup = this.defaultNewAcl?.ownerGroup || CONSTS.SYSTEM_ADMIN_GROUP;
                         } else {
                             options.ownerGroup = groups[0];
                         }
@@ -4855,7 +4844,7 @@ export class ObjectsInRedisClient {
 
         for (const setting of settings) {
             // @ts-expect-error TODO: decide https://github.com/ioBroker/ioBroker.js-controller/issues/507
-            if (this.preserveSettings.indexOf(setting) === -1) {
+            if (!this.preserveSettings.includes(setting)) {
                 // @ts-expect-error TODO: decide https://github.com/ioBroker/ioBroker.js-controller/issues/507
                 this.preserveSettings.push(setting);
             }

--- a/packages/db-objects-redis/src/lib/objects/objectsInRedisClient.ts
+++ b/packages/db-objects-redis/src/lib/objects/objectsInRedisClient.ts
@@ -155,7 +155,7 @@ export class ObjectsInRedisClient {
         this.settings = settings || {};
         this.redisNamespace = `${
             this.settings.redisNamespace ||
-            (this.settings.connection && this.settings.connection.redisNamespace) ||
+            this.settings.connection?.redisNamespace ||
             'cfg'
         }.`;
         this.fileNamespace = `${this.redisNamespace}f.`;
@@ -311,16 +311,17 @@ export class ObjectsInRedisClient {
         this.client = new Redis(this.settings.connection.options);
 
         this.client.on('error', error => {
-            this.settings.connection.enhancedLogging &&
+            if (this.settings.connection.enhancedLogging) {
                 this.log.silly(
                     `${this.namespace} Redis ERROR Objects: (${this.stop}) ${error.message} / ${error.stack}`,
                 );
+            }
             if (this.stop) {
                 return;
             }
             if (!ready) {
                 initError = true;
-                // Seems we have a socket.io server
+                // It seems we have a socket.io server
                 if (error.message.startsWith('Protocol error, got "H" as reply type byte.')) {
                     this.log.error(
                         `${this.namespace} Could not connect to objects database at ${this.settings.connection.options.host}:${this.settings.connection.options.port} (invalid protocol). Please make sure the configured IP and port points to a host running JS-Controller >= 2.0. and that the port is not occupied by other software!`,
@@ -333,14 +334,18 @@ export class ObjectsInRedisClient {
         });
 
         this.client.on('end', () => {
-            this.settings.connection.enhancedLogging &&
+            if (this.settings.connection.enhancedLogging) {
                 this.log.silly(`${this.namespace} Objects-Redis Event end (stop=${this.stop})`);
-            ready && typeof this.settings.disconnected === 'function' && this.settings.disconnected();
+            }
+            if (ready && typeof this.settings.disconnected === 'function') {
+                this.settings.disconnected();
+            }
         });
 
         this.client.on('connect', () => {
-            this.settings.connection.enhancedLogging &&
+            if (this.settings.connection.enhancedLogging) {
                 this.log.silly(`${this.namespace} Objects-Redis Event connect (stop=${this.stop})`);
+            }
             connected = true;
             if (errorLogged) {
                 this.log.info(`${this.namespace} Objects database successfully reconnected`);
@@ -349,8 +354,9 @@ export class ObjectsInRedisClient {
         });
 
         this.client.on('close', () => {
-            this.settings.connection.enhancedLogging &&
+            if (this.settings.connection.enhancedLogging) {
                 this.log.silly(`${this.namespace} Objects-Redis Event close (stop=${this.stop})`);
+            }
             //if (ready && typeof this.settings.disconnected === 'function') this.settings.disconnected();
         });
 
@@ -359,10 +365,11 @@ export class ObjectsInRedisClient {
                 reconnectCounter++;
             }
 
-            this.settings.connection.enhancedLogging &&
+            if (this.settings.connection.enhancedLogging) {
                 this.log.silly(
                     `${this.namespace} Objects-Redis Event reconnect (reconnectCounter=${reconnectCounter}, stop=${this.stop})`,
                 );
+            }
 
             if (reconnectCounter > 2) {
                 // fallback logic for nodejs <10
@@ -466,13 +473,13 @@ export class ObjectsInRedisClient {
 
                                         if (
                                             id === 'system.config' &&
-                                            obj &&
-                                            obj.common &&
-                                            obj.common.defaultNewAcl &&
+                                            obj?.common?.defaultNewAcl &&
                                             !isDeepStrictEqual(obj.common.defaultNewAcl, this.defaultNewAcl)
                                         ) {
                                             this.defaultNewAcl = deepClone(obj.common.defaultNewAcl);
-                                            this.settings.controller && this.setDefaultAcl(this.defaultNewAcl);
+                                            if (this.settings.controller) {
+                                                this.setDefaultAcl(this.defaultNewAcl);
+                                            }
                                         }
 
                                         onChange(id, obj);
@@ -500,21 +507,25 @@ export class ObjectsInRedisClient {
                 }
 
                 this.subSystem.on('end', () => {
-                    this.settings.connection.enhancedLogging &&
+                    if (this.settings.connection.enhancedLogging) {
                         this.log.silly(`${this.namespace} Objects-Redis System Event end sub (stop=${this.stop})`);
-                    ready && typeof this.settings.disconnected === 'function' && this.settings.disconnected();
+                    }
+                    if (ready && typeof this.settings.disconnected === 'function') {
+                        this.settings.disconnected();
+                    }
                 });
 
                 this.subSystem.on('error', error => {
                     if (this.stop) {
                         return;
                     }
-                    this.settings.connection.enhancedLogging &&
+                    if (this.settings.connection.enhancedLogging) {
                         this.log.silly(
                             `${this.namespace} PubSub System client Objects No redis connection: ${JSON.stringify(
                                 error,
                             )}`,
                         );
+                    }
                 });
 
                 if (this.settings.connection.enhancedLogging) {
@@ -554,19 +565,25 @@ export class ObjectsInRedisClient {
                                 )}:${tools.maybeArrayToString(this.settings.connection.port)}`,
                             );
                         }
-                        !ready && typeof this.settings.connected === 'function' && this.settings.connected();
+                        if (!ready && typeof this.settings.connected === 'function') {
+                            this.settings.connected();
+                        }
                         ready = true;
                     }
                     // subscribe on system.config anytime because also adapters need stuff like defaultNewAcl (especially admin)
                     try {
-                        this.subSystem && (await this.subSystem.psubscribe(`${this.objNamespace}system.config`));
+                        if (this.subSystem) {
+                            (await this.subSystem.psubscribe(`${this.objNamespace}system.config`));
+                        }
                     } catch {
                         // ignore
                     }
 
                     // subscribe to meta changes
                     try {
-                        this.subSystem && (await this.subSystem.psubscribe(`${this.metaNamespace}*`));
+                        if (this.subSystem) {
+                            (await this.subSystem.psubscribe(`${this.metaNamespace}*`));
+                        }
                     } catch (e) {
                         this.log.warn(
                             `${this.namespace} Unable to subscribe to meta namespace "${this.metaNamespace}" changes: ${e.message}`,
@@ -643,9 +660,12 @@ export class ObjectsInRedisClient {
                 });
 
                 this.sub.on('end', () => {
-                    this.settings.connection.enhancedLogging &&
+                    if (this.settings.connection.enhancedLogging) {
                         this.log.silly(`${this.namespace} Objects-Redis Event end user sub (stop=${this.stop})`);
-                    ready && typeof this.settings.disconnected === 'function' && this.settings.disconnected();
+                    }
+                    if (ready && typeof this.settings.disconnected === 'function') {
+                        this.settings.disconnected();
+                    }
                 });
 
                 this.sub.on('error', error => {
@@ -1196,7 +1216,7 @@ export class ObjectsInRedisClient {
         let buffer;
         buffer = await this._getBinaryState(this.getFileId(id, name, false));
 
-        const mimeType = meta && meta.mimeType;
+        const mimeType = meta?.mimeType;
         if (meta && !meta.binary && buffer) {
             buffer = buffer.toString();
         }
@@ -1224,7 +1244,7 @@ export class ObjectsInRedisClient {
             callback = options;
             options = null;
         }
-        if (options && options.acl) {
+        if (options?.acl) {
             options.acl = null;
         }
 
@@ -1353,7 +1373,7 @@ export class ObjectsInRedisClient {
             callback = options;
             options = null;
         }
-        if (options && options.acl) {
+        if (options?.acl) {
             options.acl = null;
         }
 
@@ -1501,7 +1521,7 @@ export class ObjectsInRedisClient {
         const dontCheck =
             options.user === CONSTS.SYSTEM_ADMIN_USER ||
             options.group !== CONSTS.SYSTEM_ADMIN_GROUP ||
-            (options.groups && options.groups.indexOf(CONSTS.SYSTEM_ADMIN_GROUP) !== -1);
+            options.groups?.includes(CONSTS.SYSTEM_ADMIN_GROUP);
 
         for (let i = 0; i < keys.length; i++) {
             const file = keys[i].substring(start + baseName.length, keys[i].length - end);
@@ -1568,7 +1588,7 @@ export class ObjectsInRedisClient {
             callback = options;
             options = null;
         }
-        if (options && options.acl) {
+        if (options?.acl) {
             options.acl = null;
         }
 
@@ -1698,7 +1718,7 @@ export class ObjectsInRedisClient {
             const dontCheck =
                 options.user === CONSTS.SYSTEM_ADMIN_USER ||
                 options.group !== CONSTS.SYSTEM_ADMIN_GROUP ||
-                (options.groups && options.groups.indexOf(CONSTS.SYSTEM_ADMIN_GROUP) !== -1);
+                options.groups?.includes(CONSTS.SYSTEM_ADMIN_GROUP);
 
             if (!dontCheck) {
                 result = [];
@@ -1740,7 +1760,7 @@ export class ObjectsInRedisClient {
             callback = options;
             options = null;
         }
-        if (options && options.acl) {
+        if (options?.acl) {
             options.acl = null;
         }
         if (
@@ -1807,7 +1827,7 @@ export class ObjectsInRedisClient {
             callback = options;
             options = null;
         }
-        if (options && options.acl) {
+        if (options?.acl) {
             options.acl = null;
         }
 
@@ -1852,7 +1872,7 @@ export class ObjectsInRedisClient {
         meta?: any,
     ): Promise<ioBroker.RmResult[] | undefined> {
         if (meta && !meta.isDir) {
-            // it is file
+            // it is a file
             const metaID = this.getFileId(id, name, true);
             const dataID = this.getFileId(id, name, false);
             await this.delObjectAsync(dataID);
@@ -1894,7 +1914,7 @@ export class ObjectsInRedisClient {
             const dontCheck =
                 options.user === CONSTS.SYSTEM_ADMIN_USER ||
                 options.group !== CONSTS.SYSTEM_ADMIN_GROUP ||
-                (options.groups && options.groups.indexOf(CONSTS.SYSTEM_ADMIN_GROUP) !== -1);
+                options.groups?.includes(CONSTS.SYSTEM_ADMIN_GROUP);
 
             objs = objs || [];
             if (!dontCheck) {
@@ -1937,7 +1957,7 @@ export class ObjectsInRedisClient {
             callback = options;
             options = null;
         }
-        if (options && options.acl) {
+        if (options?.acl) {
             options.acl = null;
         }
 
@@ -1953,7 +1973,7 @@ export class ObjectsInRedisClient {
                 return tools.maybeCallbackWithError(callback, ERRORS.ERROR_PERMISSION);
             }
             try {
-                const files = await this._rm(id, name, options, meta && meta.notExists ? null : meta);
+                const files = await this._rm(id, name, options, meta?.notExists ? null : meta);
                 return tools.maybeCallbackWithError(callback, null, files);
             } catch (e) {
                 return tools.maybeCallbackWithError(callback, e);
@@ -2102,7 +2122,7 @@ export class ObjectsInRedisClient {
         const dontCheck =
             options.user === CONSTS.SYSTEM_ADMIN_USER ||
             options.group !== CONSTS.SYSTEM_ADMIN_GROUP ||
-            (options.groups && options.groups.indexOf(CONSTS.SYSTEM_ADMIN_GROUP) !== -1);
+            options.groups?.includes(CONSTS.SYSTEM_ADMIN_GROUP);
         const keysFiltered = [];
         const objsFiltered = [];
         const processed: ioBroker.ChownFileResult[] = [];
@@ -2316,7 +2336,7 @@ export class ObjectsInRedisClient {
         const dontCheck =
             options.user === CONSTS.SYSTEM_ADMIN_USER ||
             options.group !== CONSTS.SYSTEM_ADMIN_GROUP ||
-            (options.groups && options.groups.indexOf(CONSTS.SYSTEM_ADMIN_GROUP) !== -1);
+            options.groups?.includes(CONSTS.SYSTEM_ADMIN_GROUP);
 
         const keysFiltered = [];
         const objsFiltered = [];
@@ -2424,7 +2444,7 @@ export class ObjectsInRedisClient {
             options = null;
         }
 
-        if (options && options.acl) {
+        if (options?.acl) {
             options.acl = null;
         }
 
@@ -2780,16 +2800,16 @@ export class ObjectsInRedisClient {
                     }
                     if (!obj.acl) {
                         obj.acl = {
-                            owner: (this.defaultNewAcl && this.defaultNewAcl.owner) || CONSTS.SYSTEM_ADMIN_USER,
+                            owner: this.defaultNewAcl?.owner || CONSTS.SYSTEM_ADMIN_USER,
                             ownerGroup:
-                                (this.defaultNewAcl && this.defaultNewAcl.ownerGroup) || CONSTS.SYSTEM_ADMIN_GROUP,
+                                this.defaultNewAcl?.ownerGroup || CONSTS.SYSTEM_ADMIN_GROUP,
                             object:
-                                (this.defaultNewAcl && this.defaultNewAcl.object) ||
+                                this.defaultNewAcl?.object ||
                                 CONSTS.ACCESS_USER_RW | CONSTS.ACCESS_GROUP_READ | CONSTS.ACCESS_EVERY_READ, // '0644'
                         };
                         if (obj.type === 'state') {
                             obj.acl!.state =
-                                (this.defaultNewAcl && this.defaultNewAcl.state) ||
+                                this.defaultNewAcl?.state ||
                                 CONSTS.ACCESS_USER_RW | CONSTS.ACCESS_GROUP_READ | CONSTS.ACCESS_EVERY_READ; // '0644'
                         }
                     }
@@ -2907,16 +2927,16 @@ export class ObjectsInRedisClient {
                     }
                     if (!obj.acl) {
                         obj.acl = {
-                            owner: (this.defaultNewAcl && this.defaultNewAcl.owner) || CONSTS.SYSTEM_ADMIN_USER,
+                            owner: this.defaultNewAcl?.owner || CONSTS.SYSTEM_ADMIN_USER,
                             ownerGroup:
-                                (this.defaultNewAcl && this.defaultNewAcl.ownerGroup) || CONSTS.SYSTEM_ADMIN_GROUP,
+                                this.defaultNewAcl?.ownerGroup || CONSTS.SYSTEM_ADMIN_GROUP,
                             object:
-                                (this.defaultNewAcl && this.defaultNewAcl.object) ||
+                                this.defaultNewAcl?.object ||
                                 CONSTS.ACCESS_USER_RW | CONSTS.ACCESS_GROUP_READ | CONSTS.ACCESS_EVERY_READ, // '0644'
                         };
                         if (obj.type === 'state') {
                             obj.acl!.state =
-                                (this.defaultNewAcl && this.defaultNewAcl.state) ||
+                                this.defaultNewAcl?.state ||
                                 CONSTS.ACCESS_USER_RW | CONSTS.ACCESS_GROUP_READ | CONSTS.ACCESS_EVERY_READ; // '0644'
                         }
                     }
@@ -3110,7 +3130,7 @@ export class ObjectsInRedisClient {
             const dontCheck =
                 options.user === CONSTS.SYSTEM_ADMIN_USER ||
                 options.group !== CONSTS.SYSTEM_ADMIN_GROUP ||
-                (options.groups && options.groups.indexOf(CONSTS.SYSTEM_ADMIN_GROUP) !== -1);
+                options.groups?.includes(CONSTS.SYSTEM_ADMIN_GROUP);
 
             if (dontCheck) {
                 for (let i = 0; i < keys.length; i++) {
@@ -3231,8 +3251,9 @@ export class ObjectsInRedisClient {
         let objs;
         try {
             objs = await this.client.mget(_keys);
-            this.settings.connection.enhancedLogging &&
+            if (this.settings.connection.enhancedLogging) {
                 this.log.silly(`${this.namespace} redis mget ${!objs ? 0 : objs.length} ${_keys.length}`);
+            }
         } catch (e) {
             this.log.warn(`${this.namespace} redis mget ${!objs ? 0 : objs.length} ${_keys.length}, err: ${e.message}`);
         }
@@ -3243,7 +3264,7 @@ export class ObjectsInRedisClient {
                 options &&
                 (options.user === CONSTS.SYSTEM_ADMIN_USER ||
                     options.group !== CONSTS.SYSTEM_ADMIN_GROUP ||
-                    (options.groups && options.groups.indexOf(CONSTS.SYSTEM_ADMIN_GROUP) !== -1));
+                    options.groups?.includes(CONSTS.SYSTEM_ADMIN_GROUP));
 
             if (!dontCheck) {
                 for (let i = 0; i < objs.length; i++) {
@@ -3344,8 +3365,9 @@ export class ObjectsInRedisClient {
             return tools.maybeCallbackWithError(callback, ERRORS.ERROR_DB_CLOSED);
         }
 
-        this.settings.connection.enhancedLogging &&
+        if (this.settings.connection.enhancedLogging) {
             this.log.silly(`${this.namespace} redis keys ${keys.length} ${pattern}`);
+        }
         this._getObjects(keys, options, callback, true);
     }
 
@@ -3369,7 +3391,7 @@ export class ObjectsInRedisClient {
                 this.getObjectsByPattern(pattern, options, (err, obj) => (err ? reject(err) : resolve(obj))),
             );
         }
-        if (options && options.acl) {
+        if (options?.acl) {
             options.acl = null;
         }
         if (typeof callback === 'function') {
@@ -3635,7 +3657,7 @@ export class ObjectsInRedisClient {
                 this.setObject(id, obj, options, (err, res) => (err ? reject(err) : resolve(res))),
             );
         }
-        if (options && options.acl) {
+        if (options?.acl) {
             options.acl = null;
         }
 
@@ -4569,7 +4591,7 @@ export class ObjectsInRedisClient {
                     return void this.getUserGroup(options.owner, (user, groups /*, permissions */) => {
                         if (!groups || !groups[0]) {
                             options.ownerGroup =
-                                (this.defaultNewAcl && this.defaultNewAcl.ownerGroup) || CONSTS.SYSTEM_ADMIN_GROUP;
+                                this.defaultNewAcl?.ownerGroup || CONSTS.SYSTEM_ADMIN_GROUP;
                         } else {
                             options.ownerGroup = groups[0];
                         }
@@ -4627,7 +4649,7 @@ export class ObjectsInRedisClient {
                 }
             }
 
-            if (oldObj.common && oldObj.common.custom && !oldObjHasCustom) {
+            if (oldObj.common?.custom && !oldObjHasCustom) {
                 // we now have custom, old object had no custom
                 commands.push(['sadd', `${this.setNamespace}object.common.custom`, this.objNamespace + id]);
             } else if (oldObjHasCustom && (!oldObj.common || !oldObj.common.custom)) {
@@ -4682,7 +4704,7 @@ export class ObjectsInRedisClient {
             );
         }
 
-        if (options && options.acl) {
+        if (options?.acl) {
             options.acl = null;
         }
 

--- a/packages/types-dev/objects.d.ts
+++ b/packages/types-dev/objects.d.ts
@@ -338,7 +338,7 @@ declare global {
             /** UI type of custom tab inside admin UI */
             custom?: 'json';
             /** UI type of tab inside admin UI */
-            tab?: 'html' | 'materialize';
+            tab?: 'html' | 'json' | 'materialize';
         }
 
         /** Installed from attribute of instance/adapter object */

--- a/packages/types-dev/objects.d.ts
+++ b/packages/types-dev/objects.d.ts
@@ -616,8 +616,6 @@ declare global {
                 singleton?: boolean;
                 /** Order number in admin tabs */
                 order?: number;
-                /** If used JSON config this command (if string) will be sent to backend. If boolean, the command "tab" will be sent to backend */
-                sendTo?: boolean | string;
             };
             /** If the mode is `schedule`, start one time adapter by ioBroker start, or by the configuration changes */
             allowInit?: boolean;

--- a/packages/types-dev/objects.d.ts
+++ b/packages/types-dev/objects.d.ts
@@ -610,7 +610,7 @@ declare global {
                 'fa-icon'?: string;
                 /** If true, the Tab is not reloaded when the configuration changes */
                 ignoreConfigUpdate?: boolean;
-                /** Describes which URL should be loaded in the tab. Supports placeholders like http://%ip%:%port% or JSON(5) configs. */
+                /** Describes which URL should be loaded in the tab. Supports placeholders like http://%ip%:%port% or JSON(5) configs. If empty `adapter/ADAPTERNAME/tab(_m).html` will be taken. JSON config file must be defined relative to "admin" folder, like "jsonTab.json"  */
                 link?: string;
                 /** If true, only one instance of this tab will be created for all instances */
                 singleton?: boolean;

--- a/packages/types-dev/objects.d.ts
+++ b/packages/types-dev/objects.d.ts
@@ -610,12 +610,14 @@ declare global {
                 'fa-icon'?: string;
                 /** If true, the Tab is not reloaded when the configuration changes */
                 ignoreConfigUpdate?: boolean;
-                /** Which URL should be loaded in the tab. Supports placeholders like http://%ip%:%port% */
+                /** Describes which URL should be loaded in the tab. Supports placeholders like http://%ip%:%port% or JSON(5) configs. */
                 link?: string;
                 /** If true, only one instance of this tab will be created for all instances */
                 singleton?: boolean;
                 /** Order number in admin tabs */
                 order?: number;
+                /** If used JSON config this command (if string) will be sent to backend. If boolean, the command "tab" will be sent to backend */
+                sendTo?: boolean | string;
             };
             /** If the mode is `schedule`, start one time adapter by ioBroker start, or by the configuration changes */
             allowInit?: boolean;

--- a/schemas/io-package.json
+++ b/schemas/io-package.json
@@ -1104,11 +1104,6 @@
         "adminTab": {
           "description": "Adds a Tab which can be shown in admin adapter",
           "type": "object",
-          "required": [
-            "fa-icon",
-            "link",
-            "name"
-          ],
           "additionalProperties": false,
           "properties": {
             "fa-icon": {

--- a/schemas/io-package.json
+++ b/schemas/io-package.json
@@ -1120,7 +1120,7 @@
               "type": "boolean"
             },
             "link": {
-              "description": "Link for iframe in the TAB. You can use parameters replacement like this: \"https://%ip%:%port%\". IP will be replaced with host IP. \"port\" will be extracted from native.port.",
+              "description": "Link for iframe or JSON config file in the TAB. You can use parameters replacement like this: \"https://%ip%:%port%\". IP will be replaced with host IP. \"port\" will be extracted from native.port.",
               "type": "string"
             },
             "name": {
@@ -1130,6 +1130,17 @@
             "singleton": {
               "description": "If true, only one TAB for all instances will be shown.",
               "type": "boolean"
+            },
+            "sendTo": {
+              "description": "If used JSON config this command (if \"string\") will be sent to instance. If boolean, the command \"tab\" will be sent to backend",
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "boolean"
+                }
+              ]
             }
           }
         },

--- a/schemas/io-package.json
+++ b/schemas/io-package.json
@@ -1125,17 +1125,6 @@
             "singleton": {
               "description": "If true, only one TAB for all instances will be shown.",
               "type": "boolean"
-            },
-            "sendTo": {
-              "description": "If used JSON config this command (if \"string\") will be sent to instance. If boolean, the command \"tab\" will be sent to backend",
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "boolean"
-                }
-              ]
             }
           }
         },


### PR DESCRIPTION
## Added types for sendTo in a case of JSON config for tabs
I implemented new feature: https://github.com/ioBroker/ioBroker.admin/tree/master/packages/jsonConfig#json-tab-in-admin
For that the new flag must be added to io-package.json

## Formatting of objectsInRedisClient.ts
Only replaced `var && var.attr` with 'var?.attr`

**Tests**
- [ ] I have added tests to avoid a recursion of this bug
- [X] It is not possible to test for this bug. But I can compile it

**Documentation**
- [X] I have documented the new feature in schema
