### PR TITLE
Reset the instance's info.connection when it goes offline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * (@krobipd) Fixed a failed adapter install/update being reported as success on npm >= 10.6.0
 * (@krobipd) Fixed the automatic ENOTEMPTY recovery not removing the blocking npm temp directory on npm >= 10.6.0
 * (@krobipd) Fixed an occasional "Connection is closed" warning logged when a fast schedule/once adapter shuts down
+* (@krobipd) Fixed `info.connection` not being reset when an instance goes offline, which also left a stray state named after the instance namespace
 
 ## 7.2.2 (2026-06-16)
 * (@Apollon77) Fixed Sentry session reporting disabling

--- a/packages/controller/src/main.ts
+++ b/packages/controller/src/main.ts
@@ -6036,11 +6036,12 @@ async function setInstanceOfflineStates(id: ioBroker.ObjectIDs.Instance): Promis
 
     const adapterInstance = id.substring(SYSTEM_ADAPTER_PREFIX.length);
 
-    const state = await states!.getState(`${adapterInstance}.info.connection`);
+    const connectionStateId = `${adapterInstance}.info.connection`;
+    const state = await states!.getState(connectionStateId);
 
     if (state?.val === true) {
         outputCount++;
-        await states!.setState(adapterInstance, { val: false, ack: true, from: hostObjectPrefix });
+        await states!.setState(connectionStateId, { val: false, ack: true, from: hostObjectPrefix });
     }
 }
 


### PR DESCRIPTION
## The problem

When an instance goes offline, `setInstanceOfflineStates()` is supposed to reset that instance's `info.connection` — that is what it was added for. It reads the right state but writes the reset to the wrong id:

```ts
const state = await states!.getState(`${adapterInstance}.info.connection`);   // reads <ns>.info.connection

if (state?.val === true) {
    outputCount++;
    await states!.setState(adapterInstance, { val: false, ack: true, ... });  // writes <ns>
}
```

Two consequences:

1. **The reset never happens.** `<ns>.info.connection` keeps whatever the adapter last wrote. For an adapter that is killed (or that does not write the state itself on shutdown) the datapoint stays `true` while the instance is stopped.
2. **A stray state is created**, named exactly like the instance namespace and with no object behind it. On my host these had accumulated over time, one per instance that was ever stopped while connected.

The guard `if (state?.val === true)` is why this stayed unnoticed for so long: an adapter that resets `info.connection` itself on shutdown is already `false` by the time the handler reads it, so nothing is written and nothing looks wrong. It shows up in exactly the situation the reset was built for — a crash or a hard kill.

## Why this looks like a slip rather than intent

The block came in with #2357 for issue #2280 (*"Request: reset info.connection at crash of adapter"*), and #2359 immediately afterwards corrected the **read** from `${adapterInstance}.connection` to `${adapterInstance}.info.connection`. The write target was not corrected along with it. The `getState` on `.info.connection` would be pointless otherwise.

Present since v5.0.9 and still on current master.

## The change

One id, named once and used for both the read and the write, so the two cannot drift apart again.

## How it was found and verified

Found on a live 7.2.2 host while checking an unrelated adapter's shutdown behaviour. Concretely: an instance that had been stopped for weeks still had `info.connection = true`, and the stray namespace state next to it carried a timestamp 79 ms after that instance's `alive` reset — the misdirected write, timestamp against timestamp. The code path was then read in the published `build/cjs/main.js` on that host and in current master; identical in both.

Local checks on the change: `eslint` and `prettier --check` clean on the touched source file, `npm run build` in `packages/controller` succeeds. (`prettier --check CHANGELOG.md` reports pre-existing style complaints on unmodified master too, so the file is deliberately left unformatted.)

No unit test is added: `setInstanceOfflineStates` is a module-local function in `main.ts` with no test seam, and the surrounding host lifecycle is covered only by the Redis integration tests. Extracting it just to pin a one-line id would be out of proportion to the fix — flagging it here rather than leaving it unsaid.

## Scope

This fixes the write going forward. Hosts that already ran an affected version still carry the stray `<ns>` states; removing those would be a migration step and is not part of this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)