### PR TITLE
fix(alias): convert a boolean result into 1/0 for a number alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * (@krobipd) Fixed a failed adapter install/update being reported as success on npm >= 10.6.0
 * (@krobipd) Fixed the automatic ENOTEMPTY recovery not removing the blocking npm temp directory on npm >= 10.6.0
 * (@krobipd) Fixed an occasional "Connection is closed" warning logged when a fast schedule/once adapter shuts down
+* (@krobipd) Fixed an alias read/write function returning a boolean (e.g. "val < 20") being stored unconverted in a state declared as number
 
 ## 7.2.2 (2026-06-16)
 * (@Apollon77) Fixed Sentry session reporting disabling

--- a/packages/common-db/src/lib/common/aliasProcessing.ts
+++ b/packages/common-db/src/lib/common/aliasProcessing.ts
@@ -74,6 +74,10 @@ export function applyAliasConvenienceConversion(options: ApplyAliasConvenienceCo
             return !!state.val;
         } else if (targetCommon.type === 'number' && typeof state.val === 'string') {
             return parseFloat(state.val);
+        } else if (targetCommon.type === 'number' && typeof state.val === 'boolean') {
+            // a read/write function may return a comparison result (e.g. "val < 20") for a
+            // numeric alias — store it as 1/0 instead of leaving a boolean in a number state
+            return state.val ? 1 : 0;
         } else if (targetCommon.type === 'string') {
             return state.val.toString();
         }

--- a/packages/controller/test/testAliasProcessing.ts
+++ b/packages/controller/test/testAliasProcessing.ts
@@ -1,0 +1,53 @@
+import assert from 'node:assert/strict';
+import { tools } from '@iobroker/js-controller-common-db';
+
+const logger = {
+    error: (msg: string): void => {
+        throw new Error(msg);
+    },
+    warn: (): void => {},
+    info: (): void => {},
+    debug: (): void => {},
+    silly: (): void => {},
+} as unknown as ioBroker.Logger;
+
+/**
+ * Run a source value through an alias with the given read function.
+ *
+ * @param read the alias read function
+ * @param targetType common.type of the alias state
+ * @param val the source value
+ */
+function readAlias(read: string, targetType: ioBroker.CommonType, val: ioBroker.StateValue): ioBroker.StateValue {
+    const state = tools.formatAliasValue({
+        sourceCommon: { type: 'number' },
+        targetCommon: { type: targetType, alias: { id: 'x.0.source', read } },
+        state: { val, ack: true, ts: 1, lc: 1, from: 'test' },
+        logger,
+        logNamespace: 'test',
+        sourceId: 'x.0.source',
+        targetId: 'alias.0.target',
+    });
+
+    return state!.val;
+}
+
+describe('alias value conversion', () => {
+    it('stores a comparison result as 1/0 in a number alias', () => {
+        assert.equal(readAlias('val < 20', 'number', 15), 1);
+        assert.equal(readAlias('val < 20', 'number', 25), 0);
+    });
+
+    it('keeps the comparison result boolean in a boolean alias', () => {
+        assert.equal(readAlias('val < 20', 'boolean', 15), true);
+        assert.equal(readAlias('val < 20', 'boolean', 25), false);
+    });
+
+    it('still converts a string result into a number', () => {
+        assert.equal(readAlias('String(val)', 'number', 42.5), 42.5);
+    });
+
+    it('leaves a numeric result untouched', () => {
+        assert.equal(readAlias('val * 2', 'number', 21), 42);
+    });
+});


### PR DESCRIPTION
### What happens today

An alias read/write function may return a comparison result. A user who wants a numeric alias to say "below 20" writes `val < 20`, and a user who wants to invert a flag writes `!val`. The function returns a JS boolean, and if the alias state is declared as `type: 'number'` (which is the usual case when the alias was created from a numeric source), that boolean is stored unchanged — the object browser then shows `true`/`false` in a state declared as number.

`applyAliasConvenienceConversion` converts **to** boolean from any type and **to** string from any type, but **to** number only from string:

```js
} else if (targetCommon.type === 'number' && typeof state.val === 'string') {
    return parseFloat(state.val);
```

so a boolean falls through to `return state.val`.

An adapter doing the same write gets a log entry for exactly this mismatch (`validator.ts`: *"State value to set for … has to be type "number" but received type "boolean""*). The alias path writes to the states DB directly and skips that validation, so nothing is logged and the mismatch is silent.

### The change

One more branch in the same conversion chain: for a number target, a boolean becomes `1` / `0`. Nothing else is touched — string→number, →boolean and →string keep their current behaviour, and a value that already matches the target type is not converted (the surrounding `typeof state.val !== targetCommon.type` guard).

### Verification

`packages/controller/test/testAliasProcessing.ts` (new) drives the public `tools.formatAliasValue()` — the same entry point the adapter uses — through a read function:

| alias `common.type` | read function | source | result |
|---|---|---|---|
| number | `val < 20` | 15 / 25 | `1` / `0` |
| boolean | `val < 20` | 15 / 25 | `true` / `false` (unchanged) |
| number | `String(val)` | 42.5 | `42.5` (unchanged) |
| number | `val * 2` | 21 | `42` (unchanged) |

Checked that the test actually covers the change: with the fix reverted, the first case fails and the other three still pass.

Users currently work around this with `1*(val < 20)` or `Number(val < 20)`; both keep working.

Reported in ioBroker/ioBroker.devices#683.