### PR TITLE
[TYPES] Added typeing and schema for Vis-2 icon set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ## __WORK IN PROGRESS__
 * (@Apollon77) Allows only numbers for ts and tc fields in state when provided for setState
+* (@GermanBluefox) Added typing for visIconSets in `io-package.json`(for vis-2 SVG icon sets)
 
 ## 7.0.7 (2025-04-17) - Lucy
 * (@foxriver76) fixed the edge-case problem on Windows (if adapter calls `readDir` on single file)
@@ -43,8 +44,7 @@
 * Backups created with 7.0.x cannot be restored with a previous version
 
 **Features**
-* (@GermanBluefox) Added support for dynamic notification data 
-(with this feature developers can create interactive notifications in the Admin adapter)
+* (@GermanBluefox) Added support for dynamic notification data (with this feature, developers can create interactive notifications in the Admin adapter)
 * (@GermanBluefox/@foxriver76) implemented automatic upload on adapter start if version mismatch is detected
 * (@foxriver76) improved backup/restore process to work for arbitrary large installations
 * (@foxriver76) added notification if new image is available on Docker Hub (for official docker systems)

--- a/packages/types-dev/objects.d.ts
+++ b/packages/types-dev/objects.d.ts
@@ -511,7 +511,16 @@ declare global {
             /** If the widget was written with TypeScript */
             bundlerType?: 'module';
             /** The vis widget does not support the listed major versions of vis */
-            ignoreInVersions: number[];
+            ignoreInVersions?: number[];
+        }
+
+        interface VisIconSet {
+            name?: ioBroker.StringOrTranslated;
+            url: string;
+            /** If set, this is not a widget set, but icon set. url, name and icon are required */
+            icon?: string; // base 64 string for iconSet (not used for widgetSets)
+            /** The vis icon set does not support the listed major versions of vis */
+            ignoreInVersions?: number[];
         }
 
         type PaidLicenseType = 'paid' | 'commercial' | 'limited';
@@ -776,6 +785,8 @@ declare global {
             version: string;
             /** Definition of the vis-2 widgets */
             visWidgets?: Record<string, VisWidget>;
+            /** Definition of the vis-2 icon sets */
+            visIconSets?: Record<string, VisIconSet>;
             /** Include the adapter version in the URL of the web adapter, e.g. `http://ip:port/1.2.3/material` instead of `http://ip:port/material` */
             webByVersion?: boolean;
             /** Whether the web server in this adapter can be extended with plugin/extensions */

--- a/schemas/io-package.json
+++ b/schemas/io-package.json
@@ -1498,6 +1498,7 @@
             ".+": {
               "description": "The key represents the name of a provided widget set",
               "required": [
+                "name",
                 "url",
                 "components",
                 "i18n"
@@ -1526,6 +1527,10 @@
                     }
                   ]
                 },
+                "name": {
+                    "description": "Name of the widget set",
+                    "type": "string"
+                },
                 "url": {
                   "description": "Relative path ('http://ip:port/vis/widgets/' + url) or full url to load component from",
                   "type": "string"
@@ -1552,6 +1557,49 @@
                     "type": "number",
                     "multipleOf": 1
                   }
+                }
+              }
+            }
+          }
+        },
+        "visIconSets": {
+          "description": "Overview of vis 2 SVG icon sets provided by the adapter, define the name of the provided sets as keys",
+          "minProperties": 1,
+          "type": "object",
+          "patternProperties": {
+            ".+": {
+              "description": "The key represents the name of a provided icon set",
+              "required": [
+                  "url"
+              ],
+              "type": "object",
+              "properties": {
+                "url": {
+                  "description": "Relative path ('http://ip:port/vis/widgets/' + url) or full url to load JSON file from",
+                  "type": "string"
+                },
+                "ignoreInVersions": {
+                  "description": "The vis icon set does not support the listed major versions of vis",
+                  "type": "array",
+                  "items": {
+                    "type": "number",
+                    "multipleOf": 1
+                  }
+                },
+                "name": {
+                  "description": "Name of the icon set",
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "$ref": "#/definitions/multilingual"
+                    }
+                  ]
+                },
+                "icon": {
+                  "description": "Base 64 icon of the widget set, data:image/svg+xml;base64,...",
+                  "type": "string"
                 }
               }
             }


### PR DESCRIPTION
ioBroker.vis-2 supports from v2.13.x the SVG icon sets. This PR defines the types for that