### PR TITLE
fix(cli): recognise npm >=10.6.0 "npm error" prefix in ENOTEMPTY self-heal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 	Placeholder for the next version (at the beginning of the line):
 	## __WORK IN PROGRESS__
 -->
+## __WORK IN PROGRESS__
+* (@krobipd) Fixed the automatic ENOTEMPTY recovery not removing the blocking npm temp directory on npm >= 10.6.0 (npm changed its error output prefix from `npm ERR!` to `npm error`), which made adapter installs/updates abort with "Could not handle ENOTEMPTY, because no deletable files were found"
+
 ## 7.2.2 (2026-06-16)
 * (@Apollon77) Fixed Sentry session reporting disabling
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 	## __WORK IN PROGRESS__
 -->
 ## __WORK IN PROGRESS__
-* (@krobipd) Fixed the automatic ENOTEMPTY recovery not removing the blocking npm temp directory on npm >= 10.6.0 (npm changed its error output prefix from `npm ERR!` to `npm error`), which made adapter installs/updates abort with "Could not handle ENOTEMPTY, because no deletable files were found"
+* (@krobipd) Fixed the automatic ENOTEMPTY recovery not removing the blocking npm temp directory on npm >= 10.6.0
 
 ## 7.2.2 (2026-06-16)
 * (@Apollon77) Fixed Sentry session reporting disabling

--- a/packages/cli/src/lib/setup/setupInstall.ts
+++ b/packages/cli/src/lib/setup/setupInstall.ts
@@ -431,7 +431,7 @@ export class Install {
 
         const errorFilePath = result.stderr
             .split('\n')
-            ?.find(line => line.startsWith('npm ERR! dest'))
+            ?.find(line => line.startsWith('npm ERR! dest') || line.startsWith('npm error dest'))
             ?.split('dest')[1]
             .trim();
 


### PR DESCRIPTION
## Problem

On npm >= 10.6.0 the automatic ENOTEMPTY recovery in `handleNpmNotEmptyError()` (`packages/cli/src/lib/setup/setupInstall.ts`) never removes the blocking npm temp directory, so an affected adapter install/upgrade aborts with:

```
Could not handle ENOTEMPTY, because no deletable files were found
```

even though the directory it needs to delete is right there.

## Root cause

The failed destination path is read from `result.stderr` via:

```ts
?.find(line => line.startsWith('npm ERR! dest'))
```

Since [npm/cli#7414](https://github.com/npm/cli/pull/7414) (npm **v10.6.0**, 2024-04-25) npm prints the log-level name instead of the old label, so the line is now `npm error dest …`. `find(...)` returns `undefined`, `errorFilePath` short-circuits to `undefined`, and the (correct) temp-dir deletion + retry is skipped.

Supported Node versions (18/20/22) ship npm from both eras — older npm prints `npm ERR!`, npm >= 10.6.0 prints `npm error` — so the parser must accept both.

## Fix

Only the `find` predicate changes; extraction and deletion are untouched, so existing (old-npm) behaviour is unaffected and the previously-missed modern case now matches:

```diff
-            ?.find(line => line.startsWith('npm ERR! dest'))
+            ?.find(line => line.startsWith('npm ERR! dest') || line.startsWith('npm error dest'))
```

## Verification

Real-world trigger: js-controller 7.2.2, Node 22.23.1, npm 10.9.8 — npm printed `npm error dest /opt/iobroker/node_modules/.iobroker.govee-smart-b0IGQWNC`. Removing that exact directory by hand (which the handler's `rmSync` targets and `/^\..*-[a-zA-Z0-9]{8}$/` matches) unblocked the install, confirming the recovery logic is sound and only the stderr parsing was broken. Path extraction verified against both `npm error dest …` and `npm ERR! dest …`; `npm run build` passes.

Related field report: #3095 (ENOTEMPTY on update where the automatic recovery silently failed and the reporter was advised to run `iob fix` manually).

Follow-up: #3417 addresses the same stale `npm ERR!` assumption in the install success check (kept separate as it touches success/failure classification).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
