### PR TITLE
refactor(adapter): extract SubscriptionManager for object + file subs (core decomposition phase 2)

### DIFF
--- a/packages/adapter/src/lib/adapter/adapter.ts
+++ b/packages/adapter/src/lib/adapter/adapter.ts
@@ -132,6 +132,7 @@ import { UserInterfaceMessagingController } from '@/lib/adapter/userInterfaceMes
 import { AsyncAdapter } from '@/lib/adapter/asyncAdapter.js';
 import { CERTIFICATES_OBJECT_ID } from '@/lib/adapter/managers/CertificateManager.js';
 import { AliasManager } from '@/lib/adapter/managers/AliasManager.js';
+import { SubscriptionManager } from '@/lib/adapter/managers/SubscriptionManager.js';
 import type { AdapterContext } from '@/lib/adapter/context.js';
 import { SYSTEM_ADAPTER_PREFIX, DEFAULT_OBJECTS_WARN_LIMIT } from '@iobroker/js-controller-common-db/constants';
 import { isLogLevel } from '@iobroker/js-controller-common-db/tools';
@@ -1016,6 +1017,15 @@ export class AdapterClass extends EventEmitter {
     get #alias(): AliasManager {
         return (this.#aliasInstance ??= new AliasManager(this.#context, (id, allowSystem, options) =>
             this._utils.validateId(id, allowSystem, options),
+        ));
+    }
+
+    #subscriptionsInstance?: SubscriptionManager;
+
+    /** Lazily-constructed object/file subscription manager. */
+    get #subscriptions(): SubscriptionManager {
+        return (this.#subscriptionsInstance ??= new SubscriptionManager(this.#context, (id, isPattern) =>
+            this._utils.fixId(id, isPattern),
         ));
     }
 
@@ -5713,19 +5723,13 @@ export class AdapterClass extends EventEmitter {
             Validator.assertObject(options, 'options');
         }
 
-        if (!this.#objects) {
-            this._logger.info(
-                `${this.namespaceLog} subscribeObjects not processed because Objects database not connected`,
+        const cb = callback as ioBroker.ErrorCallback | undefined;
+        this.#subscriptions
+            .subscribeObjects(pattern, options as { user?: ioBroker.ObjectIDs.User } | null | undefined)
+            .then(
+                () => cb?.(),
+                (err: Error) => cb?.(err),
             );
-            return tools.maybeCallbackWithError(callback, tools.ERRORS.ERROR_DB_CLOSED);
-        }
-
-        if (pattern === '*') {
-            this.#objects.subscribeUser(`${this.namespace}.*`, options, callback);
-        } else {
-            const fixedPattern = Array.isArray(pattern) ? pattern : this._utils.fixId(pattern, true);
-            this.#objects.subscribeUser(fixedPattern, options, callback);
-        }
     }
 
     /**
@@ -5772,19 +5776,13 @@ export class AdapterClass extends EventEmitter {
             Validator.assertObject(options, 'options');
         }
 
-        if (!this.#objects) {
-            this._logger.info(
-                `${this.namespaceLog} unsubscribeObjects not processed because Objects database not connected`,
+        const cb = callback as ioBroker.ErrorCallback | undefined;
+        this.#subscriptions
+            .unsubscribeObjects(pattern, options as { user?: ioBroker.ObjectIDs.User } | null | undefined)
+            .then(
+                () => cb?.(),
+                (err: Error) => cb?.(err),
             );
-            return tools.maybeCallbackWithError(callback, tools.ERRORS.ERROR_DB_CLOSED);
-        }
-
-        if (pattern === '*') {
-            this.#objects.unsubscribeUser(`${this.namespace}.*`, options, callback);
-        } else {
-            const fixedPattern = Array.isArray(pattern) ? pattern : this._utils.fixId(pattern, true);
-            this.#objects.unsubscribeUser(fixedPattern, options, callback);
-        }
     }
 
     // external signatures
@@ -5832,14 +5830,13 @@ export class AdapterClass extends EventEmitter {
             Validator.assertObject(options, 'options');
         }
 
-        if (!this.#objects) {
-            this._logger.info(
-                `${this.namespaceLog} subscribeForeignObjects not processed because Objects database not connected`,
+        const cb = callback as ioBroker.ErrorCallback | undefined;
+        this.#subscriptions
+            .subscribeForeignObjects(pattern, options as { user?: ioBroker.ObjectIDs.User } | null | undefined)
+            .then(
+                () => cb?.(),
+                (err: Error) => cb?.(err),
             );
-            return tools.maybeCallbackWithError(callback, tools.ERRORS.ERROR_DB_CLOSED);
-        }
-
-        this.#objects.subscribeUser(pattern, options, callback);
     }
 
     // external signatures
@@ -5890,14 +5887,13 @@ export class AdapterClass extends EventEmitter {
             Validator.assertObject(options, 'options');
         }
 
-        if (!this.#objects) {
-            this._logger.info(
-                `${this.namespaceLog} unsubscribeForeignObjects not processed because Objects database not connected`,
+        const cb = callback as ioBroker.ErrorCallback | undefined;
+        this.#subscriptions
+            .unsubscribeForeignObjects(pattern, options as { user?: ioBroker.ObjectIDs.User } | null | undefined)
+            .then(
+                () => cb?.(),
+                (err: Error) => cb?.(err),
             );
-            return tools.maybeCallbackWithError(callback, tools.ERRORS.ERROR_DB_CLOSED);
-        }
-
-        this.#objects.unsubscribeUser(pattern, options, callback);
     }
 
     // external signatures
@@ -5918,21 +5914,17 @@ export class AdapterClass extends EventEmitter {
      * @param options optional user context
      */
     subscribeForeignFiles(id: unknown, pattern: unknown, options?: unknown): Promise<void> {
-        if (!this.#objects) {
-            this._logger.info(
-                `${this.namespaceLog} subscribeForeignFiles not processed because Objects database not connected`,
-            );
-
-            throw new Error(tools.ERRORS.ERROR_DB_CLOSED);
-        }
-
         Validator.assertString(id, 'id');
         Validator.assertPattern(pattern, 'pattern');
         if (options !== null && options !== undefined) {
             Validator.assertObject(options, 'options');
         }
 
-        return this.#objects.subscribeUserFile(id, pattern, options);
+        return this.#subscriptions.subscribeForeignFiles(
+            id,
+            pattern,
+            options as { user?: ioBroker.ObjectIDs.User } | null | undefined,
+        );
     }
 
     // external signatures
@@ -5956,13 +5948,6 @@ export class AdapterClass extends EventEmitter {
         if (!pattern) {
             pattern = '*';
         }
-        if (!this.#objects) {
-            this._logger.info(
-                `${this.namespaceLog} unsubscribeForeignFiles not processed because Objects database not connected`,
-            );
-
-            throw new Error(tools.ERRORS.ERROR_DB_CLOSED);
-        }
 
         Validator.assertString(id, 'id');
         Validator.assertPattern(pattern, 'pattern');
@@ -5970,7 +5955,11 @@ export class AdapterClass extends EventEmitter {
             Validator.assertObject(options, 'options');
         }
 
-        return this.#objects.unsubscribeUserFile(id, pattern, options);
+        return this.#subscriptions.unsubscribeForeignFiles(
+            id,
+            pattern,
+            options as { user?: ioBroker.ObjectIDs.User } | null | undefined,
+        );
     }
 
     // external signatures

--- a/packages/adapter/src/lib/adapter/managers/SubscriptionManager.test.ts
+++ b/packages/adapter/src/lib/adapter/managers/SubscriptionManager.test.ts
@@ -1,0 +1,182 @@
+import assert from 'node:assert/strict';
+import sinon from 'sinon';
+import { tools } from '@iobroker/js-controller-common';
+import { SubscriptionManager } from './SubscriptionManager.js';
+import type { AdapterContext } from '../context.js';
+
+function makeContext(over: Partial<AdapterContext> = {}): AdapterContext {
+    return {
+        namespace: 'test.0',
+        namespaceLog: 'test.0',
+        logger: { silly() {}, debug() {}, info() {}, warn() {}, error() {} } as any,
+        uiMessagingController: {} as any,
+        states: null,
+        objects: null,
+        common: undefined,
+        config: {} as ioBroker.AdapterConfig,
+        host: 'localhost',
+        ...over,
+    };
+}
+const fixId = (id: string): string => `test.0.${id}`;
+function objStub(): {
+    subscribeUserAsync: sinon.SinonStub;
+    unsubscribeUserAsync: sinon.SinonStub;
+    subscribeUserFile: sinon.SinonStub;
+    unsubscribeUserFile: sinon.SinonStub;
+} {
+    return {
+        subscribeUserAsync: sinon.stub().resolves(),
+        unsubscribeUserAsync: sinon.stub().resolves(),
+        subscribeUserFile: sinon.stub().resolves(),
+        unsubscribeUserFile: sinon.stub().resolves(),
+    };
+}
+
+describe('SubscriptionManager object subs', () => {
+    it('subscribeForeignObjects delegates verbatim to subscribeUserAsync', async () => {
+        const objects = objStub();
+        const mgr = new SubscriptionManager(makeContext({ objects: objects as any }), fixId);
+        await mgr.subscribeForeignObjects('foo.*', { user: 'system.user.x' } as any);
+        assert.equal(objects.subscribeUserAsync.firstCall.args[0], 'foo.*');
+    });
+
+    it('subscribeObjects fixes a non-foreign pattern and namespaces "*"', async () => {
+        const objects = objStub();
+        const mgr = new SubscriptionManager(makeContext({ objects: objects as any }), fixId);
+        await mgr.subscribeObjects('chan.*');
+        assert.equal(objects.subscribeUserAsync.firstCall.args[0], 'test.0.chan.*');
+        await mgr.subscribeObjects('*');
+        assert.equal(objects.subscribeUserAsync.secondCall.args[0], 'test.0.*');
+    });
+
+    it('subscribeObjects passes an array pattern through unfixed', async () => {
+        const objects = objStub();
+        const mgr = new SubscriptionManager(makeContext({ objects: objects as any }), fixId);
+        await mgr.subscribeObjects(['chan.*', 'other.*']);
+        assert.deepEqual(objects.subscribeUserAsync.firstCall.args[0], ['chan.*', 'other.*']);
+    });
+
+    it('subscribeObjects calls fixId with isPattern=true', async () => {
+        const objects = objStub();
+        const fixIdSpy = sinon.stub().callsFake((id: string) => `test.0.${id}`);
+        const mgr = new SubscriptionManager(makeContext({ objects: objects as any }), fixIdSpy);
+        await mgr.subscribeObjects('chan.*');
+        assert.deepEqual(fixIdSpy.firstCall.args, ['chan.*', true]);
+    });
+
+    it('subscribeObjects/subscribeForeignObjects forward options to subscribeUserAsync', async () => {
+        const objects = objStub();
+        const mgr = new SubscriptionManager(makeContext({ objects: objects as any }), fixId);
+        const options = { user: 'system.user.x' } as any;
+        await mgr.subscribeObjects('chan.*', options);
+        assert.equal(objects.subscribeUserAsync.firstCall.args[1], options);
+        await mgr.subscribeForeignObjects('foo.*', options);
+        assert.equal(objects.subscribeUserAsync.secondCall.args[1], options);
+    });
+
+    it('subscribeForeignObjects forwards null options when omitted', async () => {
+        const objects = objStub();
+        const mgr = new SubscriptionManager(makeContext({ objects: objects as any }), fixId);
+        await mgr.subscribeForeignObjects('foo.*');
+        assert.equal(objects.subscribeUserAsync.firstCall.args[1], null);
+    });
+
+    it('unsubscribeObjects fixes a non-foreign pattern and namespaces "*"', async () => {
+        const objects = objStub();
+        const mgr = new SubscriptionManager(makeContext({ objects: objects as any }), fixId);
+        await mgr.unsubscribeObjects('chan.*');
+        assert.equal(objects.unsubscribeUserAsync.firstCall.args[0], 'test.0.chan.*');
+        await mgr.unsubscribeObjects('*');
+        assert.equal(objects.unsubscribeUserAsync.secondCall.args[0], 'test.0.*');
+    });
+
+    it('unsubscribeObjects passes an array pattern through unfixed', async () => {
+        const objects = objStub();
+        const mgr = new SubscriptionManager(makeContext({ objects: objects as any }), fixId);
+        await mgr.unsubscribeObjects(['chan.*']);
+        assert.deepEqual(objects.unsubscribeUserAsync.firstCall.args[0], ['chan.*']);
+    });
+
+    it('unsubscribeForeignObjects defaults pattern to "*"', async () => {
+        const objects = objStub();
+        const mgr = new SubscriptionManager(makeContext({ objects: objects as any }), fixId);
+        await mgr.unsubscribeForeignObjects(undefined as any);
+        assert.equal(objects.unsubscribeUserAsync.firstCall.args[0], '*');
+    });
+
+    it('unsubscribeForeignObjects forwards options to unsubscribeUserAsync', async () => {
+        const objects = objStub();
+        const mgr = new SubscriptionManager(makeContext({ objects: objects as any }), fixId);
+        const options = { user: 'system.user.x' } as any;
+        await mgr.unsubscribeForeignObjects('foo.*', options);
+        assert.equal(objects.unsubscribeUserAsync.firstCall.args[1], options);
+    });
+
+    it('rejects with ERROR_DB_CLOSED when objects DB down', async () => {
+        const mgr = new SubscriptionManager(makeContext({ objects: null }), fixId);
+        await assert.rejects(() => mgr.subscribeForeignObjects('foo.*'), new RegExp(tools.ERRORS.ERROR_DB_CLOSED));
+    });
+
+    it('unsubscribeObjects rejects with ERROR_DB_CLOSED when objects DB down', async () => {
+        const mgr = new SubscriptionManager(makeContext({ objects: null }), fixId);
+        await assert.rejects(() => mgr.unsubscribeObjects('foo.*'), new RegExp(tools.ERRORS.ERROR_DB_CLOSED));
+    });
+
+    it('rejects when subscribeUserAsync rejects', async () => {
+        const objects = objStub();
+        objects.subscribeUserAsync.rejects(new Error('boom'));
+        const mgr = new SubscriptionManager(makeContext({ objects: objects as any }), fixId);
+        await assert.rejects(() => mgr.subscribeForeignObjects('foo.*'), /boom/);
+    });
+
+    it('rejects when unsubscribeUserAsync rejects', async () => {
+        const objects = objStub();
+        objects.unsubscribeUserAsync.rejects(new Error('boom'));
+        const mgr = new SubscriptionManager(makeContext({ objects: objects as any }), fixId);
+        await assert.rejects(() => mgr.unsubscribeObjects('foo.*'), /boom/);
+    });
+});
+
+describe('SubscriptionManager file subs', () => {
+    it('subscribeForeignFiles delegates to subscribeUserFile', async () => {
+        const objects = objStub();
+        const mgr = new SubscriptionManager(makeContext({ objects: objects as any }), fixId);
+        await mgr.subscribeForeignFiles('vis.0', '*');
+        assert.deepEqual(objects.subscribeUserFile.firstCall.args.slice(0, 2), ['vis.0', '*']);
+    });
+
+    it('unsubscribeForeignFiles defaults pattern to "*"', async () => {
+        const objects = objStub();
+        const mgr = new SubscriptionManager(makeContext({ objects: objects as any }), fixId);
+        await mgr.unsubscribeForeignFiles('vis.0', undefined as any);
+        assert.equal(objects.unsubscribeUserFile.firstCall.args[1], '*');
+    });
+
+    it('subscribeForeignFiles/unsubscribeForeignFiles forward options', async () => {
+        const objects = objStub();
+        const mgr = new SubscriptionManager(makeContext({ objects: objects as any }), fixId);
+        const options = { user: 'system.user.x' } as any;
+        await mgr.subscribeForeignFiles('vis.0', '*', options);
+        assert.equal(objects.subscribeUserFile.firstCall.args[2], options);
+        await mgr.unsubscribeForeignFiles('vis.0', '*', options);
+        assert.equal(objects.unsubscribeUserFile.firstCall.args[2], options);
+    });
+
+    it('throws ERROR_DB_CLOSED when objects DB down', async () => {
+        const mgr = new SubscriptionManager(makeContext({ objects: null }), fixId);
+        await assert.rejects(() => mgr.subscribeForeignFiles('vis.0', '*'), new RegExp(tools.ERRORS.ERROR_DB_CLOSED));
+    });
+
+    it('unsubscribeForeignFiles throws ERROR_DB_CLOSED when objects DB down', async () => {
+        const mgr = new SubscriptionManager(makeContext({ objects: null }), fixId);
+        await assert.rejects(() => mgr.unsubscribeForeignFiles('vis.0', '*'), new RegExp(tools.ERRORS.ERROR_DB_CLOSED));
+    });
+
+    it('rejects when subscribeUserFile rejects', async () => {
+        const objects = objStub();
+        objects.subscribeUserFile.rejects(new Error('boom'));
+        const mgr = new SubscriptionManager(makeContext({ objects: objects as any }), fixId);
+        await assert.rejects(() => mgr.subscribeForeignFiles('vis.0', '*'), /boom/);
+    });
+});

--- a/packages/adapter/src/lib/adapter/managers/SubscriptionManager.ts
+++ b/packages/adapter/src/lib/adapter/managers/SubscriptionManager.ts
@@ -1,0 +1,90 @@
+import type { Pattern } from '../../_Types.js';
+import type { AdapterContext } from '@/lib/adapter/context.js';
+import { AdapterContextBase } from '@/lib/adapter/managers/AdapterContextBase.js';
+
+/** Prefixes an id or pattern with this adapter's namespace unless already namespaced. Bound to the adapter's Validator. */
+export type FixId = (id: string, isPattern?: boolean) => string;
+
+type SubOptions = { user?: ioBroker.ObjectIDs.User } | null | undefined;
+
+/** Owns object- and file-change subscriptions, delegating to the objects DB client. */
+export class SubscriptionManager extends AdapterContextBase {
+    readonly #fixId: FixId;
+
+    /**
+     * @param ctx Shared adapter context providing live runtime state
+     * @param fixId Namespace-prefixer bound to the adapter's Validator
+     */
+    constructor(ctx: AdapterContext, fixId: FixId) {
+        super(ctx);
+        this.#fixId = fixId;
+    }
+
+    /**
+     * Subscribe to object changes within this instance's namespace.
+     *
+     * @param pattern pattern without namespace, `*` for all own objects, or an array of patterns
+     *        passed through as-is (not namespaced)
+     * @param options optional user context
+     */
+    async subscribeObjects(pattern: Pattern, options?: SubOptions): Promise<void> {
+        const fixed =
+            pattern === '*' ? `${this.namespace}.*` : Array.isArray(pattern) ? pattern : this.#fixId(pattern, true);
+        return this.objects.subscribeUserAsync(fixed, options ?? null);
+    }
+
+    /**
+     * Unsubscribe from object changes within this instance's namespace.
+     *
+     * @param pattern pattern without namespace, `*` for all own objects, or an array of patterns
+     *        passed through as-is (not namespaced)
+     * @param options optional user context
+     */
+    async unsubscribeObjects(pattern: Pattern, options?: SubOptions): Promise<void> {
+        const fixed =
+            pattern === '*' ? `${this.namespace}.*` : Array.isArray(pattern) ? pattern : this.#fixId(pattern, true);
+        return this.objects.unsubscribeUserAsync(fixed, options ?? null);
+    }
+
+    /**
+     * Subscribe to object changes in any instance.
+     *
+     * @param pattern pattern or array of patterns
+     * @param options optional user context
+     */
+    async subscribeForeignObjects(pattern: Pattern, options?: SubOptions): Promise<void> {
+        return this.objects.subscribeUserAsync(pattern, options ?? null);
+    }
+
+    /**
+     * Unsubscribe from object changes in any instance.
+     *
+     * @param pattern pattern or array of patterns (defaults to `*`)
+     * @param options optional user context
+     */
+    async unsubscribeForeignObjects(pattern: Pattern, options?: SubOptions): Promise<void> {
+        return this.objects.unsubscribeUserAsync(pattern || '*', options ?? null);
+    }
+
+    /**
+     * Subscribe to file changes in a specific instance.
+     *
+     * @param id adapter id, e.g. `vis-2.0`
+     * @param pattern pattern or array of patterns
+     * @param options optional user context
+     */
+    async subscribeForeignFiles(id: string, pattern: Pattern, options?: SubOptions): Promise<void> {
+        return this.objects.subscribeUserFile(id, pattern, options ?? undefined);
+    }
+
+    /**
+     * Unsubscribe from file changes in a specific instance.
+     *
+     * @param id adapter id, e.g. `vis-2.0`
+     * @param pattern pattern or array of patterns (defaults to `*`)
+     * @param options optional user context
+     */
+    async unsubscribeForeignFiles(id: string, pattern: Pattern, options?: SubOptions): Promise<void> {
+        return this.objects.unsubscribeUserFile(id, pattern || '*', options ?? undefined);
+    }
+}


