### PR TITLE
ix duplicate stopTimeout delay on adapter restart after object changes

### DIFF
--- a/packages/controller/src/main.ts
+++ b/packages/controller/src/main.ts
@@ -858,7 +858,7 @@ function createObjects(onConnect: () => void): void {
                                 if (proc.restartTimer) {
                                     clearTimeout(proc.restartTimer);
                                 }
-                                const restartTimeout = (proc.config.common.stopTimeout || 500) + 2_500;
+                                const restartTimeout = 2_500;
                                 proc.restartTimer = setTimeout(_id => startInstance(_id), restartTimeout, id);
                             }
                         } else {


### PR DESCRIPTION
Fixes #3358.

## Summary
When an adapter is restarted after an object/configuration change, the controller currently:

1. waits for `stopInstance(id, false)` to finish, and then
2. waits an additional `common.stopTimeout + 2500ms` before restarting.

Since `stopInstance()` already waits up to `common.stopTimeout`, this effectively doubles the stop timeout during restart.

## Change
Only the post-stop restart delay in the existing-instance object-change path was adjusted:
- from: `stopTimeout + 2500ms`
- to: `2500ms`

## Notes
This does **not** change the separate "new adapter / moved host" path, which may still intentionally need extra time for a former process on another host to exit.