### PR TITLE
Add checkFeatureSupported host message 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 -->
 ## __WORK IN PROGRESS__
 * (@GermanBluefox) Added possibility to send files with cmdExec message (feature flag `CONTROLLER_CMD_EXEC_FILES`)
+* (@GermanBluefox) Added possibility to check feature by controller directly (feature flag `CONTROLLER_FEATURE_REQUEST`)
 
 ## 7.1.2 (2026-05-07) - Milla
 * (@GermanBluefox) Corrected typings

--- a/packages/adapter/src/lib/adapter/adapter.ts
+++ b/packages/adapter/src/lib/adapter/adapter.ts
@@ -57,7 +57,6 @@ import {
     ERROR_PERMISSION,
     NO_PROTECT_ADAPTERS,
     STATE_QUALITY,
-    type SupportedFeature,
     SYSTEM_ADMIN_GROUP,
     SYSTEM_ADMIN_USER,
 } from '@/lib/adapter/constants.js';
@@ -1640,7 +1639,7 @@ export class AdapterClass extends EventEmitter {
         }
     }
 
-    supportsFeature(featureName: SupportedFeature): boolean;
+    supportsFeature(featureName: ioBroker.SupportedFeature): boolean;
 
     /**
      * Method to check for available Features for adapter development
@@ -1657,7 +1656,7 @@ export class AdapterClass extends EventEmitter {
      */
     supportsFeature(featureName: unknown): boolean {
         if (typeof featureName === 'string') {
-            return this.SUPPORTED_FEATURES.includes(featureName as SupportedFeature);
+            return this.SUPPORTED_FEATURES.includes(featureName as ioBroker.SupportedFeature);
         }
         return false;
     }

--- a/packages/adapter/src/lib/adapter/constants.ts
+++ b/packages/adapter/src/lib/adapter/constants.ts
@@ -48,31 +48,5 @@ export enum STATE_QUALITY {
     SENSOR_ERROR_REPORT = 0x84,
 }
 
-/** Using the const array just for type inference */
-const SUPPORTED_FEATURES_INTERNAL = [
-    'ALIAS', // Alias Feature supported, Since `js-controller` 2.0
-    'ALIAS_SEPARATE_READ_WRITE_ID', // Alias support separated ids for read and write, Since `js-controller` 3.0
-    'ADAPTER_GETPORT_BIND', // getPort method of adapter supports second parameter to bind to a special network interface, Since js-controller 2.0
-    'ADAPTER_DEL_OBJECT_RECURSIVE', // delObject supports options.recursive flag to delete objects structures recursive, Since js-controller 2.2
-    'ADAPTER_SET_OBJECT_SETS_DEFAULT_VALUE', // setObject(*) methods set the default (def) value via setState after the object is created. Since js-controller 2.0
-    'ADAPTER_AUTO_DECRYPT_NATIVE', // all native attributes that are listed in an array `encryptedNative` in io-pack will be automatically decrypted and encrypted. Since js-controller 3.0
-    'PLUGINS', // configurable plugins supported. Since `js-controller` 3.0
-    'CONTROLLER_NPM_AUTO_REBUILD', // Automatic rebuild when node version mismatch is detected. Since `js-controller` 3.0
-    'CONTROLLER_READWRITE_BASE_SETTINGS', // If base settings could be read and written. Since js-controller 3.0
-    'CONTROLLER_MULTI_REPO', // Controller supports multiple repositories
-    'CONTROLLER_LICENSE_MANAGER', // Controller can read licenses from iobroker.net. Since js-controller 4.0
-    'CONTROLLER_OS_PACKAGE_UPGRADE', // Controller can upgrade OS packages
-    'DEL_INSTANCE_CUSTOM', // instances/adapter can be deleted with --custom flag to remove corresponding custom of all objects. Since js-controller 4.0
-    'CUSTOM_FULL_VIEW', // `getObjectView('system', 'custom-full', ...)` will return full objects and not only `common.custom` part. Since `js-controller` 5.0
-    'ADAPTER_GET_OBJECTS_BY_ARRAY', // getForeignObjects supports an array of ids too. Since js-controller 5.0
-    'CONTROLLER_UI_UPGRADE', // Controller can be updated via sendToHost('upgradeController', ...)
-    'ADAPTER_WEBSERVER_UPGRADE', // Controller supports upgrading adapter and provides a webserver (triggered via sendToHost). Since `js-controller` 5.0
-    'CONTROLLER_CMD_EXEC_FILES', // cmdExec host message supports sending files together with the command. Since `js-controller` 7.2
-] as const;
-
-export const SUPPORTED_FEATURES = [...SUPPORTED_FEATURES_INTERNAL];
-
-export type SupportedFeature = (typeof SUPPORTED_FEATURES)[number];
-
 /** Maximum possible value for 32-bit signed integer */
 export const MAX_TIMEOUT = 2 ** 32 / 2 - 1;

