### PR TITLE
Send files together with the cmdExec host message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,10 @@
 	Placeholder for the next version (at the beginning of the line):
 	## __WORK IN PROGRESS__
 -->
-## 7.1.2 (2026-05-07)
+## __WORK IN PROGRESS__
+* (@GermanBluefox) Added possibility to send files with cmdExec message
+
+## 7.1.2 (2026-05-07) - Milla
 * (@GermanBluefox) Corrected typings
 * (@GermanBluefox) Provided a default object warning limit for adapters so they can apply an appropriate limit during installation: `defaultObjectsWarnLimit`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 	## __WORK IN PROGRESS__
 -->
 ## __WORK IN PROGRESS__
-* (@GermanBluefox) Added possibility to send files with cmdExec message
+* (@GermanBluefox) Added possibility to send files with cmdExec message (feature flag `CONTROLLER_CMD_EXEC_FILES`)
 
 ## 7.1.2 (2026-05-07) - Milla
 * (@GermanBluefox) Corrected typings

--- a/README.md
+++ b/README.md
@@ -1266,6 +1266,7 @@ The following features can be checked using this method:
 * **CONTROLLER_MULTI_REPO**: indicates that the controller supports multiple repository sources, which will be combined in one (since js-controller 4.0)
 * **CONTROLLER_LICENSE_MANAGER**: js-controller can read licenses from iobroker.net (since js-controller 4.0)
 * **DEL_INSTANCE_CUSTOM**: indicates that controller is able to delete all custom attributes of an adapter and instance if it is deleted via `--custom` flag (since js-controller 4.0)
+* **CONTROLLER_CMD_EXEC_FILES**: the `cmdExec` host message supports sending files together with the command via the `files` property (since js-controller 7.2)
 
 To check if certain adapter methods itself are existing, please simply check for their existence like
 

--- a/README.md
+++ b/README.md
@@ -307,7 +307,7 @@ Another example, if you want to ignore all updates in the `1.5.x` range, you can
 The controller can upgrade OS packages on Linux via `yum` and `apt`.
 To upgrade a package, you have to send a message to the controller with the following this example:
 