### PR DESCRIPTION
## Summary

Phase 2 of the adapter core decomposition (concept: `docs/superpowers/specs/2026-07-20-adapter-core-decomposition-concept.md`), following AliasManager (#3439). Extracts the **object and file** subscription methods into a `SubscriptionManager`. State subscriptions are intentionally left for a later phase (they still carry the `autoSubscribe` / object-read-ACL / `outputCount` couplings).

## What moves

`SubscriptionManager` (`managers/SubscriptionManager.ts`, `extends AdapterContextBase`) now owns the 6 object/file subscription delegations; `AdapterClass` holds it as a lazy `#subscriptions` getter and the public methods delegate to it:

- `subscribeObjects` / `unsubscribeObjects` — `'*'`→`${namespace}.*`, else `fixId(pattern, true)` (array patterns pass through), delegating to the objects DB client's `subscribeUserAsync` / `unsubscribeUserAsync`
- `subscribeForeignObjects` / `unsubscribeForeignObjects` — pattern straight through (`unsubscribe` defaults to `'*'`)
- `subscribeForeignFiles` / `unsubscribeForeignFiles` — delegate to `subscribeUserFile` / `unsubscribeUserFile`

The manager reuses the DB client's own `*Async` methods rather than re-implementing the callback→promise wrapping. Only injected capability: a bound `fixId`. No `AdapterContext` change.

## Behavior notes (accepted)

- Object-subscription DB-closed / invalid-argument errors now surface **asynchronously** (rejected promise / `cb(err)`) instead of the old synchronous `maybeCallbackWithError` path, and the DB-closed *info* log is dropped — the same convention already shipped for MessagingManager/CertificateManager. The success callback stays async (it already fired via `setImmediate`).
- The file-subscription methods' DB-closed check moves from a synchronous throw to a rejected promise (they are `Promise`-returning; `await`/`.catch()` callers are unaffected; no internal callers exist).

State subscriptions, `autoSubscribe`, `_autoSubscribeOn`, `_getObjectsByArray`, `#states` subscriptions, and alias code are untouched.

## Testing

- `npm run test-adapter`: 97 passing, incl. new `SubscriptionManager` unit tests (delegation per method, `fixId`/`'*'` handling, array pass-through, options forwarding, DB-closed rejection, delegate-rejection propagation).
- Build, eslint (0/0), `@iobroker/types` leak-gate, and `test-types-check` all green (baseline unchanged).
- Two per-task reviews + one independent adversarial whole-branch review: no correctness findings.

## Follow-ups (not in this PR)

- **State subscriptions** → next phase, after defining an `ObjectAccess` capability (for the `getForeignObjectsAsync` back-edge), giving `autoSubscribe` a manager-owned + change-handler-callback treatment, and deciding how managers feed the global `outputCount`.
- **Latent bug for maintainer review:** `_autoSubscribeOn`'s guard `if (!this.autoSubscribe …)` never passes because `autoSubscribe` is initialized to `[]` (truthy), so the subscribable-instance enumeration and the `system.adapter.*.subscribes` counter appear dead in practice. Likely `!this.autoSubscribe.length`. Fixing it activates dormant behavior, so it belongs in its own change, not this refactor. (Inferred from code reading.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
