### PR TITLE
[TYPING] Added types because of plugin-sentry

### DIFF
--- a/packages/types-dev/objects.d.ts
+++ b/packages/types-dev/objects.d.ts
@@ -406,6 +406,9 @@ declare global {
 
             // Make it possible to narrow the object type using the custom property
             custom?: undefined;
+
+            /** If set to true, the reporting by sentry on this host is disabled for all instances */
+            disableDataReporting?: boolean;
         }
 
         interface HostNative {


### PR DESCRIPTION
I am missing a type definition for: 
https://github.com/ioBroker/plugin-sentry/blob/master/src/index.ts#L52
