### PR TITLE
[TYPES] Supports load message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## __WORK IN PROGRESS__
 * (@Apollon77) Allows only numbers for ts and tc fields in state when provided for setState
 * (@GermanBluefox) Added typing for visIconSets in `io-package.json`(for vis-2 SVG icon sets)
+* (@GermanBluefox) Added typing for smartName in the enum objects
 
 ## 7.0.7 (2025-04-17) - Lucy
 * (@foxriver76) fixed the edge-case problem on Windows (if adapter calls `readDir` on single file)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,10 @@
 -->
 
 ## __WORK IN PROGRESS__
-* (@Apollon77) Allows only numbers for ts and tc fields in state when provided for setState
-* (@GermanBluefox) Added typing for visIconSets in `io-package.json`(for vis-2 SVG icon sets)
-* (@GermanBluefox) Added typing for smartName in the enum objects
+* (@Apollon77) Allows only numbers for `ts` and `lc` fields in state when provided for setState
+* (@GermanBluefox) Added typing for `visIconSets` in `io-package.json`(for vis-2 SVG icon sets)
+* (@GermanBluefox) Added typing for `smartName` in the enum objects
+* (@GermanBluefox) Added typing for `supportsLoadingMessage` in the instance objects
 
 ## 7.0.7 (2025-04-17) - Lucy
 * (@foxriver76) fixed the edge-case problem on Windows (if adapter calls `readDir` on single file)

--- a/packages/types-dev/objects.d.ts
+++ b/packages/types-dev/objects.d.ts
@@ -186,6 +186,15 @@ declare global {
             role?: string;
         }
 
+        type SmartNameObject = { [lang in ioBroker.Languages]?: string } & {
+            /** Which kind of device it is */
+            smartType?: string | null;
+            /** Which value to set when the ON command is issued */
+            byON?: string | null;
+        };
+
+        type SmartName = null | false | string | SmartNameObject;
+
         interface StateCommon extends ObjectCommon {
             /** Type of this state. See https://github.com/ioBroker/ioBroker/blob/master/doc/SCHEMA.md#state-commonrole for a detailed description */
             type: CommonType;
@@ -268,16 +277,7 @@ declare global {
              * The string "ignore" (deprecated please use boolean `false` instead) or boolean value `false` is a special case, causing the state to be ignored.
              * A value of `null` means that the device should be removed by the IOT adapters
              */
-            smartName?:
-                | null
-                | false
-                | string
-                | ({ [lang in Languages]?: string } & {
-                      /** Which kind of device it is */
-                      smartType?: string | null;
-                      /** Which value to set when the ON command is issued */
-                      byON?: string | null;
-                  });
+            smartName?: SmartName;
         }
 
         interface ChannelCommon extends ObjectCommon {
@@ -320,6 +320,13 @@ declare global {
 
             // Make it possible to narrow the object type using the custom property
             custom?: undefined;
+
+            /**
+             * Settings for IOT adapters and how the state should be named in e.g., Alexa.
+             * The string "ignore" (deprecated please use boolean `false` instead) or boolean value `false` is a special case, causing the state to be ignored.
+             * A value of `null` means that the device should be removed by the IOT adapters
+             */
+            smartName?: SmartName;
         }
 
         interface MetaCommon extends ObjectCommon {

--- a/packages/types-dev/objects.d.ts
+++ b/packages/types-dev/objects.d.ts
@@ -644,9 +644,9 @@ declare global {
                  *  // ignore
                  *  }
                  * }
-                 * 
+                 *
                  * When loaded in iframe, inform parent window
-                 * Admin will hide a loading spinner when the message will be received. 
+                 * Admin will hide a loading spinner when the message will be received.
                  */
                 supportsLoadingMessage?: boolean;
             };

--- a/packages/types-dev/objects.d.ts
+++ b/packages/types-dev/objects.d.ts
@@ -644,7 +644,9 @@ declare global {
                  *  // ignore
                  *  }
                  * }
-                 * // when loaded in iframe, inform parent window
+                 * 
+                 * When loaded in iframe, inform parent window
+                 * Admin will hide a loading spinner when the message will be received. 
                  */
                 supportsLoadingMessage?: boolean;
             };

--- a/packages/types-dev/objects.d.ts
+++ b/packages/types-dev/objects.d.ts
@@ -634,6 +634,19 @@ declare global {
                 singleton?: boolean;
                 /** Order number in admin tabs */
                 order?: number;
+                /**
+                 * If page sends 'iobLoaded' event:
+                 *
+                 * if (window.parent !== window) {
+                 *  try {
+                 *   window.parent.postMessage('iobLoaded', '*');
+                 *  } catch {
+                 *  // ignore
+                 *  }
+                 * }
+                 * // when loaded in iframe, inform parent window
+                 */
+                supportsLoadingMessage?: boolean;
             };
             /** If the mode is `schedule`, start one time adapter by ioBroker start, or by the configuration changes */
             allowInit?: boolean;

--- a/schemas/io-package.json
+++ b/schemas/io-package.json
@@ -1145,6 +1145,10 @@
             "singleton": {
               "description": "If true, only one TAB for all instances will be shown.",
               "type": "boolean"
+            },
+            "supportsLoadingMessage": {
+              "description": "If page sends 'iobLoaded' event, when loaded",
+              "type": "boolean"
             }
           }
         },

--- a/schemas/io-package.json
+++ b/schemas/io-package.json
@@ -1147,7 +1147,7 @@
               "type": "boolean"
             },
             "supportsLoadingMessage": {
-              "description": "If page sends 'iobLoaded' event, when loaded",
+              "description": "If true, the page sends an 'iobLoaded' event when loaded",
               "type": "boolean"
             }
           }


### PR DESCRIPTION
To now when the iframe is loaded in admin, the children page could send a post message to the parent. To know that a admin should wait for iobLoaded event, this new flag is required.