--- a/packages/adapter/src/lib/adapter/utils.ts
+++ b/packages/adapter/src/lib/adapter/utils.ts
@@ -1,13 +1,12 @@
 import {
     isObject,
-    isControllerUiUpgradeSupported,
     encrypt,
     decrypt,
     appNameLowerCase,
     getRootDir,
     execAsync,
 } from '@iobroker/js-controller-common-db/tools';
-import { SUPPORTED_FEATURES, type SupportedFeature } from '@/lib/adapter/constants.js';
+import { getSupportedFeatures as getSupportedFeaturesCommon } from '@iobroker/js-controller-common';
 import path from 'node:path';
 import fs from 'fs-extra';
 
@@ -44,15 +43,8 @@ export function isMessageboxSupported(instanceCommon: ioBroker.InstanceCommon): 
 /**
  * Get the supported features for the current running controller
  */
-export function getSupportedFeatures(): SupportedFeature[] {
-    if (!isControllerUiUpgradeSupported()) {
-        const idx = SUPPORTED_FEATURES.indexOf('CONTROLLER_UI_UPGRADE');
-        if (idx !== -1) {
-            SUPPORTED_FEATURES.splice(idx, 1);
-        }
-    }
-
-    return SUPPORTED_FEATURES;
+export function getSupportedFeatures(): ioBroker.SupportedFeature[] {
+    return getSupportedFeaturesCommon();
 }
 
 /**

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -12,6 +12,7 @@ export {
     performObjectsInterview,
 } from '@/lib/common/objects.js';
 export { NotificationHandler } from '@/lib/common/notificationHandler.js';
+export { SupportedFeature } from '@/lib/common/constants.js';
 export * as zipFiles from '@/lib/common/zipFiles.js';
 export * from '@/lib/common/tools.js';
 export * from '@iobroker/js-controller-common-db';

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -12,7 +12,7 @@ export {
     performObjectsInterview,
 } from '@/lib/common/objects.js';
 export { NotificationHandler } from '@/lib/common/notificationHandler.js';
-export { SupportedFeature } from '@/lib/common/constants.js';
+export type { SupportedFeature } from '@/lib/common/constants.js';
 export * as zipFiles from '@/lib/common/zipFiles.js';
 export * from '@/lib/common/tools.js';
 export * from '@iobroker/js-controller-common-db';

--- a/packages/common/src/lib/common/constants.ts
+++ b/packages/common/src/lib/common/constants.ts
@@ -31,5 +31,6 @@ export type SupportedFeature = (typeof SUPPORTED_FEATURES)[number];
 
 // Compile-time guarantee that the runtime list stays in sync with the public `ioBroker.SupportedFeature` type (defined in @iobroker/types-dev)
 type AssertExtends<T extends U, U> = T;
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 type _AssertFeaturesInSync = AssertExtends<SupportedFeature, ioBroker.SupportedFeature> &
     AssertExtends<ioBroker.SupportedFeature, SupportedFeature>;

--- a/packages/common/src/lib/common/constants.ts
+++ b/packages/common/src/lib/common/constants.ts
@@ -1,0 +1,35 @@
+/**
+ * Constants needed for adapter.js and controller
+ */
+
+/** Using the const array just for type inference */
+const SUPPORTED_FEATURES_INTERNAL = [
+    'ALIAS', // Alias Feature supported, Since `js-controller` 2.0
+    'ALIAS_SEPARATE_READ_WRITE_ID', // Alias support separated ids for read and write, Since `js-controller` 3.0
+    'ADAPTER_GETPORT_BIND', // getPort method of adapter supports second parameter to bind to a special network interface, Since js-controller 2.0
+    'ADAPTER_DEL_OBJECT_RECURSIVE', // delObject supports options.recursive flag to delete objects structures recursive, Since js-controller 2.2
+    'ADAPTER_SET_OBJECT_SETS_DEFAULT_VALUE', // setObject(*) methods set the default (def) value via setState after the object is created. Since js-controller 2.0
+    'ADAPTER_AUTO_DECRYPT_NATIVE', // all native attributes that are listed in an array `encryptedNative` in io-pack will be automatically decrypted and encrypted. Since js-controller 3.0
+    'PLUGINS', // configurable plugins supported. Since `js-controller` 3.0
+    'CONTROLLER_NPM_AUTO_REBUILD', // Automatic rebuild when node version mismatch is detected. Since `js-controller` 3.0
+    'CONTROLLER_READWRITE_BASE_SETTINGS', // If base settings could be read and written. Since js-controller 3.0
+    'CONTROLLER_MULTI_REPO', // Controller supports multiple repositories
+    'CONTROLLER_LICENSE_MANAGER', // Controller can read licenses from iobroker.net. Since js-controller 4.0
+    'CONTROLLER_OS_PACKAGE_UPGRADE', // Controller can upgrade OS packages
+    'DEL_INSTANCE_CUSTOM', // instances/adapter can be deleted with --custom flag to remove corresponding custom of all objects. Since js-controller 4.0
+    'CUSTOM_FULL_VIEW', // `getObjectView('system', 'custom-full', ...)` will return full objects and not only `common.custom` part. Since `js-controller` 5.0
+    'ADAPTER_GET_OBJECTS_BY_ARRAY', // getForeignObjects supports an array of ids too. Since js-controller 5.0
+    'CONTROLLER_UI_UPGRADE', // Controller can be updated via sendToHost('upgradeController', ...)
+    'ADAPTER_WEBSERVER_UPGRADE', // Controller supports upgrading adapter and provides a webserver (triggered via sendToHost). Since `js-controller` 5.0
+    'CONTROLLER_CMD_EXEC_FILES', // cmdExec host message supports sending files together with the command. Since `js-controller` 7.2
+    'CONTROLLER_FEATURE_REQUEST', // Is js-controller supports feature supported requests. Since `js-controller` 7.2
+] as const;
+
+export const SUPPORTED_FEATURES = [...SUPPORTED_FEATURES_INTERNAL];
+
+export type SupportedFeature = (typeof SUPPORTED_FEATURES)[number];
+
+// Compile-time guarantee that the runtime list stays in sync with the public `ioBroker.SupportedFeature` type (defined in @iobroker/types-dev)
+type AssertExtends<T extends U, U> = T;
+type _AssertFeaturesInSync = AssertExtends<SupportedFeature, ioBroker.SupportedFeature> &
+    AssertExtends<ioBroker.SupportedFeature, SupportedFeature>;

--- a/packages/common/src/lib/common/constants.ts
+++ b/packages/common/src/lib/common/constants.ts
@@ -22,7 +22,7 @@ const SUPPORTED_FEATURES_INTERNAL = [
     'CONTROLLER_UI_UPGRADE', // Controller can be updated via sendToHost('upgradeController', ...)
     'ADAPTER_WEBSERVER_UPGRADE', // Controller supports upgrading adapter and provides a webserver (triggered via sendToHost). Since `js-controller` 5.0
     'CONTROLLER_CMD_EXEC_FILES', // cmdExec host message supports sending files together with the command. Since `js-controller` 7.2
-    'CONTROLLER_FEATURE_REQUEST', // Is js-controller supports feature supported requests. Since `js-controller` 7.2
+    'CONTROLLER_FEATURE_REQUEST', // js-controller supports feature support requests via host messages. Since `js-controller` 7.2
 ] as const;
 
 export const SUPPORTED_FEATURES = [...SUPPORTED_FEATURES_INTERNAL];

--- a/packages/common/src/lib/common/tools.ts
+++ b/packages/common/src/lib/common/tools.ts
@@ -93,5 +93,14 @@ export function isInstalledFromNpm(options: IsInstalledFromNpmOptions): boolean 
  * Get the supported features for the current running controller
  */
 export function getSupportedFeatures(): SupportedFeature[] {
-    return SUPPORTED_FEATURES;
+    const features = [...SUPPORTED_FEATURES];
+
+    if (!isControllerUiUpgradeSupported()) {
+        const idx = features.indexOf('CONTROLLER_UI_UPGRADE');
+        if (idx !== -1) {
+            features.splice(idx, 1);
+        }
+    }
+
+    return features;
 }

--- a/packages/common/src/lib/common/tools.ts
+++ b/packages/common/src/lib/common/tools.ts
@@ -1,6 +1,7 @@
 import type { Client as ObjectsClient } from '@iobroker/db-objects-redis';
 import { appName } from '@iobroker/js-controller-common-db/tools';
 import type { InternalLogger } from '@iobroker/js-controller-common-db/tools';
+import { SUPPORTED_FEATURES, type SupportedFeature } from './constants.js';
 
 export interface OrderedInstancesObject {
     1: ioBroker.InstanceObject[];
@@ -86,4 +87,11 @@ export function isInstalledFromNpm(options: IsInstalledFromNpmOptions): boolean 
     }
 
     return installedFrom.startsWith(`${appName.toLowerCase()}.${adapterName}`);
+}
+
+/**
+ * Get the supported features for the current running controller
+ */
+export function getSupportedFeatures(): SupportedFeature[] {
+    return SUPPORTED_FEATURES;
 }

--- a/packages/common/src/lib/common/tools.ts
+++ b/packages/common/src/lib/common/tools.ts
@@ -1,5 +1,5 @@
 import type { Client as ObjectsClient } from '@iobroker/db-objects-redis';
-import { appName } from '@iobroker/js-controller-common-db/tools';
+import { appName, isControllerUiUpgradeSupported } from '@iobroker/js-controller-common-db/tools';
 import type { InternalLogger } from '@iobroker/js-controller-common-db/tools';
 import { SUPPORTED_FEATURES, type SupportedFeature } from './constants.js';
 

--- a/packages/controller/src/main.ts
+++ b/packages/controller/src/main.ts
@@ -22,6 +22,8 @@ import {
     zipFiles,
     getInstancesOrderedByStartPrio,
     isInstalledFromNpm,
+    type SupportedFeature,
+    getSupportedFeatures,
 } from '@iobroker/js-controller-common';
 import {
     SYSTEM_ADAPTER_PREFIX,
@@ -3071,7 +3073,9 @@ async function processMessage(msg: ioBroker.SendableMessage): Promise<null | voi
                         .map(l => l.product)
                         .join(', ')}"`,
                 );
-                msg.callback && msg.from && sendTo(msg.from, msg.command, { result: licenses }, msg.callback);
+                if (msg.callback && msg.from) {
+                    sendTo(msg.from, msg.command, { result: licenses }, msg.callback);
+                }
             } catch (e) {
                 logger.error(`${hostLogPrefix} Cannot read licenses: ${e.message}`);
 
@@ -3108,7 +3112,9 @@ async function processMessage(msg: ioBroker.SendableMessage): Promise<null | voi
         }
 
         case 'restartController': {
-            msg.callback && sendTo(msg.from, msg.command, '', msg.callback);
+            if (msg.callback) {
+                sendTo(msg.from, msg.command, '', msg.callback);
+            }
             // let the answer be sent
             await wait(200);
             restart(() => !isStopping && stop(false));
@@ -3137,6 +3143,19 @@ async function processMessage(msg: ioBroker.SendableMessage): Promise<null | voi
 
                 sentryObj.captureMessage(message, 'info');
             });
+            break;
+        }
+
+        case 'checkFeatureSupported': {
+            const feature: unknown = msg.message;
+            if (msg.callback && msg.from) {
+                if (typeof feature === 'string') {
+                    const result = getSupportedFeatures().includes(feature as SupportedFeature);
+                    sendTo(msg.from, msg.command, { result }, msg.callback);
+                } else {
+                    sendTo(msg.from, msg.command, { error: 'Invalid feature type' }, msg.callback);
+                }
+            }
             break;
         }
     }

--- a/packages/types-dev/index.d.ts
+++ b/packages/types-dev/index.d.ts
@@ -55,6 +55,32 @@ declare global {
             SENSOR_ERROR_REPORT: 0x84;
         }
 
+        /**
+         * Features which can be checked via `adapter.supportsFeature(...)`.
+         * The runtime list of currently supported features lives in
+         * `@iobroker/js-controller-common` (`SUPPORTED_FEATURES`) and must stay in sync with this type.
+         */
+        type SupportedFeature =
+            | 'ALIAS'
+            | 'ALIAS_SEPARATE_READ_WRITE_ID'
+            | 'ADAPTER_GETPORT_BIND'
+            | 'ADAPTER_DEL_OBJECT_RECURSIVE'
+            | 'ADAPTER_SET_OBJECT_SETS_DEFAULT_VALUE'
+            | 'ADAPTER_AUTO_DECRYPT_NATIVE'
+            | 'PLUGINS'
+            | 'CONTROLLER_NPM_AUTO_REBUILD'
+            | 'CONTROLLER_READWRITE_BASE_SETTINGS'
+            | 'CONTROLLER_MULTI_REPO'
+            | 'CONTROLLER_LICENSE_MANAGER'
+            | 'CONTROLLER_OS_PACKAGE_UPGRADE'
+            | 'DEL_INSTANCE_CUSTOM'
+            | 'CUSTOM_FULL_VIEW'
+            | 'ADAPTER_GET_OBJECTS_BY_ARRAY'
+            | 'CONTROLLER_UI_UPGRADE'
+            | 'ADAPTER_WEBSERVER_UPGRADE'
+            | 'CONTROLLER_CMD_EXEC_FILES'
+            | 'CONTROLLER_FEATURE_REQUEST';
+
         type StateValue = string | number | boolean | null;
 
         interface State {


### PR DESCRIPTION
 Add checkFeatureSupported host message — query a specific host's controller for supported features (CONTROLLER_FEATURE_REQUEST)

 ## Motivation

  ioBroker supports multihost setups: several hosts, each running its own js-controller, and those hosts can be on different
  versions. Until now adapter.supportsFeature('SOME_FEATURE') could only answer for the js-controller running on the local host —
  the one the querying adapter (e.g. admin) happens to run on. There was no way to ask a remote host whether its controller
  supports a given feature, even though in a multihost system that's exactly the host whose capability you care about.

  This PR lets any host's controller answer the question directly via a host message. You send checkFeatureSupported to a
  specific host and it replies from its own, current feature list. The capability is announced as a new feature flag,
  CONTROLLER_FEATURE_REQUEST, so callers can first confirm the target controller is new enough to answer before relying on it.

  ## What changed

  - New checkFeatureSupported host message in controller/src/main.ts. It validates the requested feature name and replies with {
  result: boolean }, or { error: 'Invalid feature type' } when the payload isn't a string. Because it's a host message, it can be
  addressed to any host in the system, not just the local one.
  - New feature flag CONTROLLER_FEATURE_REQUEST advertising this capability.
  - Moved the feature registry to a shared location. SUPPORTED_FEATURES (runtime list) and the supported-features helper now live
  in @iobroker/js-controller-common, so both the adapter framework and the controller share a single source of truth instead of
  the adapter package owning it privately.
  - Promoted the SupportedFeature type to @iobroker/types-dev as the global ioBroker.SupportedFeature. This keeps the adapter's
  public API (supportsFeature(featureName: ioBroker.SupportedFeature)) free of internal @iobroker/* package references, which the
  generated public types (@iobroker/types) forbid. A compile-time assertion in common/constants.ts guarantees the runtime list
  and the public type can't drift apart.

  ## Notes

  - Drive-by cleanups in processMessage: replaced two a && b && sendTo(...) short-circuit expressions with explicit if blocks for
  readability/consistency.
  - No behavioral change for existing adapter.supportsFeature(...) callers; the underlying list simply moved packages.
  - CHANGELOG updated under WORK IN PROGRESS.