### PR TITLE
[feature] - some optimizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ## __WORK IN PROGRESS__
 * (@GermanBluefox) Added possibility to send files with cmdExec message (feature flag `CONTROLLER_CMD_EXEC_FILES`)
 * (arteck) add icon in Log for redis reconnect(sentinel)
+* (arteck) redis setState-MULTI optimization
 
 ## 7.1.2 (2026-05-07) - Milla
 * (@GermanBluefox) Corrected typings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 -->
 ## __WORK IN PROGRESS__
 * (@GermanBluefox) Added possibility to send files with cmdExec message (feature flag `CONTROLLER_CMD_EXEC_FILES`)
+* (arteck) add icon in Log for redis reconnect(sentinel)
 
 ## 7.1.2 (2026-05-07) - Milla
 * (@GermanBluefox) Corrected typings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@
 -->
 ## __WORK IN PROGRESS__
 * (@GermanBluefox) Added possibility to send files with cmdExec message (feature flag `CONTROLLER_CMD_EXEC_FILES`)
-* (arteck) add icon in Log for redis reconnect(sentinel)
-* (arteck) redis setState-MULTI optimization
+* (arteck) Added icons to the log for Redis Sentinel reconnects
+* (arteck) Optimized Redis `setState` by using MULTI
 
 ## 7.1.2 (2026-05-07) - Milla
 * (@GermanBluefox) Corrected typings

--- a/packages/controller/test/testStatesRedis.ts
+++ b/packages/controller/test/testStatesRedis.ts
@@ -168,6 +168,77 @@ describe('States-Redis: Test states in Redis', function () {
         states!.setState(testID, { val: 4, ack: true, ts: null, q: 1 });
     }).timeout(10_000);
 
