### PR TITLE
fix(cli): treat npm exit-code 1 with an error line as a failed install (npm >=10.6.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 	## __WORK IN PROGRESS__
 -->
 ## __WORK IN PROGRESS__
-* (@krobipd) Fixed a failed adapter install/update being reported as success on npm >= 10.6.0: when npm exits with code 1 the result was only treated as an error if stderr started with the old `npm ERR!` prefix, which modern npm no longer uses (`npm error`)
+* (@krobipd) Fixed a failed adapter install/update being reported as success on npm >= 10.6.0
 
 ## 7.2.2 (2026-06-16)
 * (@Apollon77) Fixed Sentry session reporting disabling

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 	Placeholder for the next version (at the beginning of the line):
 	## __WORK IN PROGRESS__
 -->
+## __WORK IN PROGRESS__
+* (@krobipd) Fixed a failed adapter install/update being reported as success on npm >= 10.6.0: when npm exits with code 1 the result was only treated as an error if stderr started with the old `npm ERR!` prefix, which modern npm no longer uses (`npm error`)
+
 ## 7.2.2 (2026-06-16)
 * (@Apollon77) Fixed Sentry session reporting disabling
 

--- a/packages/cli/src/lib/setup/setupInstall.ts
+++ b/packages/cli/src/lib/setup/setupInstall.ts
@@ -367,7 +367,9 @@ export class Install {
         });
 
         // code 1 is sometimes a real error and sometimes a strange error, where everything is installed but still the error
-        const isSuccess = result.success || (result.exitCode === 1 && !result.stderr.startsWith('npm ERR!'));
+        const isSuccess =
+            result.success ||
+            (result.exitCode === 1 && !result.stderr.startsWith('npm ERR!') && !result.stderr.startsWith('npm error '));
 
         if (isSuccess) {
             // Determine where the packet would be installed if npm succeeds


### PR DESCRIPTION
## Problem

`_npmInstall` can report a failed adapter install/upgrade as **success** on npm >= 10.6.0. When npm exits with code 1, the result is treated as successful unless `result.stderr.startsWith('npm ERR!')`:

```ts
const isSuccess = result.success || (result.exitCode === 1 && !result.stderr.startsWith('npm ERR!'));
```

Since [npm/cli#7414](https://github.com/npm/cli/pull/7414) (npm **v10.6.0**) npm prints errors as `npm error`, so `startsWith('npm ERR!')` is never true on current npm. A genuinely failed install therefore passes the check and — when the target directory already exists (an upgrade) — is reported as installed in the success branch while the old version stays in place. Silent.

In production `installNodeModule` runs npm at `--loglevel error` (`tools.ts`), which suppresses `npm warn` lines, so the error line is the first stderr line and `startsWith` is the right shape here — only the prefix was stale.

## Fix

Also match the current `npm error ` prefix; the first-line semantics and the "exit 1 with no error output" pass-through are unchanged:

```diff
-        const isSuccess = result.success || (result.exitCode === 1 && !result.stderr.startsWith('npm ERR!'));
+        const isSuccess =
+            result.success ||
+            (result.exitCode === 1 && !result.stderr.startsWith('npm ERR!') && !result.stderr.startsWith('npm error '));
```

I could not reproduce the exact "strange code-1 where everything is installed" case the comment guards, so I kept the change minimal — it only adds recognition of the modern prefix, mirroring the existing `npm ERR!` handling. Please confirm this matches your intent.

## Context

Same stale-`npm ERR!` root cause as #3416 (which fixes the ENOTEMPTY self-heal). Kept as a separate PR because #3416 is behaviour-preserving, whereas this touches install success/failure classification. `npm run build` and eslint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