-```ts
+```typescript
 sendToHostAsync('system.host.test', 'upgradeOsPackages', {
     packages: [{
       // the package name
@@ -351,13 +351,14 @@ If changes are needed there are CLI commands available to update the hostname. L
 
 If you need to set a specific hostname before the first start of iobroker you can also edit the iobroker.json file:
 
-```
+```json5
 {
   "system": {
-    ...
-    "hostname":"local",
-    ...
+    // ...
+    "hostname": "local",
+    // ...
   },
+}
 ```
 
 ### Adapter process memory limitation
@@ -367,15 +368,15 @@ By default, the memory management is done by Node.js automatically. A Garbage Co
 
 If needed, especially for low memory situations the memory limit for all adapter processes can be set in `iobroker.json`. Only set this if really needed, and you know what you are doing. Leave the value at 0 to not set a special memory limitation.
 
-```
+```json5
 {
-...
+  // ...
   "system": {
-    ...
+    // ...
     "memoryLimitMB": 0,
-    ...
+    // ...
   },
-...
+  // ...
 }
 ```
 
@@ -572,14 +573,14 @@ The js-controller and each adapter can define their own log level. By default, `
 
 The log level for js-controller is configured in iobroker.json in the logs section:
 
-```
+```json5
 {
-  ...
+  // ...
   "log": {
     "level": "info",
-    ...
+    // ...
   }
-  ...
+  // ...
 }
 ```
 
@@ -601,9 +602,9 @@ The default logging will log file based in the log directory inside the ioBroker
 
 The logging is configured in the `iobroker.json` file and can be changed there:
 
-```
+```json5
 {
-  ...
+  // ...
   "log": {
     "level": "info",
     "maxDays": 7,
@@ -618,7 +619,8 @@ The logging is configured in the `iobroker.json` file and can be changed there:
         "maxFiles": null
       },
     },
-  ...
+    // ...
+  },
 }
 ```
 
@@ -628,19 +630,20 @@ Since js-controller 3.0 Logfiles on non-Windows-based systems are compressed in 
 
 If you do not want to compress the files, this behavior can be deactivated by `iobroker.json`:
 
-```
+```json5
 {
-  ...
+  // ...
   "log": {
-    ...
+    // ...
     "transport": {
       "file1": {
-        ...
+        // ...
         "zippedArchive": false,
-        ...
+        // ...
       },
     },
-  ...
+    // ...
+  },
 }
 ```
 
@@ -650,13 +653,13 @@ If you do not want to compress the files, this behavior can be deactivated by `i
 
 ioBroker also supports logging to a syslog server. The configuration is also stored in the `iobroker.json` configuration file. A section for syslog is pre-created but disabled by default.
 
-```
+```json5
 {
-  ...
+  // ...
   "log": {
-    ...
+    // ...
     "transport": {
-      ...
+      // ...
       "syslog1": {
         "type": "syslog",
         "enabled": false,
@@ -675,7 +678,7 @@ ioBroker also supports logging to a syslog server. The configuration is also sto
       }
     }
   }
-  ...
+  // ...
 }
 ```
 
@@ -740,14 +743,14 @@ To minimize the risk, adapter instances are run by default in compact group 1 wh
 
 To enable compact mode for a js-controller instance, you can use the new "compact" CLI commands, or you can manually change the `iobroker.json` configuration file
 
-```
+```json5
 {
-  ...
+  // ...
   "system": {
-    ...
+    // ...
     "compact":true
   }
-  ...
+  // ...
 }
 ```
 and restart the js-controller.
@@ -776,14 +779,16 @@ For adapters running in compact mode, special care must be taken to clean up use
 
 The js-controller checks the available RAM of the system before starting a new adapter process. If the available RAM is below 50/100 MB by default, an error/warn is logged. The limits can be configured in iobroker.json
 
-```
-    "system": {
-        "memLimitWarn": 100,
-        "memLimitWarnComment": "If the available RAM is below this threshold on adapter start, a warning will be logged.",
-        "memLimitError": 50,
-        "memLimitErrorComment": "If the available RAM is below this threshold on adapter start, an error will be logged."
-    }
-    ...
+```json5
+{
+  "system": {
+    "memLimitWarn": 100,
+    "memLimitWarnComment": "If the available RAM is below this threshold on adapter start, a warning will be logged.",
+    "memLimitError": 50,
+    "memLimitErrorComment": "If the available RAM is below this threshold on adapter start, an error will be logged."
+  }
+  // ...
+}
 ```
 
 Later versions of js-controller might prevent the start of a new adapter process if system resources are too low! 
@@ -793,8 +798,8 @@ Later versions of js-controller might prevent the start of a new adapter process
 
 For debugging reasons, sometimes it is necessary to start an adapter instance via the command line to get more detailed logging.
 
-To do so, manually execute the adapter's main javascript file, which is usually named `main.js` or `<adaptername>.js` (where "adaptername" is the name of the adapter):
-```
+To do so, manually execute the adapter's main JavaScript file, which is usually named `main.js` or `<adaptername>.js` (where "adaptername" is the name of the adapter):
+```bash
 node node_modules/iobroker.adaptername/main.js --force --logs
 ```
 All log output will now be printed to the console.
@@ -878,7 +883,7 @@ Alternatively, you can use Admin interface on the "Objects" tab to create aliase
 
 To create an alias object simple create a new object with an own name in the `alias.0` namespace and add the alias definition in the common section (here for an alias with the id `"alias.0.aliasName"`):
 
-```
+```json5
 {
     _id: "alias.0.aliasName",
     common: {
@@ -900,7 +905,7 @@ To create an alias object simple create a new object with an own name in the `al
 
 or using different read and write ids (supported starting js-controller 3.0, check using feature flag `ALIAS_SEPARATE_READ_WRITE_ID`):
 
-```
+```json5
 {
     _id: "alias.0.aliasName",
     common: {
@@ -913,7 +918,7 @@ or using different read and write ids (supported starting js-controller 3.0, che
             id: {
                 read: 'state.id.to.read.from',
                 write: 'state.id.to.write.to'
-            }
+            },
             read: 'val * 10 + 1',
             write: '(val - 1) / 10'
         }
@@ -940,7 +945,7 @@ Note, that alias states will be automatically scaled if the following conditions
 
 To set the alias properties without a JavaScript or in adapter code you can also use the cli commands like:
 
-```
+```bash
 iobroker object set alias.0.aliasName common.alias.id=state.id.of.target
 iobroker object set alias.0.aliasName common.alias.read="read-func"
 iobroker object set alias.0.aliasName common.alias.write="write-func"
@@ -967,23 +972,26 @@ js-controller 1.x was using socket.io as the communication protocol between the 
 
 For the objects and states databases, special additional logging of the redis protocol messages can be activated in iobroker.json
 
-```
-"objects": {
-  ...
-  "enhancedLogging": false
+```json5
+{
+  "objects": {
+    //...
+    "enhancedLogging": false
+  }
 }
 ```
 
 When not configured differently, the file databases are persisted every 15s (15000ms) after data are changed. The interval in ms can be changed by configuration in iobroker.json starting js-controller 3.0.
 > **_NOTE:_** If you do that be aware that you may lose data when the js-controller crashes unexpectedly!
 
-```
-"objects": {
-  ...
-  "writeFileInterval": 60000
+```json5
+{
+  "objects": {
+    // ...
+    "writeFileInterval": 60000
+  }
 }
 ```
-
 
 #### Redis as database
 Redis is a well-known industrial grade in-memory database optimized for speed and stability. It performs better than the ioBroker In-Memory database which is written in JavaScript.
@@ -1040,7 +1048,7 @@ It is possible to switch anytime between Redis and in-memory Javascript DB.
 
 To switch to Redis, execute the following on the console:
 
-```
+```bash
 iobroker stop
 iobroker setup custom
 ```
@@ -1196,28 +1204,32 @@ It is best practice adding the field names of encrypted fields to the protectedN
 Dependencies are defined in an array and can contain an adapter name of an object.
 
 When using the object style, you can define a semver version range for this adapter:
-```
-"dependencies": [
-      {
-        "js-controller": ">=2.0.0"
-      }
-    ],
+```json5
+{
+  "dependencies": [
+    {
+      "js-controller": ">=2.0.0"
+    }
+  ],
+}
 ```
 
 If the version do not matter and just the adapter itself needs to be present you can also use:
-```
-"dependencies": [
-      "web"
-    ],
+```json5
+{
+  "dependencies": [
+    "web"
+  ],
+}
 ```
 
 There are two types of adapter dependencies that can be defined in io-package.json and will be checked on installation and adapter start.
 
-**common.dependencies for Same Host dependencies**
+**`common.dependencies` for Same Host dependencies**
 With `common.dependencies` in io-package.json you can define if an adapter needs to be present on the same host and optionally in which version.
 This is mainly used to define the needed "js-controller" version for yor adapter and can also be relevant e.g. for web extension adapters (adapters that can be plugged in into the web adapter, so the code needs to be on the same host).
 
-**common.globalDependencies for dependencies on any Host**
+**`common.globalDependencies` for dependencies on any Host**
 With common.globalDependencies in io-package.json and starting with js-controller 3.0, you can define a global dependency that will be checked over all hosts. Irrelevant where on the system the referenced adapter is installed it needs to match the version and at least one instance needs to exist.
 This can mainly be used for more loose dependencies where adapters are split over multiple hosts but still work together, e.g. Admin. 
 
@@ -1292,7 +1304,7 @@ Invalid entries could be:
 
 To make it possible to get such an entries, the maintenance mode was implemented.
 To make a call in maintenance mode, you must provide `options` object with the at least following attributes:
-```
+```json5
 {
     user: 'system.user.admin',
     maintenance: true,

--- a/packages/adapter/src/lib/adapter/constants.ts
+++ b/packages/adapter/src/lib/adapter/constants.ts
@@ -67,6 +67,7 @@ const SUPPORTED_FEATURES_INTERNAL = [
     'ADAPTER_GET_OBJECTS_BY_ARRAY', // getForeignObjects supports an array of ids too. Since js-controller 5.0
     'CONTROLLER_UI_UPGRADE', // Controller can be updated via sendToHost('upgradeController', ...)
     'ADAPTER_WEBSERVER_UPGRADE', // Controller supports upgrading adapter and provides a webserver (triggered via sendToHost). Since `js-controller` 5.0
+    'CONTROLLER_CMD_EXEC_FILES', // cmdExec host message supports sending files together with the command. Since `js-controller` 7.2
 ] as const;
 
 export const SUPPORTED_FEATURES = [...SUPPORTED_FEATURES_INTERNAL];

--- a/packages/controller/src/main.ts
+++ b/packages/controller/src/main.ts
@@ -2119,7 +2119,9 @@ async function processMessage(msg: ioBroker.SendableMessage): Promise<null | voi
                             data = data.toString().replace(/\n/g, '');
                             logger.info(`${hostLogPrefix} ${tools.appName} ${data}`);
                             if (msg.from) {
-                                sendTo(msg.from, 'cmdStdout', { id: message.id, data });
+                                sendTo(msg.from, 'cmdStdout', { id: message.id, data }).catch(e =>
+                                    logger.error(`Cannot sendTo: ${e}`),
+                                );
                             }
                         });
                     }

--- a/packages/controller/src/main.ts
+++ b/packages/controller/src/main.ts
@@ -2065,7 +2065,7 @@ async function processMessage(msg: ioBroker.SendableMessage): Promise<null | voi
                     'Invalid cmdExec object. Expected key "data" with the command as string',
                 );
             } else {
-                // cmdExec can send a files with command
+                // cmdExec can send files with the command
                 const fileNames = new Map<string, string>();
                 if (message.files?.length) {
                     // store files in an own temporary folder, so parallel cmdExec calls cannot overwrite each other

--- a/packages/controller/src/main.ts
+++ b/packages/controller/src/main.ts
@@ -2114,29 +2114,30 @@ async function processMessage(msg: ioBroker.SendableMessage): Promise<null | voi
 
                 try {
                     const child = spawn(process.execPath, args, { windowsHide: true });
-                    if (child.stdout) {
-                        child.stdout.on('data', data => {
-                            data = data.toString().replace(/\n/g, '');
-                            logger.info(`${hostLogPrefix} ${tools.appName} ${data}`);
-                            if (msg.from) {
-                                sendTo(msg.from, 'cmdStdout', { id: message.id, data }).catch(e =>
-                                    logger.error(`Cannot sendTo: ${e}`),
-                                );
-                            }
-                        });
-                    }
+                    child.stdout?.on('data', data => {
+                        data = data.toString().replace(/\n/g, '');
+                        logger.info(`${hostLogPrefix} ${tools.appName} ${data}`);
+                        if (msg.from) {
+                            sendTo(msg.from, 'cmdStdout', { id: message.id, data }).catch(e =>
+                                logger.error(`Cannot sendTo: ${e}`),
+                            );
+                        }
+                    });
 
-                    if (child.stderr) {
-                        child.stderr.on('data', data => {
-                            data = data.toString().replace(/\n/g, '');
-                            logger.error(`${hostLogPrefix} ${tools.appName} ${data}`);
-                            if (msg.from) {
-                                sendTo(msg.from, 'cmdStderr', { id: message.id, data }).catch(e =>
-                                    logger.error(`Cannot sendTo: ${e}`),
-                                );
-                            }
-                        });
-                    }
+                    child.stderr?.on('data', data => {
+                        data = data.toString().replace(/\n/g, '');
+                        logger.error(`${hostLogPrefix} ${tools.appName} ${data}`);
+                        if (msg.from) {
+                            sendTo(msg.from, 'cmdStderr', { id: message.id, data }).catch(e =>
+                                logger.error(`Cannot sendTo: ${e}`),
+                            );
+                        }
+                    });
+
+                    child.on('error', error => {
+                        logger.error(`${hostLogPrefix} ${tools.appName} error: ${error.message}`);
+                        exitFromCmd(EXIT_CODES.UNKNOWN_ERROR, error.message);
+                    });
 
                     child.on('exit', exitCode => {
                         logger.info(`${hostLogPrefix} ${tools.appName} exit ${exitCode}`);

--- a/packages/controller/src/main.ts
+++ b/packages/controller/src/main.ts
@@ -2131,7 +2131,9 @@ async function processMessage(msg: ioBroker.SendableMessage): Promise<null | voi
                             data = data.toString().replace(/\n/g, '');
                             logger.error(`${hostLogPrefix} ${tools.appName} ${data}`);
                             if (msg.from) {
-                                sendTo(msg.from, 'cmdStderr', { id: message.id, data });
+                                sendTo(msg.from, 'cmdStderr', { id: message.id, data }).catch(e =>
+                                    logger.error(`Cannot sendTo: ${e}`),
+                                );
                             }
                         });
                     }

--- a/packages/controller/src/main.ts
+++ b/packages/controller/src/main.ts
@@ -2041,7 +2041,7 @@ async function processMessage(msg: ioBroker.SendableMessage): Promise<null | voi
                     sendTo(msg.from, 'cmdExit', { id: message.id, data: exitCode }).catch(e =>
                         logger.error(`Cannot sendTo: ${e}`),
                     );
-                    // Sometimes finished command is lost, recent it
+                    // Sometimes finished command is lost, resend it
                     setTimeout(
                         () =>
                             sendTo(msg.from, 'cmdExit', { id: message.id, data: exitCode }).catch(e =>

--- a/packages/controller/src/main.ts
+++ b/packages/controller/src/main.ts
@@ -3041,6 +3041,44 @@ async function processMessage(msg: ioBroker.SendableMessage): Promise<null | voi
             });
             break;
         }
+
+        case 'writeFile': {
+            // This is used to transfer some file from admin to controller, e.g. to update some adapter from file
+            if (msg.message.data) {
+                const file = Buffer.from(msg.message.data, 'base64');
+                const fileName = msg.message.fileName || `iobroker-${Date.now()}`;
+                const storeIn = msg.message.path || os.tmpdir();
+                // Take tmp directory
+                const tmpFile = path.join(storeIn, fileName);
+                try {
+                    fs.writeFileSync(tmpFile, file);
+                    sendTo(msg.from, msg.command, { path: tmpFile }, msg.callback);
+                } catch (e) {
+                    logger.error(`${hostLogPrefix} Cannot write file ${tmpFile}: ${e.message}`);
+                    sendTo(msg.from, msg.command, { error: e.message }, msg.callback);
+                }
+            }
+            break;
+        }
+
+        case 'deleteFile': {
+            // This is used to transfer some file from admin to controller, e.g. to update some adapter from file
+            if (msg.message.data) {
+                const file = Buffer.from(msg.message.data, 'base64');
+                const fileName = msg.message.fileName || `iobroker-${Date.now()}`;
+                const storeIn = msg.message.path || os.tmpdir();
+                // Take tmp directory
+                const tmpFile = path.join(storeIn, fileName);
+                try {
+                    fs.writeFileSync(tmpFile, file);
+                    sendTo(msg.from, msg.command, { path: tmpFile }, msg.callback);
+                } catch (e) {
+                    logger.error(`${hostLogPrefix} Cannot write file ${tmpFile}: ${e.message}`);
+                    sendTo(msg.from, msg.command, { error: e.message }, msg.callback);
+                }
+            }
+            break;
+        }
     }
 }
 

--- a/packages/controller/src/main.ts
+++ b/packages/controller/src/main.ts
@@ -2003,16 +2003,112 @@ async function processMessage(msg: ioBroker.SendableMessage): Promise<null | voi
         case 'cmdExec': {
             const mainFile = path.join(tools.getControllerDir(), `${tools.appName.toLowerCase()}.js`);
             const args = [...getDefaultNodeArgs(mainFile), mainFile];
-            if (!msg.message.data || typeof msg.message.data !== 'string') {
+            const message: {
+                id: string;
+                data: string;
+                files?: { file: string | Buffer; name: string; doNotDelete?: boolean }[];
+            } = msg.message;
+            // Each cmdExec call gets an own temporary folder for the sent files to avoid collisions between parallel calls
+            let tmpFolder: string | undefined;
+            let keepTmpFolder = false;
+            const filesToDelete: string[] = [];
+            const exitFromCmd = (exitCode: number | null, error?: string): void => {
+                if (tmpFolder) {
+                    if (keepTmpFolder) {
+                        // Some files are marked with "doNotDelete", so delete only the other ones
+                        for (const fileName of filesToDelete) {
+                            try {
+                                fs.unlinkSync(fileName);
+                            } catch (e) {
+                                logger.error(`Cannot delete file "${fileName}": ${e.message}`);
+                            }
+                        }
+                    } else {
+                        try {
+                            fs.rmSync(tmpFolder, { recursive: true, force: true });
+                        } catch (e) {
+                            logger.error(`Cannot delete temporary folder "${tmpFolder}": ${e.message}`);
+                        }
+                    }
+                }
+                if (msg.from) {
+                    if (error) {
+                        sendTo(msg.from, 'cmdStderr', {
+                            id: message.id,
+                            data: error,
+                        }).catch(e => logger.error(`Cannot sendTo: ${e}`));
+                    }
+                    sendTo(msg.from, 'cmdExit', { id: message.id, data: exitCode }).catch(e =>
+                        logger.error(`Cannot sendTo: ${e}`),
+                    );
+                    // Sometimes finished command is lost, recent it
+                    setTimeout(
+                        () =>
+                            sendTo(msg.from, 'cmdExit', { id: message.id, data: exitCode }).catch(e =>
+                                logger.error(`Cannot sendTo: ${e}`),
+                            ),
+                        1_000,
+                    );
+                }
+            };
+
+            if (!message.data || typeof message.data !== 'string') {
                 logger.warn(
                     `${hostLogPrefix} ${
                         tools.appName
                     } Invalid cmdExec object. Expected key "data" with the command as string. Got as "data": ${JSON.stringify(
-                        msg.message.data,
+                        message.data,
                     )}`,
                 );
+                exitFromCmd(
+                    EXIT_CODES.INVALID_ARGUMENTS,
+                    'Invalid cmdExec object. Expected key "data" with the command as string',
+                );
             } else {
-                const extraArgs = msg.message.data.split(' ');
+                // cmdExec can send a files with command
+                const fileNames = new Map<string, string>();
+                if (message.files?.length) {
+                    // store files in an own temporary folder, so parallel cmdExec calls cannot overwrite each other
+                    try {
+                        tmpFolder = fs.mkdtempSync(path.join(os.tmpdir(), `${tools.appName.toLowerCase()}-cmd-`));
+                    } catch (e) {
+                        exitFromCmd(EXIT_CODES.UNKNOWN_ERROR, `Cannot create temporary folder: ${e.message}`);
+                        return;
+                    }
+                    for (const file of message.files) {
+                        if (!file.name || typeof file.name !== 'string') {
+                            exitFromCmd(EXIT_CODES.INVALID_ARGUMENTS, 'Empty file name');
+                            return;
+                        }
+                        if (file.name.includes('\\') || file.name.includes('/')) {
+                            exitFromCmd(
+                                EXIT_CODES.INVALID_ARGUMENTS,
+                                'Invalid file name: file name cannot contain \\ or /',
+                            );
+                            return;
+                        }
+                        const data = typeof file.file === 'string' ? Buffer.from(file.file, 'base64') : file.file;
+                        const fullName = path.join(tmpFolder, file.name);
+                        try {
+                            fs.writeFileSync(fullName, data);
+                        } catch (e) {
+                            exitFromCmd(
+                                EXIT_CODES.INVALID_ARGUMENTS,
+                                `Cannot write file "${fullName}": ${e.toString()}`,
+                            );
+                            return;
+                        }
+                        fileNames.set(file.name, fullName);
+                        if (file.doNotDelete) {
+                            keepTmpFolder = true;
+                        } else {
+                            filesToDelete.push(fullName);
+                        }
+                    }
+                }
+
+                // The sender refers to the sent files just by name, so replace the names with the full paths in the temporary folder
+                const extraArgs = message.data.split(' ').map(arg => fileNames.get(arg) || arg);
                 args.push(...extraArgs);
                 logger.info(`${hostLogPrefix} ${tools.appName.toLowerCase()} ${extraArgs.join(' ')}`);
 
@@ -2022,7 +2118,9 @@ async function processMessage(msg: ioBroker.SendableMessage): Promise<null | voi
                         child.stdout.on('data', data => {
                             data = data.toString().replace(/\n/g, '');
                             logger.info(`${hostLogPrefix} ${tools.appName} ${data}`);
-                            msg.from && sendTo(msg.from, 'cmdStdout', { id: msg.message.id, data: data });
+                            if (msg.from) {
+                                sendTo(msg.from, 'cmdStdout', { id: message.id, data });
+                            }
                         });
                     }
 
@@ -2030,24 +2128,19 @@ async function processMessage(msg: ioBroker.SendableMessage): Promise<null | voi
                         child.stderr.on('data', data => {
                             data = data.toString().replace(/\n/g, '');
                             logger.error(`${hostLogPrefix} ${tools.appName} ${data}`);
-                            msg.from && sendTo(msg.from, 'cmdStderr', { id: msg.message.id, data: data });
+                            if (msg.from) {
+                                sendTo(msg.from, 'cmdStderr', { id: message.id, data });
+                            }
                         });
                     }
 
                     child.on('exit', exitCode => {
                         logger.info(`${hostLogPrefix} ${tools.appName} exit ${exitCode}`);
-                        if (msg.from) {
-                            sendTo(msg.from, 'cmdExit', { id: msg.message.id, data: exitCode });
-                            // Sometimes finished command is lost, recent it
-                            setTimeout(
-                                () => sendTo(msg.from, 'cmdExit', { id: msg.message.id, data: exitCode }),
-                                1_000,
-                            );
-                        }
+                        exitFromCmd(exitCode);
                     });
                 } catch (e) {
                     logger.error(`${hostLogPrefix} ${tools.appName} ${e.message}`);
-                    msg.from && sendTo(msg.from, 'cmdStderr', { id: msg.message.id, data: e.message });
+                    exitFromCmd(EXIT_CODES.UNKNOWN_ERROR, e.message);
                 }
             }
 
@@ -3039,44 +3132,6 @@ async function processMessage(msg: ioBroker.SendableMessage): Promise<null | voi
 
                 sentryObj.captureMessage(message, 'info');
             });
-            break;
-        }
-
-        case 'writeFile': {
-            // This is used to transfer some file from admin to controller, e.g. to update some adapter from file
-            if (msg.message.data) {
-                const file = Buffer.from(msg.message.data, 'base64');
-                const fileName = msg.message.fileName || `iobroker-${Date.now()}`;
-                const storeIn = msg.message.path || os.tmpdir();
-                // Take tmp directory
-                const tmpFile = path.join(storeIn, fileName);
-                try {
-                    fs.writeFileSync(tmpFile, file);
-                    sendTo(msg.from, msg.command, { path: tmpFile }, msg.callback);
-                } catch (e) {
-                    logger.error(`${hostLogPrefix} Cannot write file ${tmpFile}: ${e.message}`);
-                    sendTo(msg.from, msg.command, { error: e.message }, msg.callback);
-                }
-            }
-            break;
-        }
-
-        case 'deleteFile': {
-            // This is used to transfer some file from admin to controller, e.g. to update some adapter from file
-            if (msg.message.data) {
-                const file = Buffer.from(msg.message.data, 'base64');
-                const fileName = msg.message.fileName || `iobroker-${Date.now()}`;
-                const storeIn = msg.message.path || os.tmpdir();
-                // Take tmp directory
-                const tmpFile = path.join(storeIn, fileName);
-                try {
-                    fs.writeFileSync(tmpFile, file);
-                    sendTo(msg.from, msg.command, { path: tmpFile }, msg.callback);
-                } catch (e) {
-                    logger.error(`${hostLogPrefix} Cannot write file ${tmpFile}: ${e.message}`);
-                    sendTo(msg.from, msg.command, { error: e.message }, msg.callback);
-                }
-            }
             break;
         }
     }


### PR DESCRIPTION
## What

  The cmdExec host message now accepts an optional files array. Files are transferred with the message, stored on the
  host in a unique temporary folder, made available to the executed CLI command, and cleaned up automatically after the
  command exits.

  This replaces the previous (unused) writeFile/deleteFile host messages, which have been removed.

## How it works

  - Each cmdExec call gets its own temporary folder (fs.mkdtempSync, e.g. /tmp/iobroker-cmd-Xa3F9k/), so parallel calls
  cannot overwrite each other's files and existing files in the system temp folder are never touched.
  - file can be a base64 string or a Buffer.
  - Any argument in the command string that exactly matches a sent file name is replaced with the full path of the
  stored file.
  - After the command exits, the temporary folder is deleted recursively — unless a file is marked with doNotDelete:
  true, in which case only the other files are removed and the folder is kept.
  - File names must not contain / or \ (path traversal protection); invalid messages are now reported back to the sender
  via cmdStderr/cmdExit instead of only being logged on the host.

## Example

  Install an adapter from a locally available tarball on a remote host:

```js
  const data = fs.readFileSync('iobroker.example-1.2.3.tgz');

  adapter.sendToHost('system.host.remoteHost', 'cmdExec', {
      id: 1, // ID to match cmdStdout/cmdStderr/cmdExit responses
      data: 'url iobroker.example-1.2.3.tgz --debug',
      files: [
          {
              name: 'iobroker.example-1.2.3.tgz', // stored in the temp folder under this name
              file: data.toString('base64'),      // base64 string or Buffer
              // doNotDelete: true,               // optional: keep the file after the command finished
          },
      ],
  });
```

  On the host this executes:

  `iobroker url /tmp/iobroker-cmd-Xa3F9k/iobroker.example-1.2.3.tgz --debug`

  The sender receives the usual cmdStdout / cmdStderr messages while the command runs and a final cmdExit message with
  the exit code; afterwards the temporary folder including the tarball is removed.