### PR TITLE
refactor(adapter): extract AliasManager (core decomposition phase 1)

### DIFF
--- a/packages/adapter/src/lib/adapter/adapter.ts
+++ b/packages/adapter/src/lib/adapter/adapter.ts
@@ -62,8 +62,6 @@ import {
 import { type PluginHandlerSettings, PluginHandler, type IoPackageFile } from '@iobroker/plugin-base';
 import type {
     AdapterOptions,
-    AliasDetails,
-    AliasTargetEntry,
     AllPropsUnknown,
     CalculatePermissionsCallback,
     CheckGroupCallback,
@@ -133,6 +131,7 @@ import type {
 import { UserInterfaceMessagingController } from '@/lib/adapter/userInterfaceMessagingController.js';
 import { AsyncAdapter } from '@/lib/adapter/asyncAdapter.js';
 import { CERTIFICATES_OBJECT_ID } from '@/lib/adapter/managers/CertificateManager.js';
+import { AliasManager } from '@/lib/adapter/managers/AliasManager.js';
 import type { AdapterContext } from '@/lib/adapter/context.js';
 import { SYSTEM_ADAPTER_PREFIX, DEFAULT_OBJECTS_WARN_LIMIT } from '@iobroker/js-controller-common-db/constants';
 import { isLogLevel } from '@iobroker/js-controller-common-db/tools';
@@ -902,8 +901,6 @@ export class AdapterClass extends EventEmitter {
     private readonly startedInCompactMode: boolean;
     /** List of instances which want our logs */
     private readonly logList = new Set<string>();
-    private readonly aliases = new Map<string, AliasDetails>();
-    private readonly aliasPatterns = new Set<string>();
     private enums: Record<string, ioBroker.EnumObject> = {};
     private eventLoopLags: number[] = [];
     private overwriteLogLevel: boolean = false;
@@ -978,7 +975,6 @@ export class AdapterClass extends EventEmitter {
     /** latitude configured in system.config, only available if requested via AdapterOptions `useFormatDate`*/
     latitude?: number;
     private _defaultObjs?: Record<string, Partial<ioBroker.StateCommon>>;
-    private _aliasObjectsSubscribed?: boolean;
     config: ioBroker.AdapterConfig = {};
     host?: string;
     common?: ioBroker.InstanceCommon;
@@ -1014,6 +1010,15 @@ export class AdapterClass extends EventEmitter {
     #context!: AdapterContext;
     #async!: AsyncAdapter;
     readonly #certWatchers = new Map<string, fs.FSWatcher>();
+    #aliasInstance?: AliasManager;
+
+    /** Lazily-constructed alias subscription manager. */
+    get #alias(): AliasManager {
+        return (this.#aliasInstance ??= new AliasManager(this.#context, (id, allowSystem, options) =>
+            this._utils.validateId(id, allowSystem, options),
+        ));
+    }
+
     /** True once `system.certificates` is subscribed, i.e. certificates have been requested */
     #certObjectSubscribed = false;
     /** True once a certificate change scheduled a restart, so concurrent changes schedule only one */
@@ -11413,103 +11418,6 @@ export class AdapterClass extends EventEmitter {
     }
 
     /**
-     * Add a subscription for a given alias, if it is not a state, it will be ignored
-     *
-     * @param aliasObj the alias object
-     * @param pattern pattern to subscribe for
-     */
-    private async _addAliasSubscribe(aliasObj: ioBroker.AnyObject, pattern: string): Promise<void> {
-        if (aliasObj.type !== 'state') {
-            // no state types do not need to be subscribed
-            return;
-        }
-
-        if (!aliasObj.common?.alias?.id) {
-            // if state and no id given
-            this._logger.warn(`${this.namespaceLog} Alias ${aliasObj._id} has no target 5`);
-            throw new Error(`Alias ${aliasObj._id} has no target`);
-        }
-
-        // id can be string or can have attribute read
-        const sourceId = tools.isObject(aliasObj.common.alias.id)
-            ? aliasObj.common.alias.id.read
-            : aliasObj.common.alias.id;
-
-        // validate here because we use objects/states db directly
-        try {
-            this._utils.validateId(sourceId, true, null);
-        } catch (e) {
-            throw new Error(`Error validating alias id of ${aliasObj._id}: ${e.message}`);
-        }
-
-        const targetEntry = {
-            alias: deepClone(aliasObj.common.alias),
-            id: aliasObj._id,
-            pattern,
-            type: aliasObj.common.type,
-            max: aliasObj.common.max,
-            min: aliasObj.common.min,
-            unit: aliasObj.common.unit,
-        };
-
-        let aliasDetails: AliasDetails;
-
-        if (!this.aliases.has(sourceId)) {
-            aliasDetails = { targets: [] };
-            // add the alias before doing anything async, so if a delete comes in between we can detect it
-            this.aliases.set(sourceId, aliasDetails);
-        } else {
-            aliasDetails = this.aliases.get(sourceId)!;
-        }
-
-        if (!aliasDetails.source) {
-            await this.#states!.subscribe(sourceId);
-            // we ignore permissions on the source object and thus get it as admin user
-            const sourceObj = await this.#objects!.getObject(sourceId, { user: SYSTEM_ADMIN_USER });
-
-            // if we have a common and the alias has not been removed in-between
-            if (sourceObj?.common && this.aliases.has(sourceObj._id)) {
-                aliasDetails.source = {
-                    min: sourceObj.common.min,
-                    max: sourceObj.common.max,
-                    type: sourceObj.common.type,
-                    unit: sourceObj.common.unit,
-                };
-            }
-        }
-
-        // add the alias target after we have ensured that we have the source set
-        aliasDetails.targets.push(targetEntry);
-    }
-
-    /**
-     * Remove an alias subscribe
-     *
-     * @param sourceId id of the source object
-     * @param aliasObjOrIdx the alias target or the index of the targets array
-     */
-    private async _removeAliasSubscribe(sourceId: string, aliasObjOrIdx: number | AliasTargetEntry): Promise<void> {
-        if (!this.aliases.has(sourceId)) {
-            return;
-        }
-
-        const alias = this.aliases.get(sourceId)!;
-
-        // remove from targets array
-        const pos = typeof aliasObjOrIdx === 'number' ? aliasObjOrIdx : alias.targets.indexOf(aliasObjOrIdx);
-
-        if (pos !== -1) {
-            alias.targets.splice(pos, 1);
-
-            // unsubscribe if no more aliases exists
-            if (!alias.targets.length) {
-                this.aliases.delete(sourceId);
-                await this.#states!.unsubscribe(sourceId);
-            }
-        }
-    }
-
-    /**
      * Subscribe for changes on all states of all adapters (and system states), that pass the pattern
      *
      * @param pattern string in form 'adapter.0.*' or like this. It can be an array of IDs too.
@@ -11638,26 +11546,23 @@ export class AdapterClass extends EventEmitter {
             for (const aliasPattern of pattern) {
                 if (
                     (aliasPattern.startsWith(ALIAS_STARTS_WITH) || aliasPattern.includes('*')) &&
-                    !this.aliasPatterns.has(aliasPattern)
+                    !this.#alias.hasPattern(aliasPattern)
                 ) {
                     // it's a new alias conform pattern to store
-                    this.aliasPatterns.add(aliasPattern);
+                    this.#alias.addPattern(aliasPattern);
                 }
             }
 
             const promises = [];
 
             if (aliasesIds.length) {
-                if (!this._aliasObjectsSubscribed) {
-                    this._aliasObjectsSubscribed = true;
-                    this.#objects.subscribe(`${ALIAS_STARTS_WITH}*`);
-                }
+                await this.#alias.ensureAliasObjectSubscription();
 
                 const aliasObjs = await this._getObjectsByArray(aliasesIds, options);
 
                 for (const aliasObj of aliasObjs) {
                     if (aliasObj) {
-                        promises.push(this._addAliasSubscribe(aliasObj, aliasObj._id));
+                        promises.push(this.#alias.addAliasSubscribe(aliasObj, aliasObj._id));
                     }
                 }
             }
@@ -11676,26 +11581,23 @@ export class AdapterClass extends EventEmitter {
             return tools.maybeCallback(callback);
         } else if (pattern.includes('*')) {
             if (pattern === '*' || pattern.startsWith(ALIAS_STARTS_WITH)) {
-                if (!this._aliasObjectsSubscribed) {
-                    this._aliasObjectsSubscribed = true;
-                    this.#objects.subscribe(`${ALIAS_STARTS_WITH}*`);
-                }
+                await this.#alias.ensureAliasObjectSubscription();
 
                 // read all aliases
                 try {
                     // @ts-expect-error adjust types
                     const objs = await this.getForeignObjectsAsync(pattern, null, null, options);
                     const promises = [];
-                    if (!this.aliasPatterns.has(pattern)) {
+                    if (!this.#alias.hasPattern(pattern)) {
                         // it's a new pattern to store
-                        this.aliasPatterns.add(pattern);
+                        this.#alias.addPattern(pattern);
                     }
 
                     for (const id of Object.keys(objs)) {
                         // If alias
                         if (id.startsWith(ALIAS_STARTS_WITH)) {
                             const aliasObj = objs[id];
-                            promises.push(this._addAliasSubscribe(aliasObj, pattern));
+                            promises.push(this.#alias.addAliasSubscribe(aliasObj, pattern));
                         }
                     }
 
@@ -11728,16 +11630,13 @@ export class AdapterClass extends EventEmitter {
                 return callback ? this.#states.subscribeUser(pattern, callback) : this.#states.subscribeUser(pattern);
             }
         } else if (pattern.startsWith(ALIAS_STARTS_WITH)) {
-            if (!this._aliasObjectsSubscribed) {
-                this._aliasObjectsSubscribed = true;
-                this.#objects.subscribe(`${ALIAS_STARTS_WITH}*`);
-            }
+            await this.#alias.ensureAliasObjectSubscription();
 
             // just read one alias Object
             try {
                 const aliasObj = await this.#objects.getObject(pattern, options);
                 if (aliasObj) {
-                    await this._addAliasSubscribe(aliasObj, pattern);
+                    await this.#alias.addAliasSubscribe(aliasObj, pattern);
                     return tools.maybeCallback(callback);
                 }
                 return tools.maybeCallback(callback);
@@ -11895,24 +11794,14 @@ export class AdapterClass extends EventEmitter {
         }
 
         if (aliasPattern) {
-            // if pattern known, remove it from alias patterns to not subscribe to further matching aliases
-            this.aliasPatterns.delete(aliasPattern);
-
-            for (const [sourceId, alias] of this.aliases) {
-                for (let i = alias.targets.length - 1; i >= 0; i--) {
-                    if (alias.targets[i].pattern === aliasPattern) {
-                        promises.push(this._removeAliasSubscribe(sourceId, i));
-                    }
-                }
-            }
+            // if pattern known, remove it and unsubscribe every target it pulled in
+            this.#alias.deletePattern(aliasPattern);
+            promises.push(this.#alias.removeTargetsForPattern(aliasPattern));
         }
 
         await Promise.all(promises);
-        // if no alias subscribed any longer, remove subscription
-        if (!this.aliases.size && this._aliasObjectsSubscribed) {
-            this._aliasObjectsSubscribed = false;
-            this.#objects!.unsubscribe(`${ALIAS_STARTS_WITH}*`);
-        }
+        // if no alias subscribed any longer, remove the alias.* object subscription
+        await this.#alias.maybeDropAliasObjectSubscription();
         return tools.maybeCallback(callback);
     }
 
@@ -12866,45 +12755,14 @@ export class AdapterClass extends EventEmitter {
                             }
                         }
                     }
-                } else if (!this._stopInProgress && this.adapterReady && this.aliases.has(id)) {
-                    // If adapter is ready and for this ID exist some alias links
-                    const alias = this.aliases.get(id)!;
-                    /** Prevent multiple publishes if multiple patterns contain this alias id */
-                    const uniqueTargets = new Set<string>();
-
-                    for (const target of alias.targets) {
-                        const targetId = target.id;
-                        if (uniqueTargets.has(targetId)) {
-                            continue;
-                        }
-
-                        uniqueTargets.add(targetId);
-
-                        const source = alias.source;
-
-                        const aState = state
-                            ? tools.formatAliasValue({
-                                  sourceCommon: source,
-                                  targetCommon: target,
-                                  state: deepClone(state),
-                                  logger: this._logger,
-                                  logNamespace: this.namespaceLog,
-                                  sourceId: id,
-                                  targetId,
-                              })
-                            : null;
-
-                        if (aState || !state) {
-                            if (typeof this._options.stateChange === 'function') {
-                                Promise.resolve(this._options.stateChange(targetId, aState)).catch(e =>
-                                    this._logger.error(
-                                        `${this.namespaceLog} Error in stateChange handler: ${e.message}`,
-                                    ),
-                                );
-                            } else {
-                                // emit 'stateChange' event instantly
-                                setImmediate(() => this.emit('stateChange', targetId, aState));
-                            }
+                } else if (!this._stopInProgress && this.adapterReady && this.#alias.hasSource(id)) {
+                    for (const { targetId, state: aState } of this.#alias.resolveSourceChange(id, state)) {
+                        if (typeof this._options.stateChange === 'function') {
+                            Promise.resolve(this._options.stateChange(targetId, aState)).catch(e =>
+                                this._logger.error(`${this.namespaceLog} Error in stateChange handler: ${e.message}`),
+                            );
+                        } else {
+                            setImmediate(() => this.emit('stateChange', targetId, aState));
                         }
                     }
                 }
@@ -13068,73 +12926,7 @@ export class AdapterClass extends EventEmitter {
 
                 // if alias
                 if (id.startsWith(ALIAS_STARTS_WITH)) {
-                    // if `this.aliases` is empty, or no target found, it's a new alias
-                    let isNewAlias = true;
-
-                    for (const [sourceId, alias] of this.aliases) {
-                        const targetAlias = alias.targets.find(entry => entry.id === id);
-
-                        // Find entry for this alias
-                        if (targetAlias) {
-                            isNewAlias = false;
-
-                            // new sourceId or same
-                            if (obj?.common?.alias?.id) {
-                                // check if id.read or id
-                                const newSourceId =
-                                    typeof obj.common.alias.id.read === 'string'
-                                        ? obj.common.alias.id.read
-                                        : obj.common.alias.id;
-
-                                // if linked ID changed
-                                if (newSourceId !== sourceId) {
-                                    await this._removeAliasSubscribe(sourceId, targetAlias);
-                                    try {
-                                        await this._addAliasSubscribe(obj, targetAlias.pattern);
-                                    } catch (e) {
-                                        this._logger.error(
-                                            `${this.namespaceLog} Could not add alias subscription: ${e.message}`,
-                                        );
-                                    }
-                                } else {
-                                    // update attributes
-                                    targetAlias.min = obj.common.min;
-                                    targetAlias.max = obj.common.max;
-                                    targetAlias.type = obj.common.type;
-                                    targetAlias.alias = deepClone(obj.common.alias);
-                                }
-                            } else {
-                                // link was deleted
-                                // remove from targets array
-                                await this._removeAliasSubscribe(sourceId, targetAlias);
-                            }
-                        }
-                    }
-
-                    // it's a new alias, we add it to our subscription
-                    if (isNewAlias && obj) {
-                        for (const aliasPattern of this.aliasPatterns) {
-                            // check if it's in our subs range, if so add it
-                            const testPattern =
-                                aliasPattern.slice(-1) === '*'
-                                    ? new RegExp(tools.pattern2RegEx(aliasPattern))
-                                    : aliasPattern;
-
-                            if (
-                                (typeof testPattern === 'string' && aliasPattern === id) ||
-                                (testPattern instanceof RegExp && testPattern.test(id))
-                            ) {
-                                try {
-                                    await this._addAliasSubscribe(obj, id);
-                                } catch (e) {
-                                    this._logger.warn(
-                                        `${this.namespaceLog} Could not add alias subscription: ${e.message}`,
-                                    );
-                                }
-                                break;
-                            }
-                        }
-                    }
+                    await this.#alias.handleAliasObjectChange(id, obj);
                 }
 
                 // process auto-subscribe adapters

--- a/packages/adapter/src/lib/adapter/adapter.ts
+++ b/packages/adapter/src/lib/adapter/adapter.ts
@@ -11794,13 +11794,11 @@ export class AdapterClass extends EventEmitter {
         }
 
         if (aliasPattern) {
-            // if pattern known, remove it and unsubscribe every target it pulled in
             this.#alias.deletePattern(aliasPattern);
             promises.push(this.#alias.removeTargetsForPattern(aliasPattern));
         }
 
         await Promise.all(promises);
-        // if no alias subscribed any longer, remove the alias.* object subscription
         await this.#alias.maybeDropAliasObjectSubscription();
         return tools.maybeCallback(callback);
     }

--- a/packages/adapter/src/lib/adapter/adapter.ts
+++ b/packages/adapter/src/lib/adapter/adapter.ts
@@ -11556,7 +11556,7 @@ export class AdapterClass extends EventEmitter {
             const promises = [];
 
             if (aliasesIds.length) {
-                await this.#alias.ensureAliasObjectSubscription();
+                this.#alias.ensureAliasObjectSubscription();
 
                 const aliasObjs = await this._getObjectsByArray(aliasesIds, options);
 
@@ -11581,7 +11581,7 @@ export class AdapterClass extends EventEmitter {
             return tools.maybeCallback(callback);
         } else if (pattern.includes('*')) {
             if (pattern === '*' || pattern.startsWith(ALIAS_STARTS_WITH)) {
-                await this.#alias.ensureAliasObjectSubscription();
+                this.#alias.ensureAliasObjectSubscription();
 
                 // read all aliases
                 try {
@@ -11630,7 +11630,7 @@ export class AdapterClass extends EventEmitter {
                 return callback ? this.#states.subscribeUser(pattern, callback) : this.#states.subscribeUser(pattern);
             }
         } else if (pattern.startsWith(ALIAS_STARTS_WITH)) {
-            await this.#alias.ensureAliasObjectSubscription();
+            this.#alias.ensureAliasObjectSubscription();
 
             // just read one alias Object
             try {
@@ -11799,7 +11799,7 @@ export class AdapterClass extends EventEmitter {
         }
 
         await Promise.all(promises);
-        await this.#alias.maybeDropAliasObjectSubscription();
+        this.#alias.maybeDropAliasObjectSubscription();
         return tools.maybeCallback(callback);
     }
 

--- a/packages/adapter/src/lib/adapter/managers/AliasManager.test.ts
+++ b/packages/adapter/src/lib/adapter/managers/AliasManager.test.ts
@@ -150,17 +150,17 @@ describe('AliasManager patterns + object subscription', () => {
         assert.equal(mgr.hasPattern('alias.0.*'), false);
     });
 
-    it('subscribes the alias.* object once and drops it when empty', async () => {
+    it('subscribes the alias.* object once and drops it when empty', () => {
         const subscribe = sinon.stub().resolves();
         const unsubscribe = sinon.stub().resolves();
         const mgr = new AliasManager(
             makeContext({ objects: { subscribe, unsubscribe } as any, states: {} as any }),
             validateId,
         );
-        await mgr.ensureAliasObjectSubscription();
-        await mgr.ensureAliasObjectSubscription();
+        mgr.ensureAliasObjectSubscription();
+        mgr.ensureAliasObjectSubscription();
         assert.equal(subscribe.calledOnce, true);
-        await mgr.maybeDropAliasObjectSubscription();
+        mgr.maybeDropAliasObjectSubscription();
         assert.equal(unsubscribe.calledOnceWith('alias.*'), true);
     });
 });

--- a/packages/adapter/src/lib/adapter/managers/AliasManager.test.ts
+++ b/packages/adapter/src/lib/adapter/managers/AliasManager.test.ts
@@ -1,0 +1,230 @@
+import assert from 'node:assert/strict';
+import sinon from 'sinon';
+import { AliasManager } from './AliasManager.js';
+import type { AdapterContext } from '../context.js';
+
+function makeContext(over: Partial<AdapterContext> = {}): AdapterContext {
+    return {
+        namespace: 'test.0',
+        namespaceLog: 'test.0',
+        logger: { silly() {}, debug() {}, info() {}, warn() {}, error() {} } as any,
+        uiMessagingController: {} as any,
+        states: null,
+        objects: null,
+        common: undefined,
+        config: {} as ioBroker.AdapterConfig,
+        host: 'localhost',
+        ...over,
+    };
+}
+
+const validateId = (): void => undefined; // no-op validator for tests
+
+function aliasObj(id: string, readSource: string): any {
+    return {
+        _id: id,
+        type: 'state',
+        common: { alias: { id: readSource }, type: 'number', min: 0, max: 100, unit: '%' },
+    } as any;
+}
+
+describe('AliasManager.addAliasSubscribe', () => {
+    it('creates the entry, subscribes source state + reads source object once', async () => {
+        const subscribe = sinon.stub().resolves();
+        const getObject = sinon
+            .stub()
+            .resolves({ _id: 'x.0.src', common: { min: 0, max: 10, type: 'number', unit: 'K' } });
+        const mgr = new AliasManager(
+            makeContext({ states: { subscribe } as any, objects: { getObject } as any }),
+            validateId,
+        );
+
+        await mgr.addAliasSubscribe(aliasObj('alias.0.a', 'x.0.src'), 'alias.0.*');
+        assert.equal(mgr.hasSource('x.0.src'), true);
+        assert.equal(subscribe.calledOnceWith('x.0.src'), true);
+
+        await mgr.addAliasSubscribe(aliasObj('alias.0.b', 'x.0.src'), 'alias.0.*');
+        assert.equal(subscribe.calledOnce, true); // reused entry, no second subscribe
+        assert.equal(getObject.calledOnce, true); // source resolved once
+    });
+
+    it('does not write source onto an entry deleted during the awaits (has-recheck)', async () => {
+        const subscribe = sinon.stub().resolves();
+        // getObject resolves AFTER we delete the entry to simulate an interleaved remove
+        const mgr = new AliasManager(
+            makeContext({
+                states: { subscribe, unsubscribe: sinon.stub().resolves() } as any,
+                objects: {
+                    getObject: async () => {
+                        await mgr.removeAliasSubscribe('x.0.src', 0); // interleave: drop the entry
+                        return { _id: 'x.0.src', common: { min: 1 } };
+                    },
+                } as any,
+            }),
+            validateId,
+        );
+        await mgr.addAliasSubscribe(aliasObj('alias.0.a', 'x.0.src'), 'p');
+        // entry was deleted mid-populate; must not resurrect with a source
+        assert.equal(mgr.hasSource('x.0.src'), false);
+    });
+
+    it('ignores non-state alias objects without subscribing', async () => {
+        const subscribe = sinon.stub().resolves();
+        const mgr = new AliasManager(makeContext({ states: { subscribe } as any }), validateId);
+
+        const channelObj = { _id: 'alias.0.a', type: 'channel', common: {} } as any;
+        await mgr.addAliasSubscribe(channelObj, 'p');
+        assert.equal(mgr.size, 0);
+        assert.equal(subscribe.called, false);
+    });
+
+    it('throws and does not create an entry when common.alias.id is missing', async () => {
+        const subscribe = sinon.stub().resolves();
+        const mgr = new AliasManager(makeContext({ states: { subscribe } as any }), validateId);
+
+        const noAlias = { _id: 'alias.0.a', type: 'state', common: {} } as any;
+        await assert.rejects(mgr.addAliasSubscribe(noAlias, 'p'), /has no target/);
+        assert.equal(mgr.size, 0);
+        assert.equal(subscribe.called, false);
+    });
+});
+
+describe('AliasManager.removeAliasSubscribe', () => {
+    it('splices one target and unsubscribes + drops entry when empty', async () => {
+        const subscribe = sinon.stub().resolves();
+        const unsubscribe = sinon.stub().resolves();
+        const getObject = sinon.stub().resolves({ _id: 'x.0.src', common: {} });
+        const mgr = new AliasManager(
+            makeContext({ states: { subscribe, unsubscribe } as any, objects: { getObject } as any }),
+            validateId,
+        );
+        await mgr.addAliasSubscribe(aliasObj('alias.0.a', 'x.0.src'), 'p');
+        await mgr.removeAliasSubscribe('x.0.src', 0);
+        assert.equal(mgr.hasSource('x.0.src'), false);
+        assert.equal(unsubscribe.calledOnceWith('x.0.src'), true);
+    });
+});
+
+describe('AliasManager.resolveSourceChange', () => {
+    it('is synchronous and returns one transformed entry per unique target', async () => {
+        const getObject = sinon.stub().resolves({ _id: 'x.0.src', common: { type: 'number' } });
+        const mgr = new AliasManager(
+            makeContext({ states: { subscribe: sinon.stub().resolves() } as any, objects: { getObject } as any }),
+            validateId,
+        );
+        await mgr.addAliasSubscribe(aliasObj('alias.0.a', 'x.0.src'), 'p');
+
+        const out = mgr.resolveSourceChange('x.0.src', { val: 5, ack: true } as any);
+        assert.equal(Array.isArray(out), true); // synchronous: a plain array, not a Promise
+        assert.equal(out instanceof Promise, false);
+        assert.equal(out.length, 1);
+        assert.equal(out[0].targetId, 'alias.0.a');
+    });
+
+    it('returns null-state entries when the source state is null', async () => {
+        const getObject = sinon.stub().resolves({ _id: 'x.0.src', common: {} });
+        const mgr = new AliasManager(
+            makeContext({ states: { subscribe: sinon.stub().resolves() } as any, objects: { getObject } as any }),
+            validateId,
+        );
+        await mgr.addAliasSubscribe(aliasObj('alias.0.a', 'x.0.src'), 'p');
+        const out = mgr.resolveSourceChange('x.0.src', null);
+        assert.equal(out.length, 1);
+        assert.equal(out[0].state, null);
+    });
+
+    it('returns empty for an unknown source', () => {
+        const mgr = new AliasManager(makeContext(), validateId);
+        assert.deepEqual(mgr.resolveSourceChange('nope', { val: 1 } as any), []);
+    });
+});
+
+describe('AliasManager patterns + object subscription', () => {
+    it('add/has/delete pattern and matchesAnyPattern', () => {
+        const mgr = new AliasManager(makeContext(), validateId);
+        mgr.addPattern('alias.0.*');
+        assert.equal(mgr.hasPattern('alias.0.*'), true);
+        assert.equal(mgr.matchesAnyPattern('alias.0.foo'), true);
+        assert.equal(mgr.matchesAnyPattern('alias.1.foo'), false);
+        mgr.deletePattern('alias.0.*');
+        assert.equal(mgr.hasPattern('alias.0.*'), false);
+    });
+
+    it('subscribes the alias.* object once and drops it when empty', async () => {
+        const subscribe = sinon.stub().resolves();
+        const unsubscribe = sinon.stub().resolves();
+        const mgr = new AliasManager(
+            makeContext({ objects: { subscribe, unsubscribe } as any, states: {} as any }),
+            validateId,
+        );
+        await mgr.ensureAliasObjectSubscription();
+        await mgr.ensureAliasObjectSubscription();
+        assert.equal(subscribe.calledOnce, true);
+        await mgr.maybeDropAliasObjectSubscription();
+        assert.equal(unsubscribe.calledOnceWith('alias.*'), true);
+    });
+});
+
+describe('AliasManager.handleAliasObjectChange', () => {
+    async function withOneAlias(): Promise<{
+        mgr: AliasManager;
+        subscribe: sinon.SinonStub;
+        unsubscribe: sinon.SinonStub;
+    }> {
+        const subscribe = sinon.stub().resolves();
+        const unsubscribe = sinon.stub().resolves();
+        const getObject = sinon.stub().resolves({ _id: 'x.0.src', common: { type: 'number' } });
+        const mgr = new AliasManager(
+            makeContext({ states: { subscribe, unsubscribe } as any, objects: { getObject } as any }),
+            validateId,
+        );
+        mgr.addPattern('alias.0.*');
+        await mgr.addAliasSubscribe(aliasObj('alias.0.a', 'x.0.src'), 'alias.0.*');
+        return { mgr, subscribe, unsubscribe };
+    }
+
+    it('re-points the target when the source id changes (remove old, add new)', async () => {
+        const { mgr } = await withOneAlias();
+        await mgr.handleAliasObjectChange('alias.0.a', aliasObj('alias.0.a', 'x.0.other'));
+        assert.equal(mgr.hasSource('x.0.src'), false);
+        assert.equal(mgr.hasSource('x.0.other'), true);
+    });
+
+    it('updates target metadata in place when the source id is unchanged', async () => {
+        const { mgr } = await withOneAlias();
+        const changed = aliasObj('alias.0.a', 'x.0.src');
+        changed.common.max = 42;
+        await mgr.handleAliasObjectChange('alias.0.a', changed);
+        assert.equal(mgr.hasSource('x.0.src'), true); // same source, not re-pointed
+    });
+
+    it('removes the target when the alias link is deleted', async () => {
+        const { mgr } = await withOneAlias();
+        const noLink = { _id: 'alias.0.a', type: 'state', common: { type: 'number' } } as any;
+        await mgr.handleAliasObjectChange('alias.0.a', noLink);
+        assert.equal(mgr.hasSource('x.0.src'), false);
+    });
+
+    it('picks up a brand-new alias that matches a tracked pattern', async () => {
+        const { mgr } = await withOneAlias();
+        await mgr.handleAliasObjectChange('alias.0.b', aliasObj('alias.0.b', 'x.0.src2'));
+        assert.equal(mgr.hasSource('x.0.src2'), true);
+    });
+});
+
+describe('AliasManager.removeTargetsForPattern', () => {
+    it('removes all targets subscribed under the given pattern', async () => {
+        const subscribe = sinon.stub().resolves();
+        const unsubscribe = sinon.stub().resolves();
+        const getObject = sinon.stub().resolves({ _id: 's', common: {} });
+        const mgr = new AliasManager(
+            makeContext({ states: { subscribe, unsubscribe } as any, objects: { getObject } as any }),
+            validateId,
+        );
+        await mgr.addAliasSubscribe(aliasObj('alias.0.a', 'x.0.s1'), 'alias.0.*');
+        await mgr.addAliasSubscribe(aliasObj('alias.0.b', 'x.0.s2'), 'other');
+        await mgr.removeTargetsForPattern('alias.0.*');
+        assert.equal(mgr.hasSource('x.0.s1'), false);
+        assert.equal(mgr.hasSource('x.0.s2'), true); // different pattern, kept
+    });
+});

--- a/packages/adapter/src/lib/adapter/managers/AliasManager.ts
+++ b/packages/adapter/src/lib/adapter/managers/AliasManager.ts
@@ -196,21 +196,19 @@ export class AliasManager extends AdapterContextBase {
     }
 
     /** Subscribe the `alias.*` object range once (idempotent). */
-    ensureAliasObjectSubscription(): Promise<void> {
+    ensureAliasObjectSubscription(): void {
         if (!this.#aliasObjectsSubscribed) {
             this.#aliasObjectsSubscribed = true;
             this.objects.subscribe(`${ALIAS_STARTS_WITH}*`);
         }
-        return Promise.resolve();
     }
 
     /** Drop the `alias.*` object subscription when no aliases remain. */
-    maybeDropAliasObjectSubscription(): Promise<void> {
+    maybeDropAliasObjectSubscription(): void {
         if (!this.#aliases.size && this.#aliasObjectsSubscribed) {
             this.#aliasObjectsSubscribed = false;
             this.objects.unsubscribe(`${ALIAS_STARTS_WITH}*`);
         }
-        return Promise.resolve();
     }
 
     /**

--- a/packages/adapter/src/lib/adapter/managers/AliasManager.ts
+++ b/packages/adapter/src/lib/adapter/managers/AliasManager.ts
@@ -1,0 +1,292 @@
+import { tools } from '@iobroker/js-controller-common';
+import deepClone from 'deep-clone';
+import type { AliasDetails, AliasTargetEntry } from '../../_Types.js';
+import type { ValidateIdOptions } from '@/lib/adapter/validator.js';
+import type { AdapterContext } from '@/lib/adapter/context.js';
+import { AdapterContextBase } from '@/lib/adapter/managers/AdapterContextBase.js';
+import { ALIAS_STARTS_WITH, SYSTEM_ADMIN_USER } from '@/lib/adapter/constants.js';
+
+/** Validates a (possibly foreign) id; throws on invalid. Bound to the adapter's Validator. */
+export type ValidateId = (id: string, isForeignId: boolean, options?: ValidateIdOptions | null) => void;
+
+/**
+ * Owns the alias subscription cache and its bookkeeping: which real (source) states feed which
+ * `alias.*` targets, the alias subscription patterns, and the single `alias.*` object subscription.
+ * The source-state change fan-out ({@link resolveSourceChange}) is synchronous by contract so the
+ * state-change handler cannot interleave a cache mutation mid-fan-out.
+ */
+export class AliasManager extends AdapterContextBase {
+    readonly #aliases = new Map<string, AliasDetails>();
+    readonly #aliasPatterns = new Set<string>();
+    #aliasObjectsSubscribed = false;
+    readonly #validateId: ValidateId;
+
+    /**
+     * @param ctx Shared adapter context providing live runtime state
+     * @param validateId Bound id validator from the adapter's Validator instance
+     */
+    constructor(ctx: AdapterContext, validateId: ValidateId) {
+        super(ctx);
+        this.#validateId = validateId;
+    }
+
+    /**
+     * Whether the given source (real) state id currently feeds any alias.
+     *
+     * @param id the real source state id
+     */
+    hasSource(id: string): boolean {
+        return this.#aliases.has(id);
+    }
+
+    /** Number of tracked source states. */
+    get size(): number {
+        return this.#aliases.size;
+    }
+
+    /**
+     * Whether the given subscription pattern is tracked.
+     *
+     * @param pattern the subscription pattern
+     */
+    hasPattern(pattern: string): boolean {
+        return this.#aliasPatterns.has(pattern);
+    }
+
+    /**
+     * Track a subscription pattern.
+     *
+     * @param pattern the subscription pattern
+     */
+    addPattern(pattern: string): void {
+        this.#aliasPatterns.add(pattern);
+    }
+
+    /**
+     * Stop tracking a subscription pattern.
+     *
+     * @param pattern the subscription pattern
+     */
+    deletePattern(pattern: string): void {
+        this.#aliasPatterns.delete(pattern);
+    }
+
+    /**
+     * Whether `id` falls into any tracked alias pattern (wildcards via pattern2RegEx).
+     *
+     * @param id the id to test against the tracked patterns
+     */
+    matchesAnyPattern(id: string): boolean {
+        for (const aliasPattern of this.#aliasPatterns) {
+            const testPattern =
+                aliasPattern.slice(-1) === '*' ? new RegExp(tools.pattern2RegEx(aliasPattern)) : aliasPattern;
+            if (
+                (typeof testPattern === 'string' && aliasPattern === id) ||
+                (testPattern instanceof RegExp && testPattern.test(id))
+            ) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Reacts to a change of an `alias.*` object: re-points, updates, or removes the target across the
+     * tracked sources, and picks up a newly-appeared alias that falls into a tracked pattern.
+     * Live-iterates the cache while awaiting add/remove — the loop lives here, with the map, to
+     * preserve the original mutation-during-iteration semantics exactly.
+     *
+     * @param id the changed alias object id
+     * @param obj the new object (null/undefined if deleted)
+     */
+    async handleAliasObjectChange(id: string, obj: ioBroker.Object | null | undefined): Promise<void> {
+        let isNewAlias = true;
+        for (const [sourceId, alias] of this.#aliases) {
+            const targetAlias = alias.targets.find(entry => entry.id === id);
+            if (targetAlias) {
+                isNewAlias = false;
+                if (obj?.common?.alias?.id) {
+                    const newSourceId =
+                        typeof obj.common.alias.id.read === 'string' ? obj.common.alias.id.read : obj.common.alias.id;
+                    if (newSourceId !== sourceId) {
+                        await this.removeAliasSubscribe(sourceId, targetAlias);
+                        try {
+                            await this.addAliasSubscribe(obj, targetAlias.pattern);
+                        } catch (e: any) {
+                            this.logger.error(`${this.namespaceLog} Could not add alias subscription: ${e.message}`);
+                        }
+                    } else {
+                        targetAlias.min = obj.common.min;
+                        targetAlias.max = obj.common.max;
+                        targetAlias.type = obj.common.type;
+                        targetAlias.alias = deepClone(obj.common.alias);
+                    }
+                } else {
+                    await this.removeAliasSubscribe(sourceId, targetAlias);
+                }
+            }
+        }
+        if (isNewAlias && obj && this.matchesAnyPattern(id)) {
+            try {
+                await this.addAliasSubscribe(obj, id);
+            } catch (e: any) {
+                this.logger.warn(`${this.namespaceLog} Could not add alias subscription: ${e.message}`);
+            }
+        }
+    }
+
+    /**
+     * Removes every target subscribed under the given pattern, live-iterating the cache so a removal
+     * mutating the map mid-loop keeps the original semantics. Awaits each removal.
+     *
+     * @param pattern the subscription pattern being unsubscribed
+     */
+    async removeTargetsForPattern(pattern: string): Promise<void> {
+        const promises = new Array<Promise<void>>();
+        for (const [sourceId, alias] of this.#aliases) {
+            for (let i = alias.targets.length - 1; i >= 0; i--) {
+                if (alias.targets[i].pattern === pattern) {
+                    promises.push(this.removeAliasSubscribe(sourceId, i));
+                }
+            }
+        }
+        await Promise.all(promises);
+    }
+
+    /**
+     * Synchronously computes the fan-out of a source (real) state change to its alias targets.
+     * Returns one `{ targetId, state }` per unique target. MUST NOT await — the caller relies on the
+     * cache not mutating between read and emit.
+     *
+     * @param sourceId the changed real state id
+     * @param state the new state value (or null on deletion)
+     */
+    resolveSourceChange(
+        sourceId: string,
+        state: ioBroker.State | null | undefined,
+    ): Array<{ targetId: string; state: ioBroker.State | null }> {
+        const out = new Array<{ targetId: string; state: ioBroker.State | null }>();
+        const alias = this.#aliases.get(sourceId);
+        if (!alias) {
+            return out;
+        }
+        const uniqueTargets = new Set<string>();
+        for (const target of alias.targets) {
+            const targetId = target.id;
+            if (uniqueTargets.has(targetId)) {
+                continue;
+            }
+            uniqueTargets.add(targetId);
+            const aState = state
+                ? tools.formatAliasValue({
+                      sourceCommon: alias.source,
+                      targetCommon: target,
+                      state: deepClone(state),
+                      logger: this.logger,
+                      logNamespace: this.namespaceLog,
+                      sourceId,
+                      targetId,
+                  })
+                : null;
+            if (aState || !state) {
+                out.push({ targetId, state: aState });
+            }
+        }
+        return out;
+    }
+
+    /** Subscribe the `alias.*` object range once (idempotent). */
+    ensureAliasObjectSubscription(): Promise<void> {
+        if (!this.#aliasObjectsSubscribed) {
+            this.#aliasObjectsSubscribed = true;
+            this.objects.subscribe(`${ALIAS_STARTS_WITH}*`);
+        }
+        return Promise.resolve();
+    }
+
+    /** Drop the `alias.*` object subscription when no aliases remain. */
+    maybeDropAliasObjectSubscription(): Promise<void> {
+        if (!this.#aliases.size && this.#aliasObjectsSubscribed) {
+            this.#aliasObjectsSubscribed = false;
+            this.objects.unsubscribe(`${ALIAS_STARTS_WITH}*`);
+        }
+        return Promise.resolve();
+    }
+
+    /**
+     * Register an alias target for its source state, subscribing the source state (and reading its
+     * metadata once). Preserves the create-before-await ordering and the post-await existence
+     * re-check that guard a concurrent removal.
+     *
+     * @param aliasObj the `alias.*` object being subscribed
+     * @param pattern the subscription pattern that pulled it in
+     */
+    async addAliasSubscribe(aliasObj: ioBroker.AnyObject, pattern: string): Promise<void> {
+        if (aliasObj.type !== 'state') {
+            return;
+        }
+        if (!aliasObj.common?.alias?.id) {
+            this.logger.warn(`${this.namespaceLog} Alias ${aliasObj._id} has no target 5`);
+            throw new Error(`Alias ${aliasObj._id} has no target`);
+        }
+        const sourceId = tools.isObject(aliasObj.common.alias.id)
+            ? aliasObj.common.alias.id.read
+            : aliasObj.common.alias.id;
+        try {
+            this.#validateId(sourceId, true, null);
+        } catch (e: any) {
+            throw new Error(`Error validating alias id of ${aliasObj._id}: ${e.message}`);
+        }
+        const targetEntry: AliasTargetEntry = {
+            alias: deepClone(aliasObj.common.alias),
+            id: aliasObj._id,
+            pattern,
+            type: aliasObj.common.type,
+            max: aliasObj.common.max,
+            min: aliasObj.common.min,
+            unit: aliasObj.common.unit,
+        };
+        let aliasDetails: AliasDetails;
+        if (!this.#aliases.has(sourceId)) {
+            aliasDetails = { targets: [] };
+            this.#aliases.set(sourceId, aliasDetails);
+        } else {
+            aliasDetails = this.#aliases.get(sourceId)!;
+        }
+        if (!aliasDetails.source) {
+            await this.states.subscribe(sourceId);
+            const sourceObj = await this.objects.getObject(sourceId, { user: SYSTEM_ADMIN_USER });
+            if (sourceObj?.common && this.#aliases.has(sourceObj._id)) {
+                aliasDetails.source = {
+                    min: sourceObj.common.min,
+                    max: sourceObj.common.max,
+                    type: sourceObj.common.type,
+                    unit: sourceObj.common.unit,
+                };
+            }
+        }
+        aliasDetails.targets.push(targetEntry);
+    }
+
+    /**
+     * Remove one alias target from its source; when the source has no targets left, delete the entry
+     * and unsubscribe the source state.
+     *
+     * @param sourceId the real source state id
+     * @param aliasObjOrIdx the target entry or its index in the targets array
+     */
+    async removeAliasSubscribe(sourceId: string, aliasObjOrIdx: number | AliasTargetEntry): Promise<void> {
+        if (!this.#aliases.has(sourceId)) {
+            return;
+        }
+        const alias = this.#aliases.get(sourceId)!;
+        const pos = typeof aliasObjOrIdx === 'number' ? aliasObjOrIdx : alias.targets.indexOf(aliasObjOrIdx);
+        if (pos !== -1) {
+            alias.targets.splice(pos, 1);
+            if (!alias.targets.length) {
+                this.#aliases.delete(sourceId);
+                await this.states.unsubscribe(sourceId);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Phase 1 of the adapter core decomposition (concept: `docs/superpowers/specs/2026-07-20-adapter-core-decomposition-concept.md`). Extracts the alias state-forwarding subsystem out of the `adapter.ts` god-file into a dedicated `AliasManager`, with no change to observable behavior or the public API.

Follows the established manager pattern (`extends AdapterContextBase`), with one deliberate deviation explained below.

## What moves

- **`AliasManager`** (`managers/AliasManager.ts`) now owns the alias cache (`aliases`/`aliasPatterns`/the `alias.*` object-subscription flag) and its bookkeeping:
  - async `addAliasSubscribe`/`removeAliasSubscribe`, `handleAliasObjectChange`, `removeTargetsForPattern`, `ensureAliasObjectSubscription`/`maybeDropAliasObjectSubscription`
  - synchronous `resolveSourceChange` (the source-state→alias fan-out), `hasSource`/`size`/pattern queries
- `AdapterClass` holds it as a lazy `#alias` getter and routes every former `this.aliases…` site through it; the old fields + `_addAliasSubscribe`/`_removeAliasSubscribe` are deleted.

## Design notes

- **`AliasManager` is held directly on `AdapterClass`, not under `AsyncAdapter`.** The source-change fan-out that the state-change handler calls (`resolveSourceChange`) must be **synchronous** — there must be no `await` between reading the alias cache and scheduling the `stateChange` emits, otherwise a concurrent `alias.*` object change could interleave `add`/`removeAliasSubscribe` (which splice the targets array / mutate the map) mid-fan-out. `AsyncAdapter` is the async-only facade, so a sync hot-path method doesn't belong there.
- **The live-iterating loops (`handleAliasObjectChange`, `removeTargetsForPattern`) live inside the manager**, co-located with the Map, so the original mutation-during-iteration semantics are preserved exactly rather than changed by snapshotting in the caller.
- The alias read/write transforms in `_getForeignState`/`_setState` don't touch the cache, so they stay in the state core for a later phase.
- Only injected capability this phase: a bound `validateId`. No `AdapterContext` widening needed.

## Testing

- `npm run test-adapter`: 77 passing, incl. new `AliasManager` unit tests (add/remove subscribe incl. the create-before-await + post-await re-check race guard; synchronous `resolveSourceChange` with dedup + null-state; `handleAliasObjectChange` re-point/update/delete/new-alias paths; `removeTargetsForPattern`; pattern + object-subscription toggle).
- Build, eslint (0/0), `@iobroker/types` leak-gate, and `test-types-check` all green (type-check error set is the pre-existing baseline, unchanged by this branch).
- Two per-task reviews + one independent adversarial whole-branch review: no correctness findings; extraction confirmed byte-faithful against the original.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
