### PR TITLE
Disallow non-numbers for ts/lc handling on states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 	## __WORK IN PROGRESS__
 -->
 
+## __WORK IN PROGRESS__
+* (@Apollon77) Allows only numbers for ts and tc fields in state when provided for setState
+
 ## 7.0.7 (2025-04-17) - Lucy
 * (@foxriver76) fixed the edge-case problem on Windows (if adapter calls `readDir` on single file)
 * (@foxriver76) fixed setting negative numbers via `state set` cli command

--- a/packages/controller/test/testStatesRedis.ts
+++ b/packages/controller/test/testStatesRedis.ts
@@ -95,6 +95,7 @@ describe('States-Redis: Test states in Redis', function () {
                 expect(state!.val).to.be.equal(2);
                 expect(state!.ack).to.be.false;
                 expect(state!.ts).to.be.ok;
+                expect(state!.lc).to.be.equal(state!.ts);
                 expect(state!.q).to.be.equal(0);
 
                 // @ts-expect-error adding types later on
@@ -103,12 +104,68 @@ describe('States-Redis: Test states in Redis', function () {
                 expect(state!.val).to.be.equal(2);
                 expect(state!.ack).to.be.false;
                 expect(state!.ts).to.be.ok;
+                expect(state!.lc).to.be.equal(state!.ts);
                 expect(state!.q).to.be.equal(0);
                 done();
             }
         };
 
         states!.setState(testID, 2);
+    }).timeout(10_000);
+
+    it('States-Redis: should setState with object state parameters', done => {
+        const testID = 'testObject.0.test1';
+        onStatesChanged = async (id, state) => {
+            if (id === testID) {
+                expect(state).to.be.ok;
+                expect(state!.val).to.be.equal(3);
+                expect(state!.ack).to.be.true;
+                expect(state!.ts).to.be.equal(123456);
+                expect(state!.lc).to.be.equal(state!.ts);
+                expect(state!.q).to.be.equal(1);
+
+                // @ts-expect-error adding types later on
+                state = await states!.getStateAsync(testID);
+                expect(state).to.be.ok;
+                expect(state!.val).to.be.equal(3);
+                expect(state!.ack).to.be.true;
+                expect(state!.ts).to.be.equal(123456);
+                expect(state!.lc).to.be.equal(state!.ts);
+                expect(state!.q).to.be.equal(1);
+                done();
+            }
+        };
+
+        states!.setState(testID, { val: 3, ack: true, ts: 123456, q: 1 });
+    }).timeout(10_000);
+
+    it('States-Redis: should setState with object state parameters ignoring null ts', done => {
+        const testID = 'testObject.0.test1';
+        onStatesChanged = async (id, state) => {
+            if (id === testID) {
+                expect(state).to.be.ok;
+                expect(state!.val).to.be.equal(4);
+                expect(state!.ack).to.be.true;
+                expect(state!.ts).to.be.ok;
+                expect(state!.ts).to.be.not.equal(123456);
+                expect(state!.lc).to.be.equal(state!.ts);
+                expect(state!.q).to.be.equal(1);
+
+                // @ts-expect-error adding types later on
+                state = await states!.getStateAsync(testID);
+                expect(state).to.be.ok;
+                expect(state!.val).to.be.equal(4);
+                expect(state!.ack).to.be.true;
+                expect(state!.ts).to.be.ok;
+                expect(state!.ts).to.be.not.equal(123456);
+                expect(state!.lc).to.be.equal(state!.ts);
+                expect(state!.q).to.be.equal(1);
+                done();
+            }
+        };
+
+        // @ts-expect-error ignore types here for ts to test the case
+        states!.setState(testID, { val: 4, ack: true, ts: null, q: 1 });
     }).timeout(10_000);
 
     // todo: write more tests

--- a/packages/controller/test/testStatesRedis.ts
+++ b/packages/controller/test/testStatesRedis.ts
@@ -120,7 +120,7 @@ describe('States-Redis: Test states in Redis', function () {
                 expect(state).to.be.ok;
                 expect(state!.val).to.be.equal(3);
                 expect(state!.ack).to.be.true;
-                expect(state!.ts).to.be.equal(123456);
+                expect(state!.ts).to.be.equal(123456000);
                 expect(state!.lc).to.be.equal(state!.ts);
                 expect(state!.q).to.be.equal(1);
 
@@ -129,7 +129,7 @@ describe('States-Redis: Test states in Redis', function () {
                 expect(state).to.be.ok;
                 expect(state!.val).to.be.equal(3);
                 expect(state!.ack).to.be.true;
-                expect(state!.ts).to.be.equal(123456);
+                expect(state!.ts).to.be.equal(123456000);
                 expect(state!.lc).to.be.equal(state!.ts);
                 expect(state!.q).to.be.equal(1);
                 done();
@@ -147,7 +147,7 @@ describe('States-Redis: Test states in Redis', function () {
                 expect(state!.val).to.be.equal(4);
                 expect(state!.ack).to.be.true;
                 expect(state!.ts).to.be.ok;
-                expect(state!.ts).to.be.not.equal(123456);
+                expect(state!.ts).to.be.not.equal(123456000);
                 expect(state!.lc).to.be.equal(state!.ts);
                 expect(state!.q).to.be.equal(1);
 
@@ -157,7 +157,7 @@ describe('States-Redis: Test states in Redis', function () {
                 expect(state!.val).to.be.equal(4);
                 expect(state!.ack).to.be.true;
                 expect(state!.ts).to.be.ok;
-                expect(state!.ts).to.be.not.equal(123456);
+                expect(state!.ts).to.be.not.equal(123456000);
                 expect(state!.lc).to.be.equal(state!.ts);
                 expect(state!.q).to.be.equal(1);
                 done();

--- a/packages/db-states-redis/src/lib/states/statesInRedisClient.ts
+++ b/packages/db-states-redis/src/lib/states/statesInRedisClient.ts
@@ -750,7 +750,7 @@ export class StateRedisClient {
             obj.ack = false;
         }
 
-        if (state.ts !== undefined) {
+        if (typeof state.ts === 'number') {
             obj.ts = state.ts < 946681200000 ? state.ts * 1000 : state.ts; // if less 2000.01.01 00:00:00
         } else {
             obj.ts = new Date().getTime();
@@ -775,7 +775,7 @@ export class StateRedisClient {
 
         let hasChanged;
 
-        if (state.lc !== undefined) {
+        if (typeof state.lc === 'number') {
             obj.lc = state.lc;
         } else {
             // isDeepStrictEqual works on objects and primitive values


### PR DESCRIPTION
### For Bugfixes:

**Link the issue which is closed by this PR**
In https://github.com/Apollon77/ioBroker.tuya/issues/618 it happened (I do not understand how, but seems to happen according to log) that "ts" ad "lc" got null. js.controller only checks for !== undefined

**Implementation details**
ts and lc needs to be numbers, so check for that instead of just undefined.

**Tests**
- [x] I have added tests to avoid a recursion of this bug
- [ ] It is not possible to test for this bug