+    it('States-Redis: should setState with expire (setex + publish in one MULTI)', done => {
+        // setState writes the value and publishes the change in a single MULTI.
+        // The expire branch uses SETEX, so this verifies that branch end-to-end:
+        // the value is stored with a TTL AND the publish still delivers the event.
+        const testID = 'testObject.0.testExpire';
+        onStatesChanged = (id, state) => {
+            if (id === testID && state && state.val === 5) {
+                onStatesChanged = null; // do not react to the later expiry event
+                // PUBLISH inside the MULTI delivered the change event
+                assert.strictEqual(state.ack, true);
+
+                // SETEX inside the MULTI stored the value...
+                states!.getState(testID, (err, storedState) => {
+                    assert.ok(!err);
+                    assert.ok(storedState);
+                    assert.strictEqual(storedState!.val, 5);
+
+                    // ...with a TTL, so it must be gone after the expire window
+                    setTimeout(() => {
+                        states!.getState(testID, (err, expiredState) => {
+                            assert.ok(!err);
+                            assert.strictEqual(expiredState, null);
+                            done();
+                        });
+                    }, 1_500);
+                });
+            }
+        };
+
+        states!.setState(testID, { val: 5, ack: true, expire: 1 }, err => {
+            assert.ok(!err);
+        });
+    }).timeout(10_000);
+
+    it('States-Redis: should keep lc on unchanged value and bump it on change', done => {
+        // The MULTI write is preceded by a GET to compute "lc" (last change).
+        // This guards that read-modify-write logic: lc stays stable when the value
+        // is identical and is bumped only when the value actually changes.
+        onStatesChanged = null;
+        const testID = 'testObject.0.testLc';
+        states!.setState(testID, { val: 10, ack: true }, () => {
+            states!.getState(testID, (err, first) => {
+                assert.ok(!err);
+                assert.ok(first);
+                const firstLc = first!.lc;
+                setTimeout(() => {
+                    // identical value -> lc must stay, ts must advance
+                    states!.setState(testID, { val: 10, ack: true }, () => {
+                        states!.getState(testID, (err, second) => {
+                            assert.ok(!err);
+                            assert.ok(second);
+                            assert.strictEqual(second!.lc, firstLc, 'lc must not change for identical value');
+                            assert.ok(second!.ts >= first!.ts, 'ts must advance');
+                            setTimeout(() => {
+                                // changed value -> lc must be bumped
+                                states!.setState(testID, { val: 20, ack: true }, () => {
+                                    states!.getState(testID, (err, third) => {
+                                        assert.ok(!err);
+                                        assert.ok(third);
+                                        assert.notStrictEqual(third!.lc, firstLc, 'lc must change when value changes');
+                                        done();
+                                    });
+                                });
+                            }, 5);
+                        });
+                    });
+                }, 5);
+            });
+        });
+    }).timeout(10_000);
+
     // todo: write more tests
 
     after('States-Redis: Stop js-controller', async function () {

--- a/packages/controller/test/testStatesRedis.ts
+++ b/packages/controller/test/testStatesRedis.ts
@@ -183,7 +183,7 @@ describe('States-Redis: Test states in Redis', function () {
                 states!.getState(testID, (err, storedState) => {
                     assert.ok(!err);
                     assert.ok(storedState);
-                    assert.strictEqual(storedState!.val, 5);
+                    assert.strictEqual(storedState.val, 5);
 
                     // ...with a TTL, so it must be gone after the expire window
                     setTimeout(() => {
@@ -212,22 +212,22 @@ describe('States-Redis: Test states in Redis', function () {
             states!.getState(testID, (err, first) => {
                 assert.ok(!err);
                 assert.ok(first);
-                const firstLc = first!.lc;
+                const firstLc = first.lc;
                 setTimeout(() => {
                     // identical value -> lc must stay, ts must advance
                     states!.setState(testID, { val: 10, ack: true }, () => {
                         states!.getState(testID, (err, second) => {
                             assert.ok(!err);
                             assert.ok(second);
-                            assert.strictEqual(second!.lc, firstLc, 'lc must not change for identical value');
-                            assert.ok(second!.ts >= first!.ts, 'ts must advance');
+                            assert.strictEqual(second.lc, firstLc, 'lc must not change for identical value');
+                            assert.ok(second.ts >= first.ts, 'ts must advance');
                             setTimeout(() => {
                                 // changed value -> lc must be bumped
                                 states!.setState(testID, { val: 20, ack: true }, () => {
                                     states!.getState(testID, (err, third) => {
                                         assert.ok(!err);
                                         assert.ok(third);
-                                        assert.notStrictEqual(third!.lc, firstLc, 'lc must change when value changes');
+                                        assert.notStrictEqual(third.lc, firstLc, 'lc must change when value changes');
                                         done();
                                     });
                                 });

--- a/packages/db-objects-redis/src/lib/objects/objectsInRedisClient.ts
+++ b/packages/db-objects-redis/src/lib/objects/objectsInRedisClient.ts
@@ -234,6 +234,11 @@ export class ObjectsInRedisClient {
         let connected = false;
         let reconnectCounter = 0;
         let errorLogged = false;
+        // Sentinel is in use when a list of hosts is configured
+        const isSentinel = Array.isArray(this.settings.connection.host);
+        // Becomes true after the first successful "ready" so we can tell a
+        // re-connection apart from the initial connection
+        let wasReady = false;
 
         this.settings.connection.options.retryStrategy = (reconnectCount: number): Error | number => {
             if (!ready && initError) {
@@ -334,6 +339,10 @@ export class ObjectsInRedisClient {
                 this.log.silly(`${this.namespace} Objects-Redis Event end (stop=${this.stop})`);
             }
             if (ready && typeof this.settings.disconnected === 'function') {
+                // only an unexpected disconnect is worth a warning, not an intentional shutdown
+                if (!this.stop) {
+                    this.log.warn(`❌ ${this.namespace} Objects database disconnected`);
+                }
                 this.settings.disconnected();
             }
         });
@@ -344,7 +353,7 @@ export class ObjectsInRedisClient {
             }
             connected = true;
             if (errorLogged) {
-                this.log.info(`${this.namespace} Objects database successfully reconnected`);
+                this.log.info(`✅ ${this.namespace} Objects database successfully reconnected`);
                 errorLogged = false;
             }
         });
@@ -383,6 +392,13 @@ export class ObjectsInRedisClient {
                 return;
             }
             initError = false;
+
+            if (isSentinel && wasReady) {
+                this.log.info(
+                    `✅ ${this.namespace} Objects DB reconnected via Redis Sentinel (master group "${this.settings.connection.options.name}")`,
+                );
+            }
+            wasReady = true;
 
             this.log.debug(`${this.namespace} Objects client ready ... initialize now`);
             try {

--- a/packages/db-states-redis/src/lib/states/statesInRedisClient.ts
+++ b/packages/db-states-redis/src/lib/states/statesInRedisClient.ts
@@ -153,6 +153,11 @@ export class StateRedisClient {
         let connected = false;
         let reconnectCounter = 0;
         let errorLogged = false;
+        // Sentinel is in use when a list of hosts is configured
+        const isSentinel = Array.isArray(this.settings.connection.host);
+        // Becomes true after the first successful "ready" so we can tell a
+        // re-connection apart from the initial connection
+        let wasReady = false;
 
         this.settings.connection.options = this.settings.connection.options || {};
         const retry_max_delay = this.settings.connection.options.retry_max_delay || 5000;
@@ -267,6 +272,10 @@ export class StateRedisClient {
             this.settings.connection.enhancedLogging &&
                 this.log.silly(`${this.namespace} States-Redis Event end (stop=${this.stop})`);
             if (ready && typeof this.settings.disconnected === 'function') {
+                // only an unexpected disconnect is worth a warning, not an intentional shutdown
+                if (!this.stop) {
+                    this.log.warn(`❌ ${this.namespace} States database disconnected`);
+                }
                 this.settings.disconnected();
             }
         });
@@ -276,7 +285,7 @@ export class StateRedisClient {
                 this.log.silly(`${this.namespace} States-Redis Event connect (stop=${this.stop})`);
             connected = true;
             if (errorLogged) {
-                this.log.info(`${this.namespace} Objects database successfully reconnected`);
+                this.log.info(`✅ ${this.namespace} States database successfully reconnected`);
                 errorLogged = false;
             }
         });
@@ -313,6 +322,13 @@ export class StateRedisClient {
                 return;
             }
             initError = false;
+
+            if (isSentinel && wasReady) {
+                this.log.info(
+                    `✅ ${this.namespace} States DB reconnected via Redis Sentinel (master group "${this.settings.connection.options.name}")`,
+                );
+            }
+            wasReady = true;
 
             let initCounter = 0;
             if (!this.subSystem && typeof onChange === 'function') {
@@ -789,29 +805,23 @@ export class StateRedisClient {
 
         const objString = JSON.stringify(obj);
 
-        // set object in redis
-        if (expire) {
-            try {
-                await this.client.setex(this.namespaceRedis + id, expire, objString);
-                // publish event in redis
-                this.settings.connection.enhancedLogging &&
-                    this.log.silly(`${this.namespace} redis publish ${this.namespaceRedis}${id} ${objString}`);
-                await this.client.publish(this.namespaceRedis + id, objString);
-                return tools.maybeCallbackWithError(callback, null, id);
-            } catch (e) {
-                return tools.maybeCallbackWithRedisError(callback, e, id);
-            }
-        } else {
-            try {
-                await this.client.set(this.namespaceRedis + id, objString);
-                // publish event in redis
-                this.settings.connection.enhancedLogging &&
-                    this.log.silly(`${this.namespace} redis publish ${this.namespaceRedis}${id} ${objString}`);
-                await this.client.publish(this.namespaceRedis + id, objString);
-                return tools.maybeCallbackWithError(callback, null, id);
-            } catch (e) {
-                return tools.maybeCallbackWithRedisError(callback, e, id);
-            }
+        // publish event in redis
+        this.settings.connection.enhancedLogging &&
+            this.log.silly(`${this.namespace} redis publish ${this.namespaceRedis}${id} ${objString}`);
+
+        // Write the state and publish the change in a single MULTI so both are sent
+        // in one round-trip instead of two. setState is the hottest path in the
+        // system, so saving a round-trip per call adds up significantly under load.
+        const commands: string[][] = expire
+            ? [['setex', this.namespaceRedis + id, String(expire), objString]]
+            : [['set', this.namespaceRedis + id, objString]];
+        commands.push(['publish', this.namespaceRedis + id, objString]);
+
+        try {
+            await this.client.multi(commands).exec();
+            return tools.maybeCallbackWithError(callback, null, id);
+        } catch (e) {
+            return tools.maybeCallbackWithRedisError(callback, e, id);
         }
     }
 


### PR DESCRIPTION
1. packages/db-states-redis/src/lib/states/statesInRedisClient.ts
  - setState: SET/SETEX + PUBLISH in einem MULTI (3→2 Roundtrips)
  - Sentinel-Reconnect-Logmeldung
  - ✅/❌ Connect-/Disconnect-Icons + neue Disconnect-Meldung (mit !this.stop-Guard)
  - Tippfehler-Korrektur („Objects" → „States" in der Reconnect-Meldung)
2. packages/db-objects-redis/src/lib/objects/objectsInRedisClient.ts
  - Sentinel-Reconnect-Logmeldung
  - ✅/❌ Connect-/Disconnect-Icons + neue Disconnect-Meldung (mit !this.stop-Guard)
3. packages/controller/test/testStatesRedis.ts
  - 2 neue Regressionstests (setex-Zweig + lc-Semantik